### PR TITLE
Revise README for improved project documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,92 @@
 # DataLoom
-Project is to design and implement a web-based GUI for data wrangling, aimed at simplifying the process of managing and transforming tabular datasets. This application will serve as a graphical interface for the powerful Python library, allowing users to perform complex data manipulation tasks without the need for in-depth programming knowledge. 
 
-### Apps and Packages
+DataLoom is a web-based GUI for data wrangling, designed to simplify working with tabular datasets. The application provides an intuitive interface that allows users to upload, inspect, and transform data without writing code. It acts as a graphical layer over a Python-powered backend to support operations like cleaning, filtering, reshaping, and exporting datasets.
 
-- `frontend`: a React.js app
-- `backend`:  Python(FastAPI) app
 
-### Run Application
-**Set Up Environment Variables** :
-Create a `.env` file in the `apps/backend` directory and add details as per `.env.sample` file.
+## Apps and Packages
 
-**Installing FastApi Backend** : In the `apps/backend` directory, run `python3 -m venv env`, then run `. env/scripts/activate` (On Windows), then ensure all required dependencies are installed by running `pip install -r requirements.txt`.
+- **frontend**: React.js client interface
+- **backend**: Python FastAPI service
 
-**To run the project**, run the following command:
+
+## Setup
+
+### 1. Clone the repository
+
+```bash
+git clone https://github.com/c2siorg/dataloom
+cd dataloom
 ```
-cd DataLoom
+
+### 2. Install dependencies
+
+From the project root, run:
+
+```bash
+npm install
+```
+
+This installs all required dependencies for both the backend and frontend through the monorepo setup.
+
+## Environment Variables
+
+Create a `.env` file in the project root and add your database connection details. This is required for storing logs and uploaded dataset metadata.
+
+**Example:**
+
+```env
+DATABASE_URI=mongodb://localhost:27017/dataloom
+```
+
+Adjust the URI according to your setup (local or cloud database).
+
+
+## Running the Application
+
+To start both the backend and frontend together, run:
+
+```bash
 npm run dev
 ```
 
-The backend server will start and be accessible at `http://127.0.0.1:8000`.
+This will:
+- Start the FastAPI backend server
+- Start the React development server
+- Enable hot reloading for both services
+
+Once running, open the frontend in your browser and begin using the interface.
+
+## Backend Access
+
+The backend API will be available at:
+
+```
+http://127.0.0.1:8000
+```
+
+Swagger/OpenAPI docs may be available depending on configuration.
+
+
+## Project Structure
+
+```
+dataloom/
+├── backend/       # FastAPI backend
+├── frontend/      # React frontend
+├── turbo.json     # Monorepo config
+└── package.json
+```
+
+
+## Contributing
+
+If you wish to contribute:
+
+1. Open an issue or select an existing one
+2. Discuss changes if needed
+3. Submit a pull request with a short summary of the changes
+4. Ensure the project builds and runs before submitting
+
+## License
+
+Refer to the LICENSE file contained in the repository.


### PR DESCRIPTION
Hi, I'm Yash. I'm exploring the DataLoom project as part of preparing a GSoC proposal and while setting it up locally I noticed that the setup instructions were outdated and didn't match the current monorepo/Turborepo workflow.

This PR updates the README to include:

- `npm install` and `npm run dev` workflow from the project root
- Updated instructions for environment variables
- Removal of redundant FastAPI manual setup steps
- Clarified backend + frontend unified startup
- Minor formatting and wording improvements

This reflects how the project currently works and should make onboarding easier for new contributors.

If any section should be modified, shortened, or reverted, I'm happy to adjust.
