### PR TITLE
fix: update workspace path from apps/* to frontend in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "packageManager": "npm@10.5.1",
   "workspaces": [
-    "apps/*",
+    "frontend",
     "packages/*",
     "backend"
   ]


### PR DESCRIPTION
## What does this PR do?
Updates the workspaces array in root `package.json` to correctly 
reflect the actual project folder structure. The workspaces were 
pointing to `apps/*` but the frontend directory is located at 
`frontend/`, causing `@repo/ui` to fail resolution during local setup.

## Related Issue
Fixes #42