### PR TITLE
fix: clear unapplied logs on revert to prevent stale replays on save

### DIFF
--- a/backend/app/api/endpoints/datasets.py
+++ b/backend/app/api/endpoints/datasets.py
@@ -628,10 +628,14 @@ async def revert_to_checkpoint(dataset_id: int, db: Session = Depends(database.g
     # Load the original dataset
     original_path = dataset.file_path.replace('_copy.csv', '.csv')
     df = pd.read_csv(original_path)
-    print("CSV on which applied", original_path)
 
-    # Simply save the original dataset as _copy.csv
     save_dataframe_to_csv(df, dataset.file_path)
+
+    # clear unapplied logs so save doesn't replay them
+    db.query(models.DatasetChangeLog).filter(
+        models.DatasetChangeLog.dataset_id == dataset_id,
+        models.DatasetChangeLog.applied == False
+    ).delete()
 
     db.commit()
 


### PR DESCRIPTION
## Description
Revert resets the CSV but doesn't remove unapplied logs from the DB. So when you save after reverting, those old logs get replayed and the reverted changes come back.

Fixed by deleting unapplied logs in the revert endpoint before committing.
Fixes #49 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

Describe the tests you ran to verify your changes.

- [ ] Existing tests pass
- [ ] New tests added
- [x] Manual testing
Uploaded a CSV, made changes, reverted, then saved confirmed the reverted changes don't reappear.
## Screenshots (if applicable)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally
