### PR TITLE
docs: standardize backend setup to use uv package manager

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,11 @@ npm run dev
 
 1. Make your changes in a feature branch.
 2. Test your changes:
+<<<<<<< HEAD
    - **Backend:** `cd dataloom-backend && uv run pytest`
+=======
+   - **Backend:** `cd backend && uv run pytest`
+>>>>>>> 2aaec8e (docs: standardize backend setup to use uv package manager)
    - **Frontend:** `cd dataloom-frontend && npm run test`
 3. Lint and format your code:
    - **Frontend:** `npm run lint` and `npm run format`


### PR DESCRIPTION
## Description
- Replace pip/venv setup with uv sync
- Update uvicorn command to use uv run
- Update pytest command to use uv run pytest

Standardizes CONTRIBUTING.md to use uv package manager consistently.
Removes outdated pip/venv instructions and aligns with project's current tooling.

Fixes #67

## Type of Change

- [/] Bug fix
- [/] New feature
- [/] Breaking change
- [x] Documentation update

## How Has This Been Tested?
- [x] Manual testing — verified the commands are syntactically correct and consistent with the project's uv setup

Describe the tests you ran to verify your changes.
- [/] Existing tests pass
- [/] New tests added
- [x] Manual testing

## Screenshots (if applicable)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally
