### PR TITLE
fix(context-menu): extract inline menu from Table.jsx and improve state management

### DIFF
--- a/dataloom-frontend/src/Components/ContextMenu.jsx
+++ b/dataloom-frontend/src/Components/ContextMenu.jsx
@@ -1,11 +1,12 @@
-import { useEffect, useRef, useState, useLayoutEffect } from "react";
+import { useState, useEffect, useRef, useLayoutEffect } from "react";
 import PropTypes from "prop-types";
-
 const ContextMenu = ({ isOpen, position, contextData, onClose, actions }) => {
   const menuRef = useRef(null);
 
   const [adjustedPosition, setAdjustedPosition] = useState(position);
 
+  // useLayoutEffect (not useEffect) ensures clamping runs synchronously
+  // before the browser paints, preventing visible position jump.
   useLayoutEffect(() => {
     if (!isOpen) return;
 
@@ -35,28 +36,21 @@ const ContextMenu = ({ isOpen, position, contextData, onClose, actions }) => {
   }, [isOpen, position]);
 
   useEffect(() => {
-    if (!isOpen) {
-      setAdjustedPosition(position);
-    }
+    if (!isOpen) return;
 
     const handleClickOutside = (event) => {
-      if (menuRef.current && !menuRef.current.contains(event.target)) {
-        onClose();
-      }
+      if (menuRef.current && !menuRef.current.contains(event.target)) onClose();
     };
-
     const handleKeyDown = (event) => {
-      if (event.key === "Escape") {
-        onClose();
-      }
+      if (event.key === "Escape") onClose();
     };
-
-    const handleScroll = () => {
-      onClose();
-    };
+    const handleScroll = () => onClose();
 
     document.addEventListener("click", handleClickOutside);
     document.addEventListener("keydown", handleKeyDown);
+    // Close the context menu on any scroll event.
+    // Using capture phase ensures scrolling inside nested containers
+    // (like the table's overflow area) also closes the menu.
     window.addEventListener("scroll", handleScroll, true);
 
     return () => {
@@ -64,13 +58,15 @@ const ContextMenu = ({ isOpen, position, contextData, onClose, actions }) => {
       document.removeEventListener("keydown", handleKeyDown);
       window.removeEventListener("scroll", handleScroll, true);
     };
-  }, [isOpen, onClose, position]);
+  }, [isOpen, onClose]);
 
   if (!isOpen) return null;
 
   return (
     <div
       ref={menuRef}
+      role="menu"
+      aria-label="Context menu"
       className="fixed bg-white border border-gray-200 rounded-lg shadow-lg p-1 z-50"
       style={{
         top: adjustedPosition.y,

--- a/dataloom-frontend/src/Components/Table.jsx
+++ b/dataloom-frontend/src/Components/Table.jsx
@@ -1,12 +1,26 @@
 import ContextMenu from "./ContextMenu";
 import { useContextMenu } from "../hooks/useContextMenu";
-import { useEffect, useState } from "react";
+import { useState, useEffect } from "react";
 import { transformProject } from "../api";
 import { useProjectContext } from "../context/ProjectContext";
 import InputDialog from "./common/InputDialog";
 import Toast from "./common/Toast";
 import DtypeBadge from "./common/DtypeBadge";
-import proptypes from "prop-types";
+import PropTypes from "prop-types";
+
+const MenuButton = ({ children, onClick }) => (
+  <button
+    role="menuitem"
+    className="block w-full text-left text-sm text-gray-700 px-3 py-1.5 hover:bg-gray-100 rounded-md transition-colors duration-150 whitespace-nowrap"
+    onClick={onClick}
+  >
+    {children}
+  </button>
+);
+MenuButton.propTypes = {
+  children: PropTypes.node.isRequired,
+  onClick: PropTypes.func.isRequired,
+};
 
 const Table = ({ projectId, data: externalData }) => {
   const { columns: ctxColumns, rows: ctxRows, dtypes, updateData } = useProjectContext();
@@ -291,6 +305,7 @@ const Table = ({ projectId, data: externalData }) => {
               </>
             );
           }
+          return null;
         }}
       />
 
@@ -314,21 +329,13 @@ const Table = ({ projectId, data: externalData }) => {
 };
 
 Table.propTypes = {
-  projectId: proptypes.string.isRequired,
-  data: proptypes.shape({
-    columns: proptypes.arrayOf(proptypes.string),
-    rows: proptypes.arrayOf(
-      proptypes.arrayOf(proptypes.oneOfType([proptypes.string, proptypes.number])),
+  projectId: PropTypes.string.isRequired,
+  data: PropTypes.shape({
+    columns: PropTypes.arrayOf(PropTypes.string),
+    rows: PropTypes.arrayOf(
+      PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])),
     ),
   }),
 };
 
-const MenuButton = ({ children, onClick }) => (
-  <button
-    className="block w-full text-left text-sm text-gray-700 px-3 py-1.5 hover:bg-gray-100 rounded-md transition-colors duration-150 whitespace-nowrap"
-    onClick={onClick}
-  >
-    {children}
-  </button>
-);
 export default Table;

--- a/dataloom-frontend/src/hooks/useContextMenu.js
+++ b/dataloom-frontend/src/hooks/useContextMenu.js
@@ -1,5 +1,22 @@
 import { useState, useCallback } from "react";
 
+/**
+ * Manages context menu open/close state, viewport position,and arbitrary
+ * context payload.
+ *
+ * Note: This hook only manages state. Event listeners such as click-outside,
+ * Escape key handling, and scroll closing are handled by the consumer
+ * component (`ContextMenu`), which attaches and cleans up those listeners.
+ *
+ * @returns {{
+ *   isOpen: boolean,
+ *   position: { x: number, y: number },
+ *   contextData: object | null,
+ *   open: (e: MouseEvent, data: object) => void,
+ *   close: () => void
+ * }}
+ */
+
 export function useContextMenu() {
   const [isOpen, setIsOpen] = useState(false);
   const [position, setPosition] = useState({ x: 0, y: 0 });

--- a/dataloom-frontend/src/test/ContextMenu.test.jsx
+++ b/dataloom-frontend/src/test/ContextMenu.test.jsx
@@ -1,0 +1,114 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, test, expect, vi } from "vitest";
+import ContextMenu from "../Components/ContextMenu";
+
+describe("ContextMenu", () => {
+  const position = { x: 100, y: 100 };
+
+  test("renders actions when menu is open", () => {
+    render(
+      <ContextMenu
+        isOpen
+        position={position}
+        contextData={null}
+        onClose={vi.fn()}
+        actions={() => <button>Test Action</button>}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Test Action" })).toBeInTheDocument();
+  });
+
+  test("closes when Escape key is pressed", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+
+    render(
+      <ContextMenu
+        isOpen
+        position={position}
+        contextData={null}
+        onClose={onClose}
+        actions={() => null}
+      />,
+    );
+
+    await user.keyboard("{Escape}");
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test("closes when clicking outside the menu", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+
+    render(
+      <div>
+        <div data-testid="outside" />
+        <ContextMenu
+          isOpen
+          position={position}
+          contextData={null}
+          onClose={onClose}
+          actions={() => <button>Action</button>}
+        />
+      </div>,
+    );
+
+    await user.click(screen.getByTestId("outside"));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test("closes when clicking a menu item", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+
+    render(
+      <ContextMenu
+        isOpen
+        position={position}
+        contextData={null}
+        onClose={onClose}
+        actions={() => <button>Action</button>}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Action" }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test("closes on page scroll", () => {
+    const onClose = vi.fn();
+
+    render(
+      <ContextMenu
+        isOpen
+        position={position}
+        contextData={null}
+        onClose={onClose}
+        actions={() => null}
+      />,
+    );
+
+    window.dispatchEvent(new Event("scroll"));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not render when menu is closed", () => {
+    const { container } = render(
+      <ContextMenu
+        isOpen={false}
+        position={position}
+        contextData={null}
+        onClose={vi.fn()}
+        actions={() => <button>Action</button>}
+      />,
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+});


### PR DESCRIPTION


## Description

This PR refactors the inline context menu implementation in Table.jsx into a standalone  ContextMenu component and integrates the existing  useContextMenu hook.




Closes #95

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?
Manually tested the context menu by right-clicking on rows and columns.
Verified it opens at the correct position, closes on outside click, Escape, and scroll.
Confirmed all add/delete/rename operations work and the menu closes on both success and failure.


Describe the tests you ran to verify your changes.

- [ ] Existing tests pass
- [ ] New tests added
- [x] Manual testing

## Screenshots (if applicable)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [ ] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally
