### PR TITLE
feat: add form-error-alert component and use-error hook implementations

### DIFF
--- a/dataloom-frontend/src/Components/common/FormErrorAlert.jsx
+++ b/dataloom-frontend/src/Components/common/FormErrorAlert.jsx
@@ -1,0 +1,17 @@
+import PropTypes from "prop-types";
+
+const FormErrorAlert = ({ message }) => {
+  if (!message) return null;
+
+  return (
+    <div className="mt-3 p-3 bg-red-50 border border-red-200 rounded-md text-sm text-red-700">
+      {message}
+    </div>
+  );
+};
+
+FormErrorAlert.propTypes = {
+  message: PropTypes.string,
+};
+
+export default FormErrorAlert;

--- a/dataloom-frontend/src/Components/forms/AdvQueryFilterForm.jsx
+++ b/dataloom-frontend/src/Components/forms/AdvQueryFilterForm.jsx
@@ -2,16 +2,20 @@ import { useState } from "react";
 import PropTypes from "prop-types";
 import TransformResultPreview from "./TransformResultPreview";
 import { transformProject } from "../../api";
+import useError from "../../hooks/useError";
+import FormErrorAlert from "../common/FormErrorAlert";
 
 const AdvQueryFilterForm = ({ projectId, onClose }) => {
   const [query, setQuery] = useState("");
   const [result, setResult] = useState(null);
   const [loading, setLoading] = useState(false);
+  const { error, clearError, handleError } = useError();
 
   const handleSubmit = async (e) => {
     e.preventDefault();
     console.log("Query:", query);
     setLoading(true);
+    clearError();
     try {
       const response = await transformProject(projectId, {
         operation_type: "advQueryFilter",
@@ -19,8 +23,9 @@ const AdvQueryFilterForm = ({ projectId, onClose }) => {
       });
       setResult(response);
       console.log("Query API response:", response);
-    } catch (error) {
-      console.error("Error applying query:", error.message);
+    } catch (err) {
+      console.error("Error applying query:", err.message);
+      handleError(err);
     } finally {
       setLoading(false);
     }
@@ -58,6 +63,7 @@ const AdvQueryFilterForm = ({ projectId, onClose }) => {
           </button>
         </div>
       </form>
+      <FormErrorAlert message={error} />
       {result && <TransformResultPreview columns={result.columns} rows={result.rows} />}
     </div>
   );

--- a/dataloom-frontend/src/Components/forms/CastDataTypeForm.jsx
+++ b/dataloom-frontend/src/Components/forms/CastDataTypeForm.jsx
@@ -3,6 +3,8 @@ import PropTypes from "prop-types";
 import { transformProject } from "../../api";
 import { useProjectContext } from "../../context/ProjectContext";
 import { useToast } from "../../context/ToastContext";
+import useError from "../../hooks/useError";
+import FormErrorAlert from "../common/FormErrorAlert";
 
 const CastDataTypeForm = ({ projectId, onClose, onTransform }) => {
   const { columns } = useProjectContext();
@@ -10,10 +12,12 @@ const CastDataTypeForm = ({ projectId, onClose, onTransform }) => {
 
   const [column, setColumn] = useState("");
   const [targetType, setTargetType] = useState("string");
+  const { error, clearError, handleError } = useError();
 
   const handleSubmit = async (e) => {
     e.preventDefault();
 
+    clearError();
     try {
       const response = await transformProject(projectId, {
         operation_type: "castDataType",
@@ -24,13 +28,12 @@ const CastDataTypeForm = ({ projectId, onClose, onTransform }) => {
       });
 
       onTransform(response);
-    } catch (error) {
-      console.error("Error casting data type:", error);
-
-      showToast(error.response?.data?.detail || "Failed to cast data type.", "error");
+      onClose();
+    } catch (err) {
+      console.error("Error casting data type:", err);
+      showToast(err.response?.data?.detail || "Failed to cast data type.", "error");
+      handleError(err);
     }
-
-    onClose();
   };
 
   return (
@@ -89,6 +92,7 @@ const CastDataTypeForm = ({ projectId, onClose, onTransform }) => {
           </button>
         </div>
       </form>
+      <FormErrorAlert message={error} />
     </div>
   );
 };

--- a/dataloom-frontend/src/Components/forms/DropDuplicateForm.jsx
+++ b/dataloom-frontend/src/Components/forms/DropDuplicateForm.jsx
@@ -1,10 +1,13 @@
 import { useState } from "react";
 import PropTypes from "prop-types";
 import { transformProject } from "../../api";
+import useError from "../../hooks/useError";
+import FormErrorAlert from "../common/FormErrorAlert";
 
 const DropDuplicateForm = ({ projectId, onClose, onTransform }) => {
   const [columns, setColumns] = useState("");
   const [keep, setKeep] = useState("first");
+  const { error, clearError, handleError } = useError();
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -16,6 +19,7 @@ const DropDuplicateForm = ({ projectId, onClose, onTransform }) => {
       },
     };
 
+    clearError();
     try {
       const response = await transformProject(
         projectId,
@@ -23,10 +27,11 @@ const DropDuplicateForm = ({ projectId, onClose, onTransform }) => {
       );
       console.log("Transformation response:", response);
       onTransform(response); // Pass data to parent component
-    } catch (error) {
-      console.error("Error transforming project:", error);
+      onClose(); // Close the form after submission
+    } catch (err) {
+      console.error("Error transforming project:", err);
+      handleError(err);
     }
-    onClose(); // Close the form after submission
   };
 
   return (
@@ -73,6 +78,7 @@ const DropDuplicateForm = ({ projectId, onClose, onTransform }) => {
           </button>
         </div>
       </form>
+      <FormErrorAlert message={error} />
     </div>
   );
 };

--- a/dataloom-frontend/src/Components/forms/FilterForm.jsx
+++ b/dataloom-frontend/src/Components/forms/FilterForm.jsx
@@ -2,6 +2,8 @@ import { useState } from "react";
 import PropTypes from "prop-types";
 import { transformProject } from "../../api";
 import TransformResultPreview from "./TransformResultPreview";
+import useError from "../../hooks/useError";
+import FormErrorAlert from "../common/FormErrorAlert";
 
 const FilterForm = ({ projectId, onClose }) => {
   const [filterParams, setFilterParams] = useState({
@@ -11,6 +13,7 @@ const FilterForm = ({ projectId, onClose }) => {
   });
   const [result, setResult] = useState(null);
   const [loading, setLoading] = useState(false);
+  const { error, clearError, handleError } = useError();
 
   const handleInputChange = (e) => {
     setFilterParams({
@@ -23,6 +26,7 @@ const FilterForm = ({ projectId, onClose }) => {
     e.preventDefault();
     console.log("Submitting filter with parameters:", filterParams);
     setLoading(true);
+    clearError();
     try {
       const response = await transformProject(projectId, {
         operation_type: "filter",
@@ -30,8 +34,9 @@ const FilterForm = ({ projectId, onClose }) => {
       });
       setResult(response);
       console.log("Filter API response:", response);
-    } catch (error) {
-      console.error("Error applying filter:", error.response?.data || error.message);
+    } catch (err) {
+      console.error("Error applying filter:", err.response?.data || err.message);
+      handleError(err);
     } finally {
       setLoading(false);
     }
@@ -100,6 +105,7 @@ const FilterForm = ({ projectId, onClose }) => {
           </button>
         </div>
       </form>
+      <FormErrorAlert message={error} />
       {result && <TransformResultPreview columns={result.columns} rows={result.rows} />}
     </div>
   );

--- a/dataloom-frontend/src/Components/forms/PivotTableForm.jsx
+++ b/dataloom-frontend/src/Components/forms/PivotTableForm.jsx
@@ -2,6 +2,8 @@ import { useState } from "react";
 import PropTypes from "prop-types";
 import TransformResultPreview from "./TransformResultPreview";
 import { transformProject } from "../../api";
+import useError from "../../hooks/useError";
+import FormErrorAlert from "../common/FormErrorAlert";
 
 const PivotTableForm = ({ projectId, onClose }) => {
   const [index, setIndex] = useState("");
@@ -10,10 +12,12 @@ const PivotTableForm = ({ projectId, onClose }) => {
   const [aggfun, setAggfun] = useState("sum");
   const [result, setResult] = useState(null);
   const [loading, setLoading] = useState(false);
+  const { error, clearError, handleError } = useError();
 
   const handleSubmit = async (e) => {
     e.preventDefault();
     setLoading(true);
+    clearError();
     try {
       const response = await transformProject(projectId, {
         operation_type: "pivotTables",
@@ -21,8 +25,9 @@ const PivotTableForm = ({ projectId, onClose }) => {
       });
       setResult(response);
       console.log("Pivot API response:", response);
-    } catch (error) {
-      console.error("Error applying pivot table:", error.message);
+    } catch (err) {
+      console.error("Error applying pivot table:", err.message);
+      handleError(err);
     } finally {
       setLoading(false);
     }
@@ -100,6 +105,7 @@ const PivotTableForm = ({ projectId, onClose }) => {
           </button>
         </div>
       </form>
+      <FormErrorAlert message={error} />
       {result && <TransformResultPreview columns={result.columns} rows={result.rows} />}
     </div>
   );

--- a/dataloom-frontend/src/Components/forms/SortForm.jsx
+++ b/dataloom-frontend/src/Components/forms/SortForm.jsx
@@ -2,17 +2,21 @@ import { useState } from "react";
 import PropTypes from "prop-types";
 import { transformProject } from "../../api";
 import TransformResultPreview from "./TransformResultPreview";
+import useError from "../../hooks/useError";
+import FormErrorAlert from "../common/FormErrorAlert";
 
 const SortForm = ({ projectId, onClose }) => {
   const [column, setColumn] = useState("");
   const [ascending, setAscending] = useState(true);
   const [result, setResult] = useState(null);
   const [loading, setLoading] = useState(false);
+  const { error, clearError, handleError } = useError();
 
   const handleSubmit = async (e) => {
     e.preventDefault();
     console.log("Submitting sort with parameters:", { column, ascending });
     setLoading(true);
+    clearError();
     try {
       const response = await transformProject(projectId, {
         operation_type: "sort",
@@ -23,11 +27,12 @@ const SortForm = ({ projectId, onClose }) => {
       });
       setResult(response);
       console.log("Sort API response:", response);
-    } catch (error) {
+    } catch (err) {
       console.error(
         "Error applying sort:",
-        error.response?.data || error.message
+        err.response?.data || err.message
       );
+      handleError(err);
     } finally {
       setLoading(false);
     }
@@ -77,6 +82,7 @@ const SortForm = ({ projectId, onClose }) => {
           </button>
         </div>
       </form>
+      <FormErrorAlert message={error} />
       {result && <TransformResultPreview columns={result.columns} rows={result.rows} />}
     </div>
   );

--- a/dataloom-frontend/src/hooks/useError.js
+++ b/dataloom-frontend/src/hooks/useError.js
@@ -1,0 +1,15 @@
+import { useState } from "react";
+
+const useError = () => {
+  const [error, setError] = useState(null);
+
+  const clearError = () => setError(null);
+
+  const handleError = (err) => {
+    setError(err.response?.data?.detail || "Something went wrong. Please try again.");
+  };
+
+  return { error, setError, clearError, handleError };
+};
+
+export default useError;


### PR DESCRIPTION
## Description
Added a new `useError` hook and a `FormErrorAlert` component. Using these across all the forms.

Fixes https://github.com/c2siorg/dataloom/issues/97

## Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

Describe the tests you ran to verify your changes.

- [ ] Existing tests pass
- [ ] New tests added
- [X] Manual testing

## Screenshots

### Errors

#### 1. Filter

<img width="1919" height="594" alt="image" src="https://github.com/user-attachments/assets/d367a4ec-39f1-4844-8ffd-4269958fe3da" />

#### 2. Sort

<img width="1915" height="756" alt="image" src="https://github.com/user-attachments/assets/7fb34f0e-4233-444b-9eb4-aed006f171c0" />

#### 3.Drop Duplicates

<img width="1915" height="528" alt="image" src="https://github.com/user-attachments/assets/d6edb978-9395-408a-b66f-57a0b635959b" />

#### 4. Cast Data Type
> Note: This form already had a toast based error handler.

<img width="1920" height="794" alt="image" src="https://github.com/user-attachments/assets/6f521fc9-2978-4202-90ac-55a2724f8035" />

#### 5. Advanced Query

<img width="1914" height="712" alt="image" src="https://github.com/user-attachments/assets/b33784f0-3c87-433b-b49f-e9f2cdc44027" />

#### 6. Pivot

<img width="1919" height="748" alt="image" src="https://github.com/user-attachments/assets/fcccae9b-ab79-489e-8680-e77cd9bfbe63" />

---

### Network error

<img width="1920" height="727" alt="image" src="https://github.com/user-attachments/assets/c5c529d1-6ea9-4436-84be-a3f9d03f119f" />

---

## Checklist

- [X] My code follows the project's style guidelines
- [X] I have performed a self-review
- [ ] I have added/updated documentation as needed
- [X] My changes generate no new warnings
- [X] Tests pass locally
