### PR TITLE
feat(frontend): show backend errors in transform forms + fix DropDuplicate cancel revert 

### DIFF
--- a/dataloom-frontend/src/Components/MenuNavbar.jsx
+++ b/dataloom-frontend/src/Components/MenuNavbar.jsx
@@ -257,7 +257,7 @@ const Menu_NavBar = ({ projectId, onTransform }) => {
       {showDropDuplicateForm && (
         <DropDuplicateForm
           projectId={projectId}
-          onClose={() => setShowDropDuplicateForm(false)}
+          onClose={() => { setShowDropDuplicateForm(false); onTransform(null); }}
           onTransform={onTransform}
         />
       )}

--- a/dataloom-frontend/src/Components/Table.jsx
+++ b/dataloom-frontend/src/Components/Table.jsx
@@ -24,11 +24,11 @@ const Table = ({ projectId, data: externalData }) => {
   const [toast, setToast] = useState(null);
 
   useEffect(() => {
-    if (ctxColumns.length > 0 && ctxRows.length > 0) {
+    if (!externalData && ctxColumns.length > 0 && ctxRows.length > 0) {
       setColumns(["S.No.", ...ctxColumns]);
       setData(ctxRows.map((row, index) => [index + 1, ...row]));
     }
-  }, [ctxColumns, ctxRows]);
+  }, [ctxColumns, ctxRows, externalData]);
 
   useEffect(() => {
     if (externalData) {

--- a/dataloom-frontend/src/Components/forms/AdvQueryFilterForm.jsx
+++ b/dataloom-frontend/src/Components/forms/AdvQueryFilterForm.jsx
@@ -7,10 +7,11 @@ const AdvQueryFilterForm = ({ projectId, onClose }) => {
   const [query, setQuery] = useState("");
   const [result, setResult] = useState(null);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    console.log("Query:", query);
+    setError(null);
     setLoading(true);
     try {
       const response = await transformProject(projectId, {
@@ -18,9 +19,8 @@ const AdvQueryFilterForm = ({ projectId, onClose }) => {
         adv_query: { query },
       });
       setResult(response);
-      console.log("Query API response:", response);
-    } catch (error) {
-      console.error("Error applying query:", error.message);
+    } catch (err) {
+      setError(err.response?.data?.detail || "An unexpected error occurred.");
     } finally {
       setLoading(false);
     }
@@ -41,13 +41,18 @@ const AdvQueryFilterForm = ({ projectId, onClose }) => {
             required
           />
         </div>
+        {error && (
+          <div className="mb-3 px-3 py-2 bg-red-50 border border-red-300 text-red-700 rounded-md text-sm">
+            {error}
+          </div>
+        )}
         <div className="flex justify-between">
           <button
             type="submit"
             className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-md font-medium transition-colors duration-150"
             disabled={loading}
           >
-          Submit
+          {loading ? "Applying..." : "Submit"}
           </button>
           <button
             type="button"

--- a/dataloom-frontend/src/Components/forms/CastDataTypeForm.jsx
+++ b/dataloom-frontend/src/Components/forms/CastDataTypeForm.jsx
@@ -10,9 +10,13 @@ const CastDataTypeForm = ({ projectId, onClose, onTransform }) => {
 
   const [column, setColumn] = useState("");
   const [targetType, setTargetType] = useState("string");
+  const [error, setError] = useState(null);
+  const [loading, setLoading] = useState(false);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
+    setError(null);
+    setLoading(true);
 
     try {
       const response = await transformProject(projectId, {
@@ -24,13 +28,13 @@ const CastDataTypeForm = ({ projectId, onClose, onTransform }) => {
       });
 
       onTransform(response);
-    } catch (error) {
-      console.error("Error casting data type:", error);
-
-      showToast(error.response?.data?.detail || "Failed to cast data type.", "error");
+      onClose();
+    } catch (err) {
+      setError(err.response?.data?.detail || "An unexpected error occurred.");
+      showToast(err.response?.data?.detail || "Failed to cast data type.", "error");
+    } finally {
+      setLoading(false);
     }
-
-    onClose();
   };
 
   return (
@@ -72,12 +76,18 @@ const CastDataTypeForm = ({ projectId, onClose, onTransform }) => {
           </div>
         </div>
 
+        {error && (
+          <div className="mb-3 px-3 py-2 bg-red-50 border border-red-300 text-red-700 rounded-md text-sm">
+            {error}
+          </div>
+        )}
         <div className="flex justify-between">
           <button
             type="submit"
+            disabled={loading}
             className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-md font-medium transition-colors duration-150"
           >
-            Apply
+            {loading ? "Applying..." : "Apply"}
           </button>
 
           <button

--- a/dataloom-frontend/src/Components/forms/DropDuplicateForm.jsx
+++ b/dataloom-frontend/src/Components/forms/DropDuplicateForm.jsx
@@ -1,13 +1,19 @@
 import { useState } from "react";
 import PropTypes from "prop-types";
 import { transformProject } from "../../api";
+import TransformResultPreview from "./TransformResultPreview";
 
 const DropDuplicateForm = ({ projectId, onClose, onTransform }) => {
   const [columns, setColumns] = useState("");
   const [keep, setKeep] = useState("first");
+  const [error, setError] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState(null);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
+    setError(null);
+    setLoading(true);
     const transformationInput = {
       operation_type: "dropDuplicate",
       drop_duplicate: {
@@ -21,12 +27,13 @@ const DropDuplicateForm = ({ projectId, onClose, onTransform }) => {
         projectId,
         transformationInput
       );
-      console.log("Transformation response:", response);
-      onTransform(response); // Pass data to parent component
-    } catch (error) {
-      console.error("Error transforming project:", error);
+      onTransform(response);
+      setResult(response);
+    } catch (err) {
+      setError(err.response?.data?.detail || "An unexpected error occurred.");
+    } finally {
+      setLoading(false);
     }
-    onClose(); // Close the form after submission
   };
 
   return (
@@ -57,12 +64,18 @@ const DropDuplicateForm = ({ projectId, onClose, onTransform }) => {
             </select>
           </div>
         </div>
+        {error && (
+          <div className="mb-3 px-3 py-2 bg-red-50 border border-red-300 text-red-700 rounded-md text-sm">
+            {error}
+          </div>
+        )}
         <div className="flex justify-between">
           <button
             type="submit"
+            disabled={loading}
             className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-md font-medium transition-colors duration-150"
           >
-            Submit
+            {loading ? "Applying..." : "Submit"}
           </button>
           <button
             type="button"
@@ -73,6 +86,7 @@ const DropDuplicateForm = ({ projectId, onClose, onTransform }) => {
           </button>
         </div>
       </form>
+      {result && <TransformResultPreview columns={result.columns} rows={result.rows} />}
     </div>
   );
 };

--- a/dataloom-frontend/src/Components/forms/FilterForm.jsx
+++ b/dataloom-frontend/src/Components/forms/FilterForm.jsx
@@ -11,6 +11,7 @@ const FilterForm = ({ projectId, onClose }) => {
   });
   const [result, setResult] = useState(null);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
 
   const handleInputChange = (e) => {
     setFilterParams({
@@ -21,7 +22,7 @@ const FilterForm = ({ projectId, onClose }) => {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    console.log("Submitting filter with parameters:", filterParams);
+    setError(null);
     setLoading(true);
     try {
       const response = await transformProject(projectId, {
@@ -29,9 +30,8 @@ const FilterForm = ({ projectId, onClose }) => {
         parameters: filterParams,
       });
       setResult(response);
-      console.log("Filter API response:", response);
-    } catch (error) {
-      console.error("Error applying filter:", error.response?.data || error.message);
+    } catch (err) {
+      setError(err.response?.data?.detail || "An unexpected error occurred.");
     } finally {
       setLoading(false);
     }
@@ -83,13 +83,18 @@ const FilterForm = ({ projectId, onClose }) => {
             />
           </div>
         </div>
+        {error && (
+          <div className="mb-3 px-3 py-2 bg-red-50 border border-red-300 text-red-700 rounded-md text-sm">
+            {error}
+          </div>
+        )}
         <div className="flex justify-between">
           <button
             type="submit"
             className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-md font-medium transition-colors duration-150"
             disabled={loading}
           >
-            Apply Filter
+            {loading ? "Applying..." : "Apply Filter"}
           </button>
           <button
             type="button"

--- a/dataloom-frontend/src/Components/forms/PivotTableForm.jsx
+++ b/dataloom-frontend/src/Components/forms/PivotTableForm.jsx
@@ -10,9 +10,11 @@ const PivotTableForm = ({ projectId, onClose }) => {
   const [aggfun, setAggfun] = useState("sum");
   const [result, setResult] = useState(null);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
+    setError(null);
     setLoading(true);
     try {
       const response = await transformProject(projectId, {
@@ -20,9 +22,8 @@ const PivotTableForm = ({ projectId, onClose }) => {
         pivot_query: { index, column, value, aggfun },
       });
       setResult(response);
-      console.log("Pivot API response:", response);
-    } catch (error) {
-      console.error("Error applying pivot table:", error.message);
+    } catch (err) {
+      setError(err.response?.data?.detail || "An unexpected error occurred.");
     } finally {
       setLoading(false);
     }
@@ -83,6 +84,11 @@ const PivotTableForm = ({ projectId, onClose }) => {
             </select>
           </div>
         </div>
+        {error && (
+          <div className="mb-3 px-3 py-2 bg-red-50 border border-red-300 text-red-700 rounded-md text-sm">
+            {error}
+          </div>
+        )}
         <div className="flex justify-between">
           <button
             type="submit"

--- a/dataloom-frontend/src/Components/forms/SortForm.jsx
+++ b/dataloom-frontend/src/Components/forms/SortForm.jsx
@@ -8,10 +8,11 @@ const SortForm = ({ projectId, onClose }) => {
   const [ascending, setAscending] = useState(true);
   const [result, setResult] = useState(null);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    console.log("Submitting sort with parameters:", { column, ascending });
+    setError(null);
     setLoading(true);
     try {
       const response = await transformProject(projectId, {
@@ -22,12 +23,8 @@ const SortForm = ({ projectId, onClose }) => {
         },
       });
       setResult(response);
-      console.log("Sort API response:", response);
-    } catch (error) {
-      console.error(
-        "Error applying sort:",
-        error.response?.data || error.message
-      );
+    } catch (err) {
+      setError(err.response?.data?.detail || "An unexpected error occurred.");
     } finally {
       setLoading(false);
     }
@@ -60,13 +57,18 @@ const SortForm = ({ projectId, onClose }) => {
             </select>
           </div>
         </div>
+        {error && (
+          <div className="mb-3 px-3 py-2 bg-red-50 border border-red-300 text-red-700 rounded-md text-sm">
+            {error}
+          </div>
+        )}
         <div className="flex justify-between">
           <button
             type="submit"
             className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-md font-medium transition-colors duration-150"
             disabled={loading}
           >
-            Submit
+            {loading ? "Applying..." : "Submit"}
           </button>
           <button
             type="button"


### PR DESCRIPTION
# feat(frontend): Add Error Response Display to Transform Forms

Closes #97

## Summary

When a transformation API call failed in DataLoom, the error response from the backend was only
logged to the browser console. Users had no visible feedback about what went wrong, leaving them
confused about why their operation produced no change.

This PR adds a visible red alert box to all six transform form components that displays the
backend `detail` error message directly inside the form UI. Errors are cleared automatically
on each new submission so users always see fresh feedback. Along the way, two additional UX
bugs were discovered and fixed: forms that closed unconditionally on error, and the Drop
Duplicates form having no way to revert to the original data after applying the operation.

## Changes

**All 6 forms** (`FilterForm`, `SortForm`, `CastDataTypeForm`, `PivotTableForm`,
`DropDuplicateForm`, `AdvQueryFilterForm`):
- Added `error` state (`useState(null)`)
- `setError(null)` called at the start of every submit — clears stale errors before each request
- `catch` block sets `setError(err.response?.data?.detail || "An unexpected error occurred.")`
- Red alert box renders above the action buttons, hidden when there is no error
- Submit button text changes to `"Applying..."` during the request, making the error-clearing
  moment visually obvious

**`CastDataTypeForm`** (additional fix):
- Added missing `loading` state with `disabled={loading}` on the submit button
- `onClose()` moved inside the `try` block so the form only closes on success — previously
  it closed unconditionally, making error display impossible

**`DropDuplicateForm`** (additional fixes):
- Added missing `loading` state with `disabled={loading}` on the submit button
- `onClose()` removed from the success path entirely — form now stays open after a successful
  operation and renders `TransformResultPreview` inline (consistent with Filter, Sort, etc.)
- `onTransform(response)` called on success to update the main data table

**`MenuNavbar.jsx`** — Cancel now reverts the main table:
- `DropDuplicateForm`'s `onClose` calls `onTransform(null)` in addition to hiding the form,
  resetting `DataScreen.tableData` to `null`

**`Table.jsx`** — fixed conflicting `useEffect` hooks:
- The context data effect (`ctxColumns`/`ctxRows`) now skips when `externalData` is present.
  Previously, any context refresh after a transform would override the transform result
  shown to the user. With this fix, context data only populates the table when no external
  transform result is active — so clicking Cancel on the Drop Duplicates form correctly
  restores the original data.

## Screenshots

### Filter — invalid column name
The error from the backend (`Column 'Series_title_0' not found. Available columns: [...]`)
is shown in a red alert box inside the form. The data table remains unchanged.

<p align="center">
  <img src="https://github.com/user-attachments/assets/3a04526e-610b-442f-94d8-1c46bd3946ad" width="650">
  <br/>
  <em>Filter error</em>
</p>




### Sort — invalid column
`Column 'series_1' not found` is shown immediately below the form fields, above the buttons.

<p align="center">
  <img src="https://github.com/user-attachments/assets/9f265703-2987-4e88-a478-41b3c80ea3a6" width="650">
  <br/>
  <em>Sort — invalid column</em>
</p>


### Cast Data Type — incompatible type cast
`Failed to cast column 'Period' to DataType.integer: cannot safely cast non-equivalent object to int64`
is shown in the in-form alert box AND as a toast notification. The form stays open so the
user can select a compatible type and re-submit.

<p align="center">
  <img src="https://github.com/user-attachments/assets/edf588a3-787c-4426-ba1f-d123b7922c0b" width="650">
  <br/>
  <em>Cast Data Type — incompatible type cast</em>
</p>


### Pivot Table — column not found (with previous result still visible)
`Columns ['Unnamed:'] not found in dataset` — the form stays open after the error.
The previous successful result is visible below, demonstrating that re-submission works
and the form layout is not broken.

<p align="center">
  <img src="https://github.com/user-attachments/assets/97670b29-2410-47b7-af4c-5bc4be468ae5" width="650">
  <br/>
  <em>Pivot Table — column not found (previous result still visible)</em>
</p>


### Advanced Query — invalid query syntax
`invalid syntax (<unknown>, line 1)` from the pandas query engine is shown directly in
the form, giving the user actionable feedback to fix their query expression.


<p align="center">
  <img src="https://github.com/user-attachments/assets/9f5cd178-d74d-41a4-a573-23c93e070307" width="650">
  <br/>
  <em>Advanced Query — invalid query syntax</em>
</p>


### Network error — server unreachable
`An unexpected error occurred.` is shown when the backend is down or unreachable,
giving the user a clear fallback message instead of a silent failure.

<p align="center">
  <img src="https://github.com/user-attachments/assets/a018cb4d-107b-4575-b150-0f27f4a171be" width="650">
  <br/>
  <em>Network error — server unreachable</em>
</p>


## Acceptance Criteria

| # | Criterion | Status |
|---|-----------|--------|
| 1 | All transform form components display backend error messages in a visible red alert box | ✅ Verified — all 6 forms show `bg-red-50 border-red-300 text-red-700` alert |
| 2 | Error message shows the actual `detail` text from the backend response | ✅ Verified — `err.response?.data?.detail` used in all catch blocks (see screenshots) |
| 3 | Errors are cleared when the user submits the form again | ✅ Verified — `setError(null)` + `setLoading(true)` batched before each API call; button shows `"Applying..."` making the clear visible |
| 4 | Network errors (e.g., server unreachable) show a generic fallback message | ✅ Verified - "An unexpected error occurred." fallback in all 6 forms |
| 5 | Error display does not break the form layout or prevent re-submission | ✅ Verified — alert is a block element above buttons; submit is never disabled due to error |
| 6 | Error alert is visually consistent across all forms (same styling) | ✅ Verified — identical Tailwind classes across all 6 forms |
| 7 | The filter form shows errors (e.g., invalid column name) | ✅ Screenshot: `Column 'Series_title_0' not found` |
| 8 | The sort form shows errors (e.g., invalid column) | ✅ Screenshot: `Column 'series_1' not found` |
| 9 | The cast data type form shows errors (e.g., incompatible type cast) | ✅ Screenshot: `Failed to cast column 'Period' to DataType.integer` |
| 10 | The pivot table form shows errors (e.g., invalid aggregation) | ✅ Screenshot: `Columns ['Unnamed:'] not found in dataset` |
| 11 | The drop duplicates form shows errors | ✅ Implemented — `loading` state + error display added |
| 12 | The advanced query filter form shows errors (e.g., invalid query syntax) | ✅ Screenshot: `invalid syntax (<unknown>, line 1)` |
| 13 | Drop Duplicates Cancel button reverts the main table to original data | ✅ Fixed — `onTransform(null)` on close resets `tableData`; Table.jsx context effect restores original |
| 14 | Drop Duplicates form stays open after success so the result can be reviewed | ✅ Fixed — `onClose()` removed from success path; `TransformResultPreview` shown inline |

## Files Changed

```
dataloom-frontend/src/Components/Table.jsx
dataloom-frontend/src/Components/MenuNavbar.jsx
dataloom-frontend/src/Components/forms/FilterForm.jsx
dataloom-frontend/src/Components/forms/SortForm.jsx
dataloom-frontend/src/Components/forms/CastDataTypeForm.jsx
dataloom-frontend/src/Components/forms/PivotTableForm.jsx
dataloom-frontend/src/Components/forms/DropDuplicateForm.jsx
dataloom-frontend/src/Components/forms/AdvQueryFilterForm.jsx
```
