### PR TITLE
Added Trim Whitespace Transformation

### DIFF
--- a/dataloom-backend/app/api/endpoints/transformations.py
+++ b/dataloom-backend/app/api/endpoints/transformations.py
@@ -91,6 +91,12 @@ def _handle_basic_transform(df, transformation_input, project, db, project_id):
         p = transformation_input.cast_data_type_params
         return ts.cast_data_type(df, p.column, p.target_type), True
 
+    elif op == 'trimWhitespace':
+        if not transformation_input.trim_whitespace_params:
+            raise HTTPException(status_code=400, detail="Trim whitespace parameters required")
+        p = transformation_input.trim_whitespace_params
+        return ts.trim_whitespace(df, p.column), True
+
     else:
         raise HTTPException(status_code=400, detail=f"Unsupported operation: {op}")
 

--- a/dataloom-backend/app/schemas.py
+++ b/dataloom-backend/app/schemas.py
@@ -35,6 +35,7 @@ class OperationType(str, Enum):
     changeCellValue = 'changeCellValue'
     renameCol = 'renameCol'
     castDataType = 'castDataType'
+    trimWhitespace = 'trimWhitespace'
 
 
 class DropDup(str, Enum):
@@ -68,6 +69,7 @@ class ActionTypes(str, Enum):
     changeCellValue = 'changeCellValue'
     renameCol = 'renameCol'
     castDataType = 'castDataType'
+    trimWhitespace = 'trimWhitespace'
 
 
 # --- Basic transformation parameter schemas ---
@@ -130,6 +132,11 @@ class CastDataTypeParams(BaseModel):
     target_type: DataType
 
 
+class TrimWhitespaceParams(BaseModel):
+    """Parameters for trimming whitespace from columns."""
+    column: str
+
+
 # --- Complex transformation parameter schemas ---
 
 class DropDuplicates(BaseModel):
@@ -185,6 +192,7 @@ class TransformationInput(BaseModel):
     change_cell_value: Optional[ChangeCellValue] = None
     rename_col_params: Optional[RenameColumnParams] = None
     cast_data_type_params: Optional[CastDataTypeParams] = None
+    trim_whitespace_params: Optional[TrimWhitespaceParams] = None
 
 
 class BasicQueryResponse(BaseModel):

--- a/dataloom-backend/app/services/transformation_service.py
+++ b/dataloom-backend/app/services/transformation_service.py
@@ -281,6 +281,30 @@ def cast_data_type(df: pd.DataFrame, column: str, target_type: str) -> pd.DataFr
     return df
 
 
+def trim_whitespace(df: pd.DataFrame, column: str) -> pd.DataFrame:
+    """Trim leading and trailing whitespace from string columns.
+
+    Args:
+        df: Source DataFrame.
+        column: Column name to trim, or "All string columns" to trim all string columns.
+
+    Returns:
+        DataFrame with whitespace trimmed from specified column(s).
+    """
+    df = df.copy()
+    
+    if column == "All string columns":
+        for col in df.columns:
+            if pd.api.types.is_string_dtype(df[col]) or pd.api.types.is_object_dtype(df[col]):
+                df[col] = df[col].apply(lambda x: x.strip() if isinstance(x, str) else x)
+    else:
+        if column not in df.columns:
+            raise TransformationError(f"Column '{column}' not found")
+        df[column] = df[column].apply(lambda x: x.strip() if isinstance(x, str) else x)
+    
+    return df
+
+
 def drop_duplicates(df: pd.DataFrame, columns: str, keep) -> pd.DataFrame:
     """Remove duplicate rows based on specified columns.
 
@@ -421,6 +445,10 @@ def apply_logged_transformation(df: pd.DataFrame, action_type: str, action_detai
         column = action_details['cast_data_type_params']['column']
         target_type = action_details['cast_data_type_params']['target_type']
         return cast_data_type(df, column, target_type)
+
+    elif action_type == 'trimWhitespace':
+        column = action_details['trim_whitespace_params']['column']
+        return trim_whitespace(df, column)
 
     else:
         logger.warning("Unknown action type in log replay: %s", action_type)

--- a/dataloom-frontend/src/Components/MenuNavbar.jsx
+++ b/dataloom-frontend/src/Components/MenuNavbar.jsx
@@ -5,6 +5,7 @@ import DropDuplicateForm from "./forms/DropDuplicateForm";
 import AdvQueryFilterForm from "./forms/AdvQueryFilterForm";
 import PivotTableForm from "./forms/PivotTableForm";
 import CastDataTypeForm from "./forms/CastDataTypeForm";
+import TrimWhitespaceForm from "./forms/TrimWhitespaceForm";
 import LogsPanel from "./history/LogsPanel";
 import CheckpointsPanel from "./history/CheckpointsPanel";
 import InputDialog from "./common/InputDialog";
@@ -23,6 +24,7 @@ import {
   LuBookmark,
   LuDownload,
   LuRefreshCw,
+  LuScissors,
 } from "react-icons/lu";
 
 const Menu_NavBar = ({ projectId, onTransform }) => {
@@ -34,6 +36,7 @@ const Menu_NavBar = ({ projectId, onTransform }) => {
   const [showLogs, setShowLogs] = useState(false);
   const [showCheckpoints, setShowCheckpoints] = useState(false);
   const [showCastDataTypeForm, setShowCastDataTypeForm] = useState(false);
+  const [showTrimWhitespaceForm, setShowTrimWhitespaceForm] = useState(false);
   const [logs, setLogs] = useState([]);
   const [checkpoints, setCheckpoints] = useState(null);
   const [isInputOpen, setIsInputOpen] = useState(false);
@@ -119,6 +122,7 @@ const Menu_NavBar = ({ projectId, onTransform }) => {
     setShowAdvQueryFilterForm(false);
     setShowPivotTableForm(false);
     setShowCastDataTypeForm(false);
+    setShowTrimWhitespaceForm(false);
     setShowLogs(false);
     setShowCheckpoints(false);
 
@@ -140,6 +144,9 @@ const Menu_NavBar = ({ projectId, onTransform }) => {
         break;
       case "CastDataTypeForm":
         setShowCastDataTypeForm(true);
+        break;
+      case "TrimWhitespaceForm":
+        setShowTrimWhitespaceForm(true);
         break;
       case "Logs":
         setShowLogs(true);
@@ -187,6 +194,11 @@ const Menu_NavBar = ({ projectId, onTransform }) => {
             icon: LuRefreshCw,
             onClick: () => handleMenuClick("CastDataTypeForm"),
           },
+          {
+            label: "Trim Space",
+            icon: LuScissors,
+            onClick: () => handleMenuClick("TrimWhitespaceForm"),
+          },
         ],
       },
       {
@@ -214,11 +226,10 @@ const Menu_NavBar = ({ projectId, onTransform }) => {
           <button
             key={tabName}
             onClick={() => setActiveTab(tabName)}
-            className={`px-4 py-1.5 text-sm font-medium ${
-              activeTab === tabName
+            className={`px-4 py-1.5 text-sm font-medium ${activeTab === tabName
                 ? "text-blue-600 border-b-2 border-blue-500"
                 : "text-gray-500 hover:text-gray-700"
-            }`}
+              }`}
           >
             {tabName}
           </button>
@@ -274,6 +285,13 @@ const Menu_NavBar = ({ projectId, onTransform }) => {
         <CastDataTypeForm
           projectId={projectId}
           onClose={() => setShowCastDataTypeForm(false)}
+          onTransform={onTransform}
+        />
+      )}
+      {showTrimWhitespaceForm && (
+        <TrimWhitespaceForm
+          projectId={projectId}
+          onClose={() => setShowTrimWhitespaceForm(false)}
           onTransform={onTransform}
         />
       )}

--- a/dataloom-frontend/src/Components/forms/TrimWhitespaceForm.jsx
+++ b/dataloom-frontend/src/Components/forms/TrimWhitespaceForm.jsx
@@ -1,0 +1,84 @@
+import { useState } from "react";
+import PropTypes from "prop-types";
+import { transformProject } from "../../api";
+import { useProjectContext } from "../../context/ProjectContext";
+import { useToast } from "../../context/ToastContext";
+
+const TrimWhitespaceForm = ({ projectId, onClose, onTransform }) => {
+    const { columns } = useProjectContext();
+    const { showToast } = useToast();
+
+    const [column, setColumn] = useState("");
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+
+        try {
+            const response = await transformProject(projectId, {
+                operation_type: "trimWhitespace",
+                trim_whitespace_params: {
+                    column,
+                },
+            });
+
+            onTransform(response);
+        } catch (error) {
+            console.error("Error trimming whitespace:", error);
+
+            showToast(error.response?.data?.detail || "Failed to trim whitespace.", "error");
+        }
+
+        onClose();
+    };
+
+    return (
+        <div className="p-4 border border-gray-200 rounded-lg bg-white">
+            <form onSubmit={handleSubmit}>
+                <h3 className="font-semibold text-gray-900 mb-2">Trim Whitespace</h3>
+
+                <div className="mb-4">
+                    <label className="block text-sm font-medium text-gray-700">Column:</label>
+                    <select
+                        value={column}
+                        onChange={(e) => setColumn(e.target.value)}
+                        className="border border-gray-300 rounded-md w-full px-3 py-2 bg-white text-gray-900 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none"
+                        required
+                    >
+                        <option value="">Select column...</option>
+                        <option value="All string columns">All string columns</option>
+                        {columns.map((col) => (
+                            <option key={col} value={col}>
+                                {col}
+                            </option>
+                        ))}
+                    </select>
+                </div>
+
+                <div className="flex justify-between">
+                    <button
+                        type="submit"
+                        className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-md font-medium transition-colors duration-150"
+                    >
+                        Apply
+                    </button>
+
+                    <button
+                        type="button"
+                        onClick={onClose}
+                        className="bg-white border border-gray-300 text-gray-700 hover:bg-gray-50 px-4 py-2 rounded-md font-medium transition-colors duration-150"
+                    >
+                        Cancel
+                    </button>
+                </div>
+            </form>
+        </div>
+    );
+};
+
+TrimWhitespaceForm.propTypes = {
+    projectId: PropTypes.string.isRequired,
+    onClose: PropTypes.func.isRequired,
+    onTransform: PropTypes.func.isRequired,
+};
+
+export default TrimWhitespaceForm;

--- a/dataloom-frontend/src/constants/operationTypes.js
+++ b/dataloom-frontend/src/constants/operationTypes.js
@@ -25,3 +25,9 @@ export const DROP_DUPLICATE = "dropDuplicate";
 export const ADV_QUERY_FILTER = "advQueryFilter";
 /** @type {string} Create a pivot table */
 export const PIVOT_TABLE = "pivotTables";
+/** @type {string} Rename a column */
+export const RENAME_COLUMN = "renameCol";
+/** @type {string} Cast column to different data type */
+export const CAST_DATA_TYPE = "castDataType";
+/** @type {string} Trim whitespace from columns */
+export const TRIM_WHITESPACE = "trimWhitespace";


### PR DESCRIPTION
## Description

Adds a "Trim Whitespace" transformation that removes leading and trailing whitespace from string columns. Users can trim a single column or all string columns at once. This addresses a common data cleaning issue where invisible spaces cause comparison failures and duplicate groupby results.

Fixes #93 

## Type of Change

- [x] New feature

## How Has This Been Tested?

- [x] Manual testing: Verified single column and "All string columns" options
- [x] Tested with NaN/None values (correctly preserved)
- [x] Verified numeric columns remain unaffected
- [x] Confirmed transformation logging and replay functionality
- [x] Tested error handling for invalid columns

**Test cases verified:**
- `" hello "` → `"hello"`
- All string columns trimmed when option selected
- Numeric data types unchanged
- Missing values preserved as NaN/None

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally

## Changes Made

**Backend:**
- Added `trimWhitespace` to `OperationType` and `ActionTypes` enums
- Created `TrimWhitespaceParams` schema with column field
- Implemented `trim_whitespace()` function in transformation service
- Added endpoint handler in `_handle_basic_transform()`
- Integrated log replay support in `apply_logged_transformation()`

**Frontend:**
- Created `TrimWhitespaceForm.jsx` component with column dropdown
- Added "All string columns" special option
- Integrated form into MenuNavbar Data > Transform group
- Added `TRIM_WHITESPACE` constant to operationTypes
- Used LuScissors icon for menu button

**Modified Files:**
- `app/schemas.py`
- `app/services/transformation_service.py`
- `app/api/endpoints/transformations.py`
- `src/Components/forms/TrimWhitespaceForm.jsx` (new)
- `src/Components/MenuNavbar.jsx`
- `src/constants/operationTypes.js`