### PR TITLE
Added sample rows transform and preview table updates

### DIFF
--- a/dataloom-backend/app/api/endpoints/transformations.py
+++ b/dataloom-backend/app/api/endpoints/transformations.py
@@ -91,6 +91,12 @@ def _handle_basic_transform(df, transformation_input, project, db, project_id):
         p = transformation_input.cast_data_type_params
         return ts.cast_data_type(df, p.column, p.target_type), True
 
+    elif op == 'sample':
+        if not transformation_input.sample_rows_params:
+            raise HTTPException(status_code=400, detail="Sample parameters required")
+        p = transformation_input.sample_rows_params
+        return ts.sample_rows(df, p.sample_size, p.random_seed), False
+
     elif op == 'trimWhitespace':
         if not transformation_input.trim_whitespace_params:
             raise HTTPException(status_code=400, detail="Trim whitespace parameters required")

--- a/dataloom-backend/app/schemas.py
+++ b/dataloom-backend/app/schemas.py
@@ -36,6 +36,7 @@ class OperationType(str, Enum):
     renameCol = 'renameCol'
     castDataType = 'castDataType'
     trimWhitespace = 'trimWhitespace'
+    sample = 'sample'
 
 
 class DropDup(str, Enum):
@@ -69,6 +70,7 @@ class ActionTypes(str, Enum):
     changeCellValue = 'changeCellValue'
     renameCol = 'renameCol'
     castDataType = 'castDataType'
+    sample = 'sample'
     trimWhitespace = 'trimWhitespace'
 
 
@@ -132,6 +134,12 @@ class CastDataTypeParams(BaseModel):
     target_type: DataType
 
 
+class SampleRowsParams(BaseModel):
+    """Parameters for sampling rows from a dataset."""
+    sample_size: int
+    random_seed: Optional[int] = None
+
+
 class TrimWhitespaceParams(BaseModel):
     """Parameters for trimming whitespace from columns."""
     column: str
@@ -192,6 +200,7 @@ class TransformationInput(BaseModel):
     change_cell_value: Optional[ChangeCellValue] = None
     rename_col_params: Optional[RenameColumnParams] = None
     cast_data_type_params: Optional[CastDataTypeParams] = None
+    sample_rows_params: Optional[SampleRowsParams] = None
     trim_whitespace_params: Optional[TrimWhitespaceParams] = None
 
 

--- a/dataloom-frontend/src/Components/MenuNavbar.jsx
+++ b/dataloom-frontend/src/Components/MenuNavbar.jsx
@@ -5,6 +5,7 @@ import DropDuplicateForm from "./forms/DropDuplicateForm";
 import AdvQueryFilterForm from "./forms/AdvQueryFilterForm";
 import PivotTableForm from "./forms/PivotTableForm";
 import CastDataTypeForm from "./forms/CastDataTypeForm";
+import SampleRowsForm from "./forms/SampleRowsForm";
 import TrimWhitespaceForm from "./forms/TrimWhitespaceForm";
 import LogsPanel from "./history/LogsPanel";
 import CheckpointsPanel from "./history/CheckpointsPanel";
@@ -24,6 +25,7 @@ import {
   LuBookmark,
   LuDownload,
   LuRefreshCw,
+  LuDices,
   LuScissors,
 } from "react-icons/lu";
 
@@ -33,6 +35,7 @@ const Menu_NavBar = ({ projectId, onTransform }) => {
   const [showDropDuplicateForm, setShowDropDuplicateForm] = useState(false);
   const [showAdvQueryFilterForm, setShowAdvQueryFilterForm] = useState(false);
   const [showPivotTableForm, setShowPivotTableForm] = useState(false);
+  const [showSampleRowsForm, setShowSampleRowsForm] = useState(false);
   const [showLogs, setShowLogs] = useState(false);
   const [showCheckpoints, setShowCheckpoints] = useState(false);
   const [showCastDataTypeForm, setShowCastDataTypeForm] = useState(false);
@@ -121,6 +124,7 @@ const Menu_NavBar = ({ projectId, onTransform }) => {
     setShowDropDuplicateForm(false);
     setShowAdvQueryFilterForm(false);
     setShowPivotTableForm(false);
+    setShowSampleRowsForm(false);
     setShowCastDataTypeForm(false);
     setShowTrimWhitespaceForm(false);
     setShowLogs(false);
@@ -141,6 +145,9 @@ const Menu_NavBar = ({ projectId, onTransform }) => {
         break;
       case "PivotTableForm":
         setShowPivotTableForm(true);
+        break;
+      case "SampleRowsForm":
+        setShowSampleRowsForm(true);
         break;
       case "CastDataTypeForm":
         setShowCastDataTypeForm(true);
@@ -188,6 +195,11 @@ const Menu_NavBar = ({ projectId, onTransform }) => {
             label: "Drop Dup",
             icon: LuCopyMinus,
             onClick: () => handleMenuClick("DropDuplicateForm"),
+          },
+          {
+            label: "Sample",
+            icon: LuDices,
+            onClick: () => handleMenuClick("SampleRowsForm"),
           },
           {
             label: "Cast Type",
@@ -286,6 +298,12 @@ const Menu_NavBar = ({ projectId, onTransform }) => {
           projectId={projectId}
           onClose={() => setShowCastDataTypeForm(false)}
           onTransform={onTransform}
+        />
+      )}
+      {showSampleRowsForm && (
+        <SampleRowsForm
+          projectId={projectId}
+          onClose={() => setShowSampleRowsForm(false)}
         />
       )}
       {showTrimWhitespaceForm && (

--- a/dataloom-frontend/src/Components/forms/SampleRowsForm.jsx
+++ b/dataloom-frontend/src/Components/forms/SampleRowsForm.jsx
@@ -1,0 +1,106 @@
+import { useState } from "react";
+import PropTypes from "prop-types";
+import { transformProject } from "../../api";
+import TransformResultPreview from "./TransformResultPreview";
+
+const SampleRowsForm = ({ projectId, onClose }) => {
+    const [sampleSize, setSampleSize] = useState("");
+    const [randomSeed, setRandomSeed] = useState("");
+    const [result, setResult] = useState(null);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState("");
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+        setError("");
+
+        // Validate sample size
+        const size = parseInt(sampleSize, 10);
+        if (!sampleSize || isNaN(size) || size <= 0) {
+            setError("Sample size must be a positive integer");
+            return;
+        }
+
+        console.log("Submitting sample with parameters:", {
+            sample_size: size,
+            random_seed: randomSeed ? parseInt(randomSeed, 10) : null,
+        });
+        setLoading(true);
+        try {
+            const params = {
+                sample_size: size,
+            };
+            if (randomSeed) {
+                params.random_seed = parseInt(randomSeed, 10);
+            }
+
+            const response = await transformProject(projectId, {
+                operation_type: "sample",
+                sample_rows_params: params,
+            });
+            setResult(response);
+            console.log("Sample API response:", response);
+        } catch (err) {
+            setError(err.response?.data?.detail || "Error applying sample");
+            console.error("Error applying sample:", err.response?.data || err.message);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    return (
+        <div className="p-4 border border-gray-200 rounded-lg bg-white">
+            <form onSubmit={handleSubmit}>
+                <h3 className="font-semibold text-gray-900 mb-2">Sample Rows</h3>
+                {error && <div className="mb-4 p-2 bg-red-50 border border-red-200 text-red-700 rounded-md text-sm">{error}</div>}
+                <div className="flex flex-wrap mb-4">
+                    <div className="w-full sm:w-1/2 mb-2">
+                        <label className="block mb-1 text-sm font-medium text-gray-700">Sample Size:</label>
+                        <input
+                            type="number"
+                            value={sampleSize}
+                            onChange={(e) => setSampleSize(e.target.value)}
+                            placeholder="e.g., 100"
+                            className="border border-gray-300 rounded-md px-3 py-2 w-full bg-white text-gray-900 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none"
+                            required
+                        />
+                    </div>
+                    <div className="w-full sm:w-1/2 mb-2 pl-2">
+                        <label className="block mb-1 text-sm font-medium text-gray-700">Random Seed (Optional):</label>
+                        <input
+                            type="number"
+                            value={randomSeed}
+                            onChange={(e) => setRandomSeed(e.target.value)}
+                            placeholder="e.g., 42"
+                            className="border border-gray-300 rounded-md px-3 py-2 w-full bg-white text-gray-900 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none"
+                        />
+                    </div>
+                </div>
+                <div className="flex justify-between">
+                    <button
+                        type="submit"
+                        className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-md font-medium transition-colors duration-150"
+                        disabled={loading}
+                    >
+                        Sample Rows
+                    </button>
+                    <button
+                        type="button"
+                        onClick={onClose}
+                        className="bg-white border border-gray-300 text-gray-700 hover:bg-gray-50 px-4 py-2 rounded-md font-medium transition-colors duration-150"
+                    >
+                        Cancel
+                    </button>
+                </div>
+            </form>
+            {result && <TransformResultPreview columns={result.columns} rows={result.rows} />}
+        </div>
+    );
+};
+
+SampleRowsForm.propTypes = {
+    projectId: PropTypes.string.isRequired,
+    onClose: PropTypes.func.isRequired,
+};
+
+export default SampleRowsForm;

--- a/dataloom-frontend/src/Components/forms/TransformResultPreview.jsx
+++ b/dataloom-frontend/src/Components/forms/TransformResultPreview.jsx
@@ -9,44 +9,65 @@ const TransformResultPreview = ({ columns, rows }) => {
     return <p className="text-gray-500 mt-4">No columns available</p>;
   }
 
+  const sNoColumnKey = "__row_number";
+  const hasRowNumber = columns[0] === sNoColumnKey;
+  const displayColumns = hasRowNumber ? columns.slice(1) : columns;
+  const displayRows = hasRowNumber ? rows.map((row) => row.slice(1)) : rows;
+  const sNoValues = hasRowNumber ? rows.map((row) => row[0]) : rows.map((_, index) => index + 1);
+
   return (
     <div className="p-4 mt-4 border border-gray-200 rounded-lg bg-gray-50">
       <h4 className="font-medium text-sm text-gray-700 mb-2">API Response:</h4>
-      <table className="min-w-full divide-y divide-gray-200">
-        <thead className="bg-gray-100">
-          <tr>
-            {columns.map((col, index) => (
-              <th
-                key={index}
-                className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
-              >
-                {col}
+      <div
+        className="overflow-x-scroll overflow-y-auto border border-gray-200 rounded-lg shadow-sm"
+        style={{ maxHeight: "calc(100vh - 140px)" }}
+      >
+        <table className="min-w-full bg-white">
+          <thead className="sticky top-0 bg-gray-50">
+            <tr>
+              <th className="py-1.5 px-3 border-b border-gray-200 text-left text-xs font-medium text-gray-500">
+                <button className="w-full text-left text-gray-500 hover:text-gray-700 hover:bg-gray-100 py-0.5 px-1.5 rounded-md transition-colors duration-150">
+                  S.No.
+                </button>
               </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody className="bg-white divide-y divide-gray-200">
-          {rows.map((row, rowIndex) => (
-            <tr key={rowIndex}>
-              {row.map((cell, cellIndex) => (
-                <td
-                  key={cellIndex}
-                  className="px-6 py-4 whitespace-nowrap text-sm text-gray-700"
+              {displayColumns.map((col, index) => (
+                <th
+                  key={index}
+                  className="py-1.5 px-3 border-b border-gray-200 text-left text-xs font-medium text-gray-500"
                 >
-                  {cell}
-                </td>
+                  <button className="w-full text-left text-gray-500 hover:text-gray-700 hover:bg-gray-100 py-0.5 px-1.5 rounded-md transition-colors duration-150">
+                    {col}
+                  </button>
+                </th>
               ))}
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {displayRows.map((row, rowIndex) => (
+              <tr
+                key={rowIndex}
+                className="border-b border-gray-100 hover:bg-gray-50 transition-colors duration-150"
+              >
+                <td className="py-1 px-3 text-xs text-gray-700">
+                  {sNoValues[rowIndex]}
+                </td>
+                {row.map((cell, cellIndex) => (
+                  <td key={cellIndex} className="py-1 px-3 text-xs text-gray-700">
+                    {cell}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 };
 
 TransformResultPreview.propTypes = {
   columns: PropTypes.arrayOf(PropTypes.string).isRequired,
-  rows: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.string)).isRequired,
+  rows: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.any)).isRequired,
 };
 
 export default TransformResultPreview;

--- a/dataloom-frontend/src/constants/operationTypes.js
+++ b/dataloom-frontend/src/constants/operationTypes.js
@@ -25,6 +25,8 @@ export const DROP_DUPLICATE = "dropDuplicate";
 export const ADV_QUERY_FILTER = "advQueryFilter";
 /** @type {string} Create a pivot table */
 export const PIVOT_TABLE = "pivotTables";
+/** @type {string} Sample random rows from dataset */
+export const SAMPLE_ROWS = "sample";
 /** @type {string} Rename a column */
 export const RENAME_COLUMN = "renameCol";
 /** @type {string} Cast column to different data type */


### PR DESCRIPTION
## Description

This change introduces a full “Sample Rows” workflow to DataLoom, spanning backend logic, API validation, logging, and frontend UX. The backend now supports sampling with an optional random seed for deterministic results, rejects invalid sample sizes, and preserves original row numbers so users can trace sampled rows back to their positions in the source dataset. The transformation is logged like other operations, and preview results are returned in the same response shape as existing transforms.

On the frontend, a dedicated Sample Rows form was added to the Transform menu. The preview table has been brought in line with the main dataset table: consistent typography, spacing, and header styling, plus both horizontal and vertical scrolling with a sticky header. Column headings preserve original casing (no forced uppercase), and the S.No column displays original row numbers from the sampled data instead of sequential preview indices.

Fixes #96 

---

## Type of Change

- [ ] Bug fix  
- [x] New feature  
- [ ] Breaking change  
- [ ] Documentation update  

---

## How Has This Been Tested?

- [ ] Existing tests pass  
- [ ] New tests added  
- [x] Manual testing  

Manual testing details:
- Sample Rows with valid size and seed from the UI.
- Verified reproducibility with the same seed.
- Verified behavior when sample size exceeds dataset length.
- Verified validation errors for zero/negative sample size.
- Confirmed preview table scrolling (both axes), spacing, and header casing.
- Confirmed S.No reflects original row numbers for sampled data.
- Verified transformation appears in logs.

---

## Screenshots

https://github.com/user-attachments/assets/4e585d7a-a47e-4a0e-931f-b27db6191f98



---

## Checklist

- [x] My code follows the project's style guidelines  
- [x] I have performed a self-review  
- [ ] I have added/updated documentation as needed  
- [x] My changes generate no new warnings  
- [ ] Tests pass locally