### PR TITLE
feat: show all checkpoints instead of last one only

### DIFF
--- a/dataloom-frontend/src/Components/history/CheckpointsPanel.jsx
+++ b/dataloom-frontend/src/Components/history/CheckpointsPanel.jsx
@@ -1,12 +1,41 @@
+import { useState } from "react";
 import PropTypes from "prop-types";
+import ConfirmDialog from "../common/ConfirmDialog";
 
-const CheckpointsPanel = ({ checkpoints, onClose, onRevert }) => {
-  const hasCheckpoints = checkpoints && Array.isArray(checkpoints) ? checkpoints.length > 0 : checkpoints && checkpoints.id;
+const CheckpointsPanel = ({ checkpoints, onClose, onRevert, loading = false, error = null }) => {
+  const [confirmData, setConfirmData] = useState(null);
+  const [revertingId, setRevertingId] = useState(null);
+
+  const handleRevertClick = (checkpoint) => {
+    setConfirmData({
+      checkpoint,
+      message: `Are you sure you want to revert to checkpoint "${checkpoint.message}"?\n\nThis action will restore the project to ${new Date(checkpoint.created_at).toLocaleString()} and remove all subsequent changes.`,
+    });
+  };
+
+  const handleConfirmRevert = async () => {
+    if (!confirmData?.checkpoint) return;
+
+    setRevertingId(confirmData.checkpoint.id);
+    setConfirmData(null);
+
+    try {
+      await onRevert(confirmData.checkpoint.id);
+    } finally {
+      setRevertingId(null);
+    }
+  };
+
+  const handleCancelRevert = () => {
+    setConfirmData(null);
+  };
+
+  const hasCheckpoints = checkpoints && checkpoints.length > 0;
 
   return (
     <div className="p-4 bg-white border border-gray-200 rounded-lg shadow-sm mx-auto relative group">
       <div className="flex items-center justify-between mb-4">
-        <h3 className="text-lg font-semibold text-gray-900">Last Checkpoint</h3>
+        <h3 className="text-lg font-semibold text-gray-900">All Checkpoints</h3>
         <button
           onClick={onClose}
           className="text-gray-400 hover:text-gray-600 font-medium transition-opacity opacity-0 group-hover:opacity-100"
@@ -22,60 +51,97 @@ const CheckpointsPanel = ({ checkpoints, onClose, onRevert }) => {
       </div>
 
       <div className="overflow-x-auto">
-        <table className="min-w-full bg-white rounded-lg overflow-hidden">
-          <thead className="bg-gray-50">
-            <tr>
-              <th className="py-3 px-4 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                Message
-              </th>
-              <th className="py-3 px-4 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                Created At
-              </th>
-              <th className="py-3 px-4 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">
-                Action
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            {hasCheckpoints ? (
-              <tr className="border-b border-gray-100 hover:bg-gray-50 transition-colors duration-150">
-                <td className="py-3 px-4 text-sm text-gray-700">
-                  {checkpoints.message}
-                </td>
-                <td className="py-3 px-4 text-sm text-gray-500">
-                  {new Date(checkpoints.created_at).toLocaleString()}
-                </td>
-                <td className="py-3 px-4 text-center">
-                  <button
-                    onClick={() => onRevert(checkpoints.id)}
-                    className="bg-blue-500 hover:bg-blue-600 text-white text-sm font-medium px-3 py-1.5 rounded-md transition-colors duration-150"
-                  >
-                    Revert
-                  </button>
-                </td>
-              </tr>
-            ) : (
+        <div
+          className="min-w-full bg-white rounded-lg overflow-hidden"
+          style={{ maxHeight: "400px", overflowY: "auto" }}
+        >
+          <table className="min-w-full">
+            <thead className="bg-gray-50 sticky top-0">
               <tr>
-                <td colSpan="3" className="py-4 px-4 text-center text-sm text-gray-500">
-                  No checkpoint available
-                </td>
+                <th className="py-3 px-4 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Message
+                </th>
+                <th className="py-3 px-4 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Created At
+                </th>
+                <th className="py-3 px-4 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Action
+                </th>
               </tr>
-            )}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {loading ? (
+                <tr>
+                  <td colSpan="3" className="py-4 px-4 text-center text-sm text-gray-500">
+                    Loading checkpoints...
+                  </td>
+                </tr>
+              ) : error ? (
+                <tr>
+                  <td colSpan="3" className="py-4 px-4 text-center text-sm text-red-500">
+                    Error loading checkpoints: {error}
+                  </td>
+                </tr>
+              ) : hasCheckpoints ? (
+                checkpoints.map((checkpoint, index) => (
+                  <tr
+                    key={checkpoint.id}
+                    className="border-b border-gray-100 hover:bg-gray-50 transition-colors duration-150"
+                  >
+                    <td className="py-3 px-4 text-sm text-gray-700">
+                      {checkpoint.message}
+                    </td>
+                    <td className="py-3 px-4 text-sm text-gray-500">
+                      {new Date(checkpoint.created_at).toLocaleString()}
+                    </td>
+                    <td className="py-3 px-4 text-center">
+                      <button
+                        onClick={() => handleRevertClick(checkpoint)}
+                        disabled={revertingId === checkpoint.id}
+                        className={`text-sm font-medium px-3 py-1.5 rounded-md transition-colors duration-150 ${revertingId === checkpoint.id
+                          ? "bg-gray-400 text-white cursor-not-allowed"
+                          : "bg-blue-500 hover:bg-blue-600 text-white"
+                          }`}
+                      >
+                        {revertingId === checkpoint.id ? "Reverting..." : "Revert"}
+                      </button>
+                    </td>
+                  </tr>
+                ))
+              ) : (
+                <tr>
+                  <td colSpan="3" className="py-4 px-4 text-center text-sm text-gray-500">
+                    No checkpoints yet
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
       </div>
+
+      <ConfirmDialog
+        isOpen={!!confirmData}
+        message={confirmData?.message}
+        onConfirm={handleConfirmRevert}
+        onCancel={handleCancelRevert}
+      />
     </div>
   );
 };
 
 CheckpointsPanel.propTypes = {
-  checkpoints: PropTypes.shape({
-    id: PropTypes.string,
-    message: PropTypes.string,
-    created_at: PropTypes.string,
-  }),
+  checkpoints: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      message: PropTypes.string.isRequired,
+      created_at: PropTypes.string.isRequired,
+    })
+  ).isRequired,
   onClose: PropTypes.func.isRequired,
   onRevert: PropTypes.func.isRequired,
+  loading: PropTypes.bool,
+  error: PropTypes.string,
 };
 
 export default CheckpointsPanel;

--- a/dataloom-frontend/src/api/projects.js
+++ b/dataloom-frontend/src/api/projects.js
@@ -59,9 +59,7 @@ export const saveProject = async (projectId, commitMessage) => {
  * @returns {Promise<Object>} Reverted project response.
  */
 export const revertToCheckpoint = async (projectId, checkpointId) => {
-  const response = await client.post(
-    `/projects/${projectId}/revert?checkpoint_id=${checkpointId}`
-  );
+  const response = await client.post(`/projects/${projectId}/checkpoints/${checkpointId}/revert`);
   return response.data;
 };
 
@@ -84,5 +82,15 @@ export const exportProject = async (projectId) => {
  */
 export const deleteProject = async (projectId) => {
   const response = await client.delete(`/projects/${projectId}`);
+  return response.data;
+};
+
+/**
+ * Get all checkpoints for a project ordered by creation time.
+ * @param {string} projectId - The project ID.
+ * @returns {Promise<Array>} List of checkpoint objects.
+ */
+export const getAllCheckpoints = async (projectId) => {
+  const response = await client.get(`/projects/${projectId}/checkpoints`);
   return response.data;
 };


### PR DESCRIPTION
## Description

Implemented complete checkpoint history display showing all checkpoints instead of just the last one. Added loading states during operations, confirmation dialogs for revert actions, and automatic log cleanup after reverting to maintain data consistency.

Fixes #88 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

Manual testing performed across all functionality:

- [x] Existing tests pass
- [ ] New tests added
- [x] Manual testing

**Testing Details:**
- Created multiple checkpoints and verified all display in chronological order
- Tested scrollable container with many checkpoints
- Verified loading states during fetch and revert operations
- Confirmed revert functionality with proper log cleanup
- Tested error handling and CORS configuration
- Verified data table and logs panel refresh after operations

## Screenshots (if applicable)
<img width="1920" height="1080" alt="Screenshot 2026-02-27 170042" src="https://github.com/user-attachments/assets/cf71fb74-9e8c-468e-8e50-443ea49f0d3d" />
<img width="1920" height="1080" alt="Screenshot 2026-02-27 170302" src="https://github.com/user-attachments/assets/66a0fd64-801a-439f-959f-8844161c5b55" />


- Checkpoint panel now shows complete history instead of single entry
- Scrollable interface handles large checkpoint lists
- Loading states provide user feedback during operations
- Confirmation dialog prevents accidental reverts

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally