### PR TITLE
feat: create initial tables with UUID primary keys for datasets, checkpoints, and user logs

### DIFF
--- a/dataloom-backend/alembic/versions/34e620d988fc_use_uuids_for_dataset_and_checkpoint_ids.py
+++ b/dataloom-backend/alembic/versions/34e620d988fc_use_uuids_for_dataset_and_checkpoint_ids.py
@@ -19,111 +19,50 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    """Upgrade schema."""
-    # Step 1: Drop all foreign keys that reference columns being altered
-    op.drop_constraint(op.f('checkpoints_dataset_id_fkey'), 'checkpoints', type_='foreignkey')
-    op.drop_constraint(op.f('user_logs_dataset_id_fkey'), 'user_logs', type_='foreignkey')
-    op.drop_constraint(op.f('user_logs_checkpoint_id_fkey'), 'user_logs', type_='foreignkey')
+    """Create initial tables with UUID primary keys."""
+    # datasets table (will be renamed to projects in a later migration)
+    op.create_table(
+        'datasets',
+        sa.Column('dataset_id', sa.Uuid(), server_default=sa.text('gen_random_uuid()'), nullable=False),
+        sa.Column('name', sa.String(), nullable=False),
+        sa.Column('description', sa.String(), nullable=True),
+        sa.Column('upload_date', sa.DateTime(), server_default=sa.text('now()'), nullable=True),
+        sa.Column('last_modified', sa.DateTime(), server_default=sa.text('now()'), nullable=True),
+        sa.Column('file_path', sa.String(), nullable=False),
+        sa.PrimaryKeyConstraint('dataset_id'),
+    )
+    op.create_index(op.f('ix_datasets_name'), 'datasets', ['name'], unique=False)
 
-    # Step 2: Drop indexes on columns being altered
-    op.drop_index(op.f('ix_checkpoints_id'), table_name='checkpoints')
-    op.drop_index(op.f('ix_datasets_dataset_id'), table_name='datasets')
+    # checkpoints table
+    op.create_table(
+        'checkpoints',
+        sa.Column('id', sa.Uuid(), server_default=sa.text('gen_random_uuid()'), nullable=False),
+        sa.Column('dataset_id', sa.Uuid(), nullable=False),
+        sa.Column('message', sa.String(), nullable=False),
+        sa.Column('created_at', sa.DateTime(), server_default=sa.text('now()'), nullable=True),
+        sa.ForeignKeyConstraint(['dataset_id'], ['datasets.dataset_id'], name='checkpoints_dataset_id_fkey'),
+        sa.PrimaryKeyConstraint('id'),
+    )
 
-    # Step 3: Drop serial defaults before type change (nextval can't cast to UUID)
-    op.alter_column('datasets', 'dataset_id', server_default=None)
-    op.alter_column('checkpoints', 'id', server_default=None)
-
-    # Step 4: Alter all primary key columns first (referenced by FKs)
-    op.alter_column('datasets', 'dataset_id',
-               existing_type=sa.INTEGER(),
-               type_=sa.Uuid(),
-               existing_nullable=False,
-               postgresql_using='gen_random_uuid()')
-    op.alter_column('checkpoints', 'id',
-               existing_type=sa.INTEGER(),
-               type_=sa.Uuid(),
-               existing_nullable=False,
-               postgresql_using='gen_random_uuid()')
-
-    # Step 5: Set new UUID defaults
-    op.alter_column('datasets', 'dataset_id', server_default=sa.text('gen_random_uuid()'))
-    op.alter_column('checkpoints', 'id', server_default=sa.text('gen_random_uuid()'))
-
-    # Step 6: Alter all foreign key columns to match
-    op.alter_column('checkpoints', 'dataset_id',
-               existing_type=sa.INTEGER(),
-               type_=sa.Uuid(),
-               existing_nullable=False,
-               postgresql_using='gen_random_uuid()')
-    op.alter_column('user_logs', 'dataset_id',
-               existing_type=sa.INTEGER(),
-               type_=sa.Uuid(),
-               existing_nullable=False,
-               postgresql_using='gen_random_uuid()')
-    op.alter_column('user_logs', 'checkpoint_id',
-               existing_type=sa.INTEGER(),
-               type_=sa.Uuid(),
-               existing_nullable=True,
-               postgresql_using='checkpoint_id::text::uuid')
-
-    # Step 7: Alter non-FK columns
-    op.alter_column('datasets', 'name',
-               existing_type=sa.VARCHAR(),
-               nullable=False)
-    op.alter_column('datasets', 'file_path',
-               existing_type=sa.VARCHAR(),
-               nullable=False)
-
-    # Step 8: Recreate all foreign keys
-    op.create_foreign_key(None, 'checkpoints', 'datasets', ['dataset_id'], ['dataset_id'])
-    op.create_foreign_key(None, 'user_logs', 'datasets', ['dataset_id'], ['dataset_id'])
-    op.create_foreign_key(None, 'user_logs', 'checkpoints', ['checkpoint_id'], ['id'])
+    # user_logs table
+    op.create_table(
+        'user_logs',
+        sa.Column('change_log_id', sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column('dataset_id', sa.Uuid(), nullable=False),
+        sa.Column('action_type', sa.String(length=50), nullable=False),
+        sa.Column('action_details', sa.JSON(), nullable=False),
+        sa.Column('timestamp', sa.DateTime(), server_default=sa.text('now()'), nullable=False),
+        sa.Column('checkpoint_id', sa.Uuid(), nullable=True),
+        sa.Column('applied', sa.Boolean(), server_default='false', nullable=False),
+        sa.ForeignKeyConstraint(['checkpoint_id'], ['checkpoints.id'], name='user_logs_checkpoint_id_fkey'),
+        sa.ForeignKeyConstraint(['dataset_id'], ['datasets.dataset_id'], name='user_logs_dataset_id_fkey'),
+        sa.PrimaryKeyConstraint('change_log_id'),
+    )
 
 
 def downgrade() -> None:
-    """Downgrade schema."""
-    # Step 1: Drop all foreign keys
-    op.drop_constraint(None, 'user_logs', type_='foreignkey')
-    op.drop_constraint(None, 'user_logs', type_='foreignkey')
-    op.drop_constraint(None, 'checkpoints', type_='foreignkey')
+    op.drop_table('user_logs')
+    op.drop_table('checkpoints')
+    op.drop_index(op.f('ix_datasets_name'), table_name='datasets')
+    op.drop_table('datasets')
 
-    # Step 2: Revert FK columns back to INTEGER
-    op.alter_column('user_logs', 'checkpoint_id',
-               existing_type=sa.Uuid(),
-               type_=sa.INTEGER(),
-               existing_nullable=True)
-    op.alter_column('user_logs', 'dataset_id',
-               existing_type=sa.Uuid(),
-               type_=sa.INTEGER(),
-               existing_nullable=False)
-    op.alter_column('checkpoints', 'dataset_id',
-               existing_type=sa.Uuid(),
-               type_=sa.INTEGER(),
-               existing_nullable=False)
-
-    # Step 3: Revert PK columns back to INTEGER
-    op.alter_column('datasets', 'dataset_id',
-               existing_type=sa.Uuid(),
-               type_=sa.INTEGER(),
-               existing_nullable=False)
-    op.alter_column('checkpoints', 'id',
-               existing_type=sa.Uuid(),
-               type_=sa.INTEGER(),
-               existing_nullable=False)
-
-    # Step 4: Revert non-FK column changes
-    op.alter_column('datasets', 'file_path',
-               existing_type=sa.VARCHAR(),
-               nullable=True)
-    op.alter_column('datasets', 'name',
-               existing_type=sa.VARCHAR(),
-               nullable=True)
-
-    # Step 5: Recreate indexes
-    op.create_index(op.f('ix_datasets_dataset_id'), 'datasets', ['dataset_id'], unique=False)
-    op.create_index(op.f('ix_checkpoints_id'), 'checkpoints', ['id'], unique=False)
-
-    # Step 6: Recreate foreign keys
-    op.create_foreign_key(op.f('checkpoints_dataset_id_fkey'), 'checkpoints', 'datasets', ['dataset_id'], ['dataset_id'], ondelete='CASCADE')
-    op.create_foreign_key(op.f('user_logs_checkpoint_id_fkey'), 'user_logs', 'checkpoints', ['checkpoint_id'], ['id'], ondelete='SET NULL')
-    op.create_foreign_key(op.f('user_logs_dataset_id_fkey'), 'user_logs', 'datasets', ['dataset_id'], ['dataset_id'], ondelete='CASCADE')


### PR DESCRIPTION
## Description

Fixes fresh database setup failure during backend onboarding.

This PR updates the initial Alembic migration (`34e620d988fc_use_uuids_for_dataset_and_checkpoint_ids`) so it creates the base tables (`datasets`, `checkpoints`, `user_logs`) directly with UUID keys, instead of trying to alter non-existent tables on a clean database.

Without this change, running `uv run alembic upgrade head` on a new PostgreSQL instance fails with `relation "checkpoints" does not exist`, blocking new contributors from completing setup.

Fixes #141

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

Describe the tests you ran to verify your changes.

- [X] Existing tests pass
- [ ] New tests added
- [ ] Manual testing

## Screenshots (if applicable)

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review
- [ ] I have added/updated documentation as needed
- [ ] My changes generate no new warnings
- [ ] Tests pass locally
