### PR TITLE
feat: implement CSV export functionality with customizable options

### DIFF
--- a/dataloom-backend/app/api/endpoints/projects.py
+++ b/dataloom-backend/app/api/endpoints/projects.py
@@ -3,10 +3,11 @@
 Handles upload, retrieval, save (checkpoint), and revert operations.
 """
 
+import io
 import uuid
 
-from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
-from fastapi.responses import FileResponse
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile
+from fastapi.responses import StreamingResponse
 from sqlmodel import Session
 
 from app import database, models, schemas
@@ -185,10 +186,31 @@ async def revert_to_checkpoint(
 
 
 @router.get("/{project_id}/export")
-async def export_project(project_id: uuid.UUID, db: Session = Depends(database.get_db)):
-    """Download the current working copy of a project as a CSV file."""
+async def export_project(
+    project_id: uuid.UUID,
+    delimiter: schemas.ExportDelimiter = Query(default=schemas.ExportDelimiter.comma),
+    include_header: bool = Query(default=True),
+    encoding: schemas.ExportEncoding = Query(default=schemas.ExportEncoding.utf8),
+    db: Session = Depends(database.get_db),
+):
+    """Download the current working copy of a project as a CSV file.
+
+    Supports custom delimiter, header inclusion, and file encoding.
+    """
     project = get_project_or_404(project_id, db)
-    return FileResponse(project.file_path, media_type="text/csv", filename=f"{project.name}.csv")
+    df = read_csv_safe(project.file_path)
+
+    buffer = io.StringIO()
+    df.to_csv(buffer, index=False, sep=delimiter.to_char(), header=include_header)
+    csv_bytes = buffer.getvalue().encode(encoding.value)
+
+    filename = f"{project.name}.csv"
+    logger.info("Export: id=%s, delimiter=%s, header=%s, encoding=%s", project_id, delimiter, include_header, encoding)
+    return StreamingResponse(
+        io.BytesIO(csv_bytes),
+        media_type=f"text/csv; charset={encoding.value}",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
 
 
 @router.delete("/{project_id}")

--- a/dataloom-backend/app/api/endpoints/projects.py
+++ b/dataloom-backend/app/api/endpoints/projects.py
@@ -5,9 +5,10 @@ Handles upload, retrieval, save (checkpoint), and revert operations.
 
 import io
 import uuid
+from urllib.parse import quote
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile
-from fastapi.responses import StreamingResponse
+from fastapi.responses import FileResponse, Response, StreamingResponse
 from sqlmodel import Session
 
 from app import database, models, schemas
@@ -21,7 +22,7 @@ from app.services.project_service import (
 from app.services.file_service import delete_project_files, get_original_path, store_upload
 from app.services.transformation_service import apply_logged_transformation
 from app.utils.logging import get_logger
-from app.utils.pandas_helpers import dataframe_to_response, read_csv_safe, save_csv_safe
+from app.utils.pandas_helpers import dataframe_to_response, read_csv_as_strings, read_csv_safe, save_csv_safe
 from app.utils.security import validate_upload_file
 
 logger = get_logger(__name__)
@@ -198,18 +199,63 @@ async def export_project(
     Supports custom delimiter, header inclusion, and file encoding.
     """
     project = get_project_or_404(project_id, db)
-    df = read_csv_safe(project.file_path)
+
+    # Build a safe Content-Disposition header per RFC 6266.
+    # Strip characters that would break the quoted-string token, then provide
+    # both a legacy ASCII fallback and a percent-encoded filename* parameter
+    # for non-ASCII names and modern browsers.
+    safe_name = project.name.replace('"', "").replace("\\", "")
+    encoded_name = quote(f"{safe_name}.csv", safe="")
+    content_disposition = (
+        f'attachment; filename="{safe_name}.csv"; '
+        f"filename*=UTF-8''{encoded_name}"
+    )
+    headers = {"Content-Disposition": content_disposition}
+
+    logger.info(
+        "Export: id=%s, delimiter=%s, header=%s, encoding=%s",
+        project_id, delimiter, include_header, encoding,
+    )
+
+    # Fast path: serve the raw file bytes for the default combination so that
+    # no pandas round-trip can silently alter data values (leading zeros, date
+    # reformatting, scientific notation, etc.).
+    if (
+        delimiter == schemas.ExportDelimiter.comma
+        and include_header
+        and encoding == schemas.ExportEncoding.utf8
+    ):
+        return FileResponse(
+            project.file_path,
+            media_type="text/csv; charset=utf-8",
+            headers=headers,
+        )
+
+    # Non-default: read every cell as a string to preserve original
+    # representations, then re-serialise with the requested options.
+    df = read_csv_as_strings(project.file_path)
 
     buffer = io.StringIO()
     df.to_csv(buffer, index=False, sep=delimiter.to_char(), header=include_header)
-    csv_bytes = buffer.getvalue().encode(encoding.value)
 
-    filename = f"{project.name}.csv"
-    logger.info("Export: id=%s, delimiter=%s, header=%s, encoding=%s", project_id, delimiter, include_header, encoding)
-    return StreamingResponse(
-        io.BytesIO(csv_bytes),
+    try:
+        csv_bytes = buffer.getvalue().encode(encoding.value)
+    except UnicodeEncodeError:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"The data contains characters that cannot be encoded as "
+                f"{encoding.value}. Try UTF-8 instead."
+            ),
+        )
+
+    # The full content is already in memory (required to catch the encoding
+    # error above), so use Response directly rather than giving a false
+    # impression of streaming via StreamingResponse.
+    return Response(
+        content=csv_bytes,
         media_type=f"text/csv; charset={encoding.value}",
-        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+        headers=headers,
     )
 
 

--- a/dataloom-backend/app/schemas.py
+++ b/dataloom-backend/app/schemas.py
@@ -126,6 +126,26 @@ class DataType(str, Enum):
     datetime = "datetime"
 
 
+class ExportDelimiter(str, Enum):
+    """Supported CSV delimiter options for export."""
+    comma = "comma"
+    tab = "tab"
+    semicolon = "semicolon"
+    pipe = "pipe"
+
+    def to_char(self) -> str:
+        """Return the actual delimiter character."""
+        return {"comma": ",", "tab": "\t", "semicolon": ";", "pipe": "|"}[self.value]
+
+
+class ExportEncoding(str, Enum):
+    """Supported file encoding options for export."""
+    utf8 = "utf-8"
+    latin1 = "latin-1"
+    ascii = "ascii"
+    utf16 = "utf-16"
+
+
 class CastDataTypeParams(BaseModel):
     """Parameters for casting a column to a different data type."""
     column: str

--- a/dataloom-backend/app/schemas.py
+++ b/dataloom-backend/app/schemas.py
@@ -2,7 +2,7 @@
 
 import uuid
 from pydantic import BaseModel
-from enum import Enum
+from enum import Enum, StrEnum
 from typing import Optional, Union, Any, List
 import datetime
 
@@ -126,7 +126,7 @@ class DataType(str, Enum):
     datetime = "datetime"
 
 
-class ExportDelimiter(str, Enum):
+class ExportDelimiter(StrEnum):
     """Supported CSV delimiter options for export."""
     comma = "comma"
     tab = "tab"
@@ -135,15 +135,19 @@ class ExportDelimiter(str, Enum):
 
     def to_char(self) -> str:
         """Return the actual delimiter character."""
-        return {"comma": ",", "tab": "\t", "semicolon": ";", "pipe": "|"}[self.value]
+        match self:
+            case ExportDelimiter.comma:     return ","
+            case ExportDelimiter.tab:       return "\t"
+            case ExportDelimiter.semicolon: return ";"
+            case ExportDelimiter.pipe:      return "|"
 
 
-class ExportEncoding(str, Enum):
+class ExportEncoding(StrEnum):
     """Supported file encoding options for export."""
     utf8 = "utf-8"
     latin1 = "latin-1"
     ascii = "ascii"
-    utf16 = "utf-16"
+    utf16le = "utf-16-le"
 
 
 class CastDataTypeParams(BaseModel):

--- a/dataloom-backend/app/utils/pandas_helpers.py
+++ b/dataloom-backend/app/utils/pandas_helpers.py
@@ -26,6 +26,29 @@ def read_csv_safe(path: Path) -> pd.DataFrame:
         raise HTTPException(status_code=500, detail=f"Error reading CSV: {str(e)}")
 
 
+def read_csv_as_strings(path: Path) -> pd.DataFrame:
+    """Read a CSV preserving all values as their original string representations.
+
+    Uses dtype=str and keep_default_na=False to prevent pandas from silently
+    converting values (e.g. "00123"→123, "1.10"→"1.1", ""→NaN).
+
+    Args:
+        path: Path to the CSV file.
+
+    Returns:
+        DataFrame where every cell is a string.
+
+    Raises:
+        HTTPException: If the file cannot be read.
+    """
+    try:
+        return pd.read_csv(path, dtype=str, keep_default_na=False)
+    except FileNotFoundError:
+        raise HTTPException(status_code=404, detail=f"CSV file not found: {path}")
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Error reading CSV: {str(e)}")
+
+
 def save_csv_safe(df: pd.DataFrame, path: Path) -> None:
     """Save a DataFrame to CSV safely.
 

--- a/dataloom-backend/tests/test_new_features.py
+++ b/dataloom-backend/tests/test_new_features.py
@@ -1,6 +1,7 @@
 """Tests for new features: rename column, cast data type, export, and delete project."""
 
 import csv
+import io
 
 import pandas as pd
 import pytest
@@ -111,33 +112,146 @@ class TestLogReplay:
 
 # --- Export Endpoint Tests ---
 
+@pytest.fixture
+def seeded_project(client, sample_csv):
+    """Upload the sample CSV and return the project_id."""
+    with open(sample_csv, "rb") as f:
+        response = client.post(
+            "/projects/upload",
+            files={"file": ("test.csv", f, "text/csv")},
+            data={"projectName": "Export Test", "projectDescription": "Test export"},
+        )
+    assert response.status_code == 200
+    return response.json()["project_id"]
+
+
+@pytest.fixture
+def seeded_unicode_project(client, tmp_path):
+    """Upload a CSV that contains non-ASCII characters and return the project_id."""
+    csv_path = tmp_path / "unicode_data.csv"
+    with open(csv_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(["name", "city"])
+        writer.writerow(["Alice", "Köln"])   # ö — non-ASCII Latin
+        writer.writerow(["Bob", "北京"])      # Chinese characters
+    with open(csv_path, "rb") as f:
+        response = client.post(
+            "/projects/upload",
+            files={"file": ("unicode.csv", f, "text/csv")},
+            data={"projectName": "Unicode Test", "projectDescription": "Test"},
+        )
+    assert response.status_code == 200
+    return response.json()["project_id"]
+
+
 class TestExportEndpoint:
-    def test_export_project(self, client, sample_csv, db):
-        # Upload a project first
-        with open(sample_csv, "rb") as f:
-            response = client.post(
-                "/projects/upload",
-                files={"file": ("test.csv", f, "text/csv")},
-                data={"projectName": "Export Test", "projectDescription": "Test export"},
-            )
-        assert response.status_code == 200
-        project_id = response.json()["project_id"]
+    # --- Default (fast-path) ---
 
-        # Export the project
-        export_response = client.get(f"/projects/{project_id}/export")
-        assert export_response.status_code == 200
-        assert export_response.headers["content-type"] == "text/csv; charset=utf-8"
+    def test_export_default_returns_valid_csv(self, client, seeded_project):
+        r = client.get(f"/projects/{seeded_project}/export")
+        assert r.status_code == 200
+        assert "text/csv" in r.headers["content-type"]
+        assert "utf-8" in r.headers["content-type"]
 
-        # Verify content is valid CSV
-        content = export_response.content.decode("utf-8")
-        reader = csv.reader(content.strip().splitlines())
-        rows = list(reader)
+        rows = list(csv.reader(r.content.decode("utf-8").strip().splitlines()))
         assert rows[0] == ["name", "age", "city"]
         assert len(rows) == 5  # header + 4 data rows
 
     def test_export_nonexistent_project(self, client):
-        response = client.get("/projects/00000000-0000-0000-0000-000000000000/export")
-        assert response.status_code == 404
+        r = client.get("/projects/00000000-0000-0000-0000-000000000000/export")
+        assert r.status_code == 404
+
+    # --- Delimiter variants ---
+
+    @pytest.mark.parametrize("delimiter,expected_sep", [
+        ("comma",     b","),
+        ("tab",       b"\t"),
+        ("semicolon", b";"),
+        ("pipe",      b"|"),
+    ])
+    def test_export_delimiter(self, client, seeded_project, delimiter, expected_sep):
+        r = client.get(f"/projects/{seeded_project}/export?delimiter={delimiter}")
+        assert r.status_code == 200
+        assert expected_sep in r.content
+
+    def test_export_invalid_delimiter_returns_422(self, client, seeded_project):
+        r = client.get(f"/projects/{seeded_project}/export?delimiter=space")
+        assert r.status_code == 422
+
+    # --- Header toggle ---
+
+    def test_export_no_header_omits_header_row(self, client, seeded_project):
+        r = client.get(f"/projects/{seeded_project}/export?include_header=false")
+        assert r.status_code == 200
+        first_line = r.content.decode("utf-8").splitlines()[0]
+        # Data row starts with "Alice", not the column name "name"
+        assert first_line.startswith("Alice")
+
+    def test_export_with_header_includes_header_row(self, client, seeded_project):
+        r = client.get(f"/projects/{seeded_project}/export?include_header=true")
+        assert r.status_code == 200
+        first_line = r.content.decode("utf-8").splitlines()[0]
+        assert first_line.startswith("name")
+
+    # --- Encoding variants ---
+
+    def test_export_latin1_encoding(self, client, seeded_project):
+        r = client.get(f"/projects/{seeded_project}/export?encoding=latin-1")
+        assert r.status_code == 200
+        # ASCII-safe content should round-trip cleanly through Latin-1
+        rows = list(csv.reader(r.content.decode("latin-1").strip().splitlines()))
+        assert rows[0] == ["name", "age", "city"]
+
+    def test_export_utf16le_encoding(self, client, seeded_project):
+        r = client.get(f"/projects/{seeded_project}/export?encoding=utf-16-le")
+        assert r.status_code == 200
+        # UTF-16-LE has no BOM; the first two bytes are the first char of "name"
+        assert r.content[:2] == "n".encode("utf-16-le")
+
+    def test_export_utf16le_no_bom(self, client, seeded_project):
+        """Confirm the BOM bytes FF FE are NOT present at the start of the output."""
+        r = client.get(f"/projects/{seeded_project}/export?encoding=utf-16-le")
+        assert r.status_code == 200
+        assert not r.content.startswith(b"\xff\xfe")
+        assert not r.content.startswith(b"\xfe\xff")
+
+    def test_export_invalid_encoding_returns_422(self, client, seeded_project):
+        r = client.get(f"/projects/{seeded_project}/export?encoding=utf-32")
+        assert r.status_code == 422
+
+    # --- Encoding incompatibility → 400 ---
+
+    def test_export_ascii_on_unicode_data_returns_400(self, client, seeded_unicode_project):
+        r = client.get(f"/projects/{seeded_unicode_project}/export?encoding=ascii")
+        assert r.status_code == 400
+        assert "ascii" in r.json()["detail"].lower()
+
+    def test_export_latin1_on_cjk_data_returns_400(self, client, seeded_unicode_project):
+        r = client.get(f"/projects/{seeded_unicode_project}/export?encoding=latin-1")
+        assert r.status_code == 400
+
+    # --- Content-Disposition header ---
+
+    def test_export_content_disposition_contains_filename(self, client, seeded_project):
+        r = client.get(f"/projects/{seeded_project}/export")
+        cd = r.headers.get("content-disposition", "")
+        assert "attachment" in cd
+        assert ".csv" in cd
+
+    def test_export_filename_with_double_quote_is_sanitized(self, client, sample_csv):
+        """A project name containing " must not break or inject the header."""
+        with open(sample_csv, "rb") as f:
+            resp = client.post(
+                "/projects/upload",
+                files={"file": ("test.csv", f, "text/csv")},
+                data={"projectName": 'Evil"Name', "projectDescription": "Test"},
+            )
+        project_id = resp.json()["project_id"]
+        r = client.get(f"/projects/{project_id}/export")
+        assert r.status_code == 200
+        cd = r.headers.get("content-disposition", "")
+        # The literal quote should have been stripped from the header value
+        assert '"Evil"Name' not in cd
 
 
 # --- Delete Endpoint Tests ---

--- a/dataloom-frontend/src/Components/MenuNavbar.jsx
+++ b/dataloom-frontend/src/Components/MenuNavbar.jsx
@@ -6,12 +6,14 @@ import AdvQueryFilterForm from "./forms/AdvQueryFilterForm";
 import PivotTableForm from "./forms/PivotTableForm";
 import CastDataTypeForm from "./forms/CastDataTypeForm";
 import TrimWhitespaceForm from "./forms/TrimWhitespaceForm";
+import ExportDialog from "./forms/ExportDialog";
 import LogsPanel from "./history/LogsPanel";
 import CheckpointsPanel from "./history/CheckpointsPanel";
 import InputDialog from "./common/InputDialog";
 import ConfirmDialog from "./common/ConfirmDialog";
 import Toast from "./common/Toast";
-import { saveProject, exportProject, getLogs, getCheckpoints, revertToCheckpoint } from "../api";
+import { saveProject, getLogs, getCheckpoints, revertToCheckpoint } from "../api";
+import { useProjectContext } from "../context/ProjectContext";
 import proptype from "prop-types";
 import {
   LuFilter,
@@ -28,6 +30,7 @@ import {
 } from "react-icons/lu";
 
 const Menu_NavBar = ({ projectId, onTransform }) => {
+  const { projectName } = useProjectContext();
   const [showFilterForm, setShowFilterForm] = useState(false);
   const [showSortForm, setShowSortForm] = useState(false);
   const [showDropDuplicateForm, setShowDropDuplicateForm] = useState(false);
@@ -37,6 +40,7 @@ const Menu_NavBar = ({ projectId, onTransform }) => {
   const [showCheckpoints, setShowCheckpoints] = useState(false);
   const [showCastDataTypeForm, setShowCastDataTypeForm] = useState(false);
   const [showTrimWhitespaceForm, setShowTrimWhitespaceForm] = useState(false);
+  const [showExportDialog, setShowExportDialog] = useState(false);
   const [logs, setLogs] = useState([]);
   const [checkpoints, setCheckpoints] = useState(null);
   const [isInputOpen, setIsInputOpen] = useState(false);
@@ -83,21 +87,7 @@ const Menu_NavBar = ({ projectId, onTransform }) => {
     }
   };
 
-  const handleExport = async () => {
-    try {
-      const blob = await exportProject(projectId);
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = "export.csv";
-      document.body.appendChild(a);
-      a.click();
-      a.remove();
-      URL.revokeObjectURL(url);
-    } catch {
-      setToast({ message: "Failed to export project.", type: "error" });
-    }
-  };
+  const handleExport = () => setShowExportDialog(true);
 
   const handleRevert = (checkpointId) => {
     setConfirmData({
@@ -295,6 +285,12 @@ const Menu_NavBar = ({ projectId, onTransform }) => {
           onTransform={onTransform}
         />
       )}
+      <ExportDialog
+        isOpen={showExportDialog}
+        onClose={() => setShowExportDialog(false)}
+        projectId={projectId}
+        projectName={projectName}
+      />
       {showLogs && <LogsPanel logs={logs} onClose={() => setShowLogs(false)} />}
       {showCheckpoints && (
         <CheckpointsPanel

--- a/dataloom-frontend/src/Components/forms/ExportDialog.jsx
+++ b/dataloom-frontend/src/Components/forms/ExportDialog.jsx
@@ -1,0 +1,143 @@
+import { useState } from "react";
+import Modal from "../common/Modal";
+import { exportProject } from "../../api";
+import proptype from "prop-types";
+
+const DELIMITERS = [
+  { value: "comma", label: "Comma (,)" },
+  { value: "tab", label: "Tab (\\t)" },
+  { value: "semicolon", label: "Semicolon (;)" },
+  { value: "pipe", label: "Pipe (|)" },
+];
+
+const ENCODINGS = [
+  { value: "utf-8", label: "UTF-8" },
+  { value: "latin-1", label: "Latin-1" },
+  { value: "ascii", label: "ASCII" },
+  { value: "utf-16", label: "UTF-16" },
+];
+
+/**
+ * Dialog for configuring and triggering a CSV export.
+ * @param {Object} props
+ * @param {boolean} props.isOpen - Whether the dialog is visible.
+ * @param {Function} props.onClose - Callback to close the dialog.
+ * @param {string} props.projectId - The project ID to export.
+ * @param {string} props.projectName - The project name used as the download filename.
+ */
+const ExportDialog = ({ isOpen, onClose, projectId, projectName }) => {
+  const [delimiter, setDelimiter] = useState("comma");
+  const [includeHeader, setIncludeHeader] = useState(true);
+  const [encoding, setEncoding] = useState("utf-8");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const handleExport = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const blob = await exportProject(projectId, {
+        delimiter,
+        include_header: includeHeader,
+        encoding,
+      });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `${projectName || "export"}.csv`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+      onClose();
+    } catch {
+      setError("Failed to export. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Export CSV">
+      <div className="flex flex-col gap-5">
+
+        {/* Delimiter */}
+        <div className="flex flex-col gap-1.5">
+          <label className="text-sm font-medium text-gray-700">Delimiter</label>
+          <select
+            value={delimiter}
+            onChange={(e) => setDelimiter(e.target.value)}
+            className="border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          >
+            {DELIMITERS.map((d) => (
+              <option key={d.value} value={d.value}>
+                {d.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Encoding */}
+        <div className="flex flex-col gap-1.5">
+          <label className="text-sm font-medium text-gray-700">Encoding</label>
+          <select
+            value={encoding}
+            onChange={(e) => setEncoding(e.target.value)}
+            className="border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          >
+            {ENCODINGS.map((e) => (
+              <option key={e.value} value={e.value}>
+                {e.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Include Header */}
+        <div className="flex items-center gap-3">
+          <input
+            id="include-header"
+            type="checkbox"
+            checked={includeHeader}
+            onChange={(e) => setIncludeHeader(e.target.checked)}
+            className="w-4 h-4 accent-blue-600 cursor-pointer"
+          />
+          <label htmlFor="include-header" className="text-sm font-medium text-gray-700 cursor-pointer">
+            Include header row
+          </label>
+        </div>
+
+        {error && (
+          <p className="text-sm text-red-600">{error}</p>
+        )}
+
+        {/* Actions */}
+        <div className="flex justify-end gap-3 pt-1">
+          <button
+            onClick={onClose}
+            className="px-4 py-2 text-sm rounded-md border border-gray-300 text-gray-700 hover:bg-gray-50 transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleExport}
+            disabled={loading}
+            className="px-4 py-2 text-sm rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-60 transition-colors"
+          >
+            {loading ? "Exporting…" : "Export"}
+          </button>
+        </div>
+
+      </div>
+    </Modal>
+  );
+};
+
+ExportDialog.propTypes = {
+  isOpen: proptype.bool.isRequired,
+  onClose: proptype.func.isRequired,
+  projectId: proptype.string.isRequired,
+  projectName: proptype.string,
+};
+
+export default ExportDialog;

--- a/dataloom-frontend/src/Components/forms/ExportDialog.jsx
+++ b/dataloom-frontend/src/Components/forms/ExportDialog.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import Modal from "../common/Modal";
 import { exportProject } from "../../api";
 import proptype from "prop-types";
@@ -14,7 +14,7 @@ const ENCODINGS = [
   { value: "utf-8", label: "UTF-8" },
   { value: "latin-1", label: "Latin-1" },
   { value: "ascii", label: "ASCII" },
-  { value: "utf-16", label: "UTF-16" },
+  { value: "utf-16-le", label: "UTF-16 LE" },
 ];
 
 /**
@@ -31,6 +31,17 @@ const ExportDialog = ({ isOpen, onClose, projectId, projectName }) => {
   const [encoding, setEncoding] = useState("utf-8");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
+
+  // Reset all options to defaults whenever the dialog is opened so stale
+  // settings from a previous session do not cause accidental wrong-format exports.
+  useEffect(() => {
+    if (isOpen) {
+      setDelimiter("comma");
+      setIncludeHeader(true);
+      setEncoding("utf-8");
+      setError(null);
+    }
+  }, [isOpen]);
 
   const handleExport = async () => {
     setLoading(true);
@@ -50,8 +61,14 @@ const ExportDialog = ({ isOpen, onClose, projectId, projectName }) => {
       a.remove();
       URL.revokeObjectURL(url);
       onClose();
-    } catch {
-      setError("Failed to export. Please try again.");
+    } catch (err) {
+      console.error("Export failed:", err);
+      const status = err?.response?.status;
+      const msg =
+        status === 400
+          ? "Export failed: the data contains characters incompatible with the selected encoding."
+          : "Failed to export. Please try again.";
+      setError(msg);
     } finally {
       setLoading(false);
     }
@@ -63,8 +80,9 @@ const ExportDialog = ({ isOpen, onClose, projectId, projectName }) => {
 
         {/* Delimiter */}
         <div className="flex flex-col gap-1.5">
-          <label className="text-sm font-medium text-gray-700">Delimiter</label>
+          <label htmlFor="export-delimiter" className="text-sm font-medium text-gray-700">Delimiter</label>
           <select
+            id="export-delimiter"
             value={delimiter}
             onChange={(e) => setDelimiter(e.target.value)}
             className="border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
@@ -79,8 +97,9 @@ const ExportDialog = ({ isOpen, onClose, projectId, projectName }) => {
 
         {/* Encoding */}
         <div className="flex flex-col gap-1.5">
-          <label className="text-sm font-medium text-gray-700">Encoding</label>
+          <label htmlFor="export-encoding" className="text-sm font-medium text-gray-700">Encoding</label>
           <select
+            id="export-encoding"
             value={encoding}
             onChange={(e) => setEncoding(e.target.value)}
             className="border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"

--- a/dataloom-frontend/src/api/projects.js
+++ b/dataloom-frontend/src/api/projects.js
@@ -68,10 +68,15 @@ export const revertToCheckpoint = async (projectId, checkpointId) => {
 /**
  * Export the current working copy of a project as a CSV download.
  * @param {string} projectId - The project ID.
+ * @param {Object} [options] - Export format options.
+ * @param {string} [options.delimiter="comma"] - Delimiter: comma, tab, semicolon, pipe.
+ * @param {boolean} [options.include_header=true] - Whether to include the header row.
+ * @param {string} [options.encoding="utf-8"] - File encoding: utf-8, latin-1, ascii, utf-16.
  * @returns {Promise<Blob>} The CSV file as a Blob.
  */
-export const exportProject = async (projectId) => {
+export const exportProject = async (projectId, { delimiter = "comma", include_header = true, encoding = "utf-8" } = {}) => {
   const response = await client.get(`/projects/${projectId}/export`, {
+    params: { delimiter, include_header, encoding },
     responseType: "blob",
   });
   return response.data;


### PR DESCRIPTION
## Description

Implements configurable CSV export options, allowing users to choose delimiter, encoding, and header inclusion before downloading their data.

- Added `ExportDelimiter` and `ExportEncoding` Pydantic enums to schemas.py
- Updated `GET /projects/{project_id}/export` to accept `delimiter`, `include_header`, and `encoding` query params, validated via enums, returning a `StreamingResponse` with correct `Content-Disposition` and charset headers
- Invalid delimiter or encoding values are rejected with a `422` error automatically via FastAPI enum validation
- Updated `exportProject()` in projects.js to forward format options as query params (defaults preserved, no breaking change for existing callers)
- Added `ExportDialog` component with delimiter, encoding, and header options
- Wired `ExportDialog` into `MenuNavbar`, the existing Export button now opens the dialog instead of triggering an immediate download

Fixes #92

here are some screenshots : 
<img width="1823" height="622" alt="image" src="https://github.com/user-attachments/assets/54504875-11d3-4860-b163-422a1e458ba2" />
<img width="1207" height="719" alt="image" src="https://github.com/user-attachments/assets/4bad42b8-ee4b-4f3b-becc-eba6d6803f6f" />
<img width="1080" height="569" alt="image" src="https://github.com/user-attachments/assets/fcf4d4b2-ea70-49b7-8484-78c3bb4e0749" />



## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

Describe the tests you ran to verify your changes.

- [X] Existing tests pass
- [ ] New tests added
- [ ] Manual testing

## Screenshots (if applicable)

## Checklist

- [X] My code follows the project's style guidelines
- [X] I have performed a self-review
- [ ] I have added/updated documentation as needed
- [X] My changes generate no new warnings
- [X] Tests pass locally
