### PR TITLE
fix: prevent invalid file upload from triggering API request

### DIFF
--- a/dataloom-frontend/src/Components/Homescreen.jsx
+++ b/dataloom-frontend/src/Components/Homescreen.jsx
@@ -95,6 +95,11 @@ const HomeScreen = () => {
       return;
     }
 
+    if (!fileUpload.name.endsWith(".csv")) {
+      showToast("Only CSV files are allowed.", "warning");
+      return;
+    }
+
     if (!projectName.trim()) {
       showToast("Project Name cannot be empty", "warning");
       return;
@@ -203,6 +208,7 @@ const HomeScreen = () => {
             <h2 className="text-2xl font-semibold text-gray-900 mb-4">Upload Dataset</h2>
             <input
               type="file"
+              accept=".csv"
               className="block w-full text-lg text-gray-900 border border-gray-300 rounded-md px-3 py-2 bg-white cursor-pointer focus:outline-none mb-4"
               onChange={handleFileUpload}
             />


### PR DESCRIPTION
## Description

Prevents non-CSV files from triggering an API request in the Create Project modal.

Fixes #(issue number)
#148 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update



Describe the tests you ran to verify your changes.

- [ ] Existing tests pass
- [ ] New tests added
- [x] Manual testing

## Screenshots 

1. File picker restricted to CSV files
<img width="1063" height="492" alt="image" src="https://github.com/user-attachments/assets/2532a1e2-f457-4d16-9c71-c82d5f7d343e" />

2. Client-side validation blocks request and displays error toast
<img width="1710" height="1107" alt="image" src="https://github.com/user-attachments/assets/f11d2a67-496d-4feb-b3b9-821e2a689041" />



## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [ ] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally
