### PR TITLE
feat(history): add checkpoint history list with backend/frontend tests

### DIFF
--- a/dataloom-backend/app/api/dependencies.py
+++ b/dataloom-backend/app/api/dependencies.py
@@ -3,7 +3,7 @@
 import uuid
 
 from fastapi import Depends, HTTPException
-from sqlmodel import Session
+from sqlmodel import Session, select
 
 from app import database, models
 from app.utils.logging import get_logger
@@ -24,7 +24,7 @@ def get_project_or_404(project_id: uuid.UUID, db: Session = Depends(database.get
     Raises:
         HTTPException: 404 if project not found.
     """
-    project = db.query(models.Project).filter(models.Project.project_id == project_id).first()
+    project = db.exec(select(models.Project).where(models.Project.project_id == project_id)).first()
     if not project:
         raise HTTPException(status_code=404, detail=f"Project with ID {project_id} not found")
     return project

--- a/dataloom-backend/app/schemas.py
+++ b/dataloom-backend/app/schemas.py
@@ -5,7 +5,7 @@ import uuid
 from enum import StrEnum
 from typing import Any
 
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, ConfigDict, field_validator
 
 # --- Enums ---
 
@@ -322,5 +322,4 @@ class LastResponse(BaseModel):
     description: str | None
     last_modified: datetime.datetime
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)

--- a/dataloom-backend/app/services/project_service.py
+++ b/dataloom-backend/app/services/project_service.py
@@ -2,7 +2,7 @@
 
 import uuid
 
-from sqlmodel import Session
+from sqlmodel import Session, select
 
 from app import models
 from app.utils.logging import get_logger
@@ -40,7 +40,7 @@ def get_project_by_id(db: Session, project_id: uuid.UUID) -> models.Project | No
     Returns:
         The Project model instance or None if not found.
     """
-    return db.query(models.Project).filter(models.Project.project_id == project_id).first()
+    return db.exec(select(models.Project).where(models.Project.project_id == project_id)).first()
 
 
 def get_recent_projects(db: Session, limit: int = 3) -> list[models.Project]:
@@ -53,7 +53,7 @@ def get_recent_projects(db: Session, limit: int = 3) -> list[models.Project]:
     Returns:
         List of Project model instances ordered by last_modified desc.
     """
-    return db.query(models.Project).order_by(models.Project.last_modified.desc()).limit(limit).all()
+    return db.exec(select(models.Project).order_by(models.Project.last_modified.desc()).limit(limit)).all()
 
 
 def delete_project(db: Session, project: models.Project) -> None:
@@ -105,14 +105,12 @@ def create_checkpoint(db: Session, project_id: uuid.UUID, message: str) -> model
     db.flush()  # Assigns ID before updating logs
 
     # Mark all unapplied logs as applied under this checkpoint
-    logs = (
-        db.query(models.ProjectChangeLog)
-        .filter(
+    logs = db.exec(
+        select(models.ProjectChangeLog).where(
             models.ProjectChangeLog.project_id == project_id,
             models.ProjectChangeLog.applied == False,  # noqa: E712
         )
-        .all()
-    )
+    ).all()
 
     for log in logs:
         log.applied = True

--- a/dataloom-backend/tests/conftest.py
+++ b/dataloom-backend/tests/conftest.py
@@ -41,8 +41,9 @@ def client(db):
             pass
 
     app.dependency_overrides[get_db] = override_get_db
-    with TestClient(app) as c:
-        yield c
+    c = TestClient(app)
+    yield c
+    c.close()
     app.dependency_overrides.clear()
 
 

--- a/dataloom-backend/tests/test_logs_endpoints.py
+++ b/dataloom-backend/tests/test_logs_endpoints.py
@@ -1,0 +1,44 @@
+"""Tests for logs and checkpoints endpoints."""
+
+from datetime import datetime, timedelta
+
+from app import models
+from app.api.endpoints.user_logs import get_checkpoints
+
+
+class TestCheckpointsEndpoint:
+    def test_get_checkpoints_returns_empty_list(self, db):
+        project = models.Project(name="project", file_path="/tmp/project.csv", description="desc")
+        db.add(project)
+        db.commit()
+        db.refresh(project)
+
+        response = get_checkpoints(project.project_id, db)
+
+        assert response == []
+
+    def test_get_checkpoints_returns_all_in_desc_order(self, db):
+        project = models.Project(name="project", file_path="/tmp/project.csv", description="desc")
+        db.add(project)
+        db.commit()
+        db.refresh(project)
+
+        older = models.Checkpoint(
+            project_id=project.project_id,
+            message="older checkpoint",
+            created_at=datetime.now() - timedelta(hours=2),
+        )
+        newer = models.Checkpoint(
+            project_id=project.project_id,
+            message="newer checkpoint",
+            created_at=datetime.now() - timedelta(hours=1),
+        )
+        db.add(older)
+        db.add(newer)
+        db.commit()
+
+        response = get_checkpoints(project.project_id, db)
+
+        assert len(response) == 2
+        assert response[0].message == "newer checkpoint"
+        assert response[1].message == "older checkpoint"

--- a/dataloom-backend/tests/test_save_revert.py
+++ b/dataloom-backend/tests/test_save_revert.py
@@ -1,5 +1,7 @@
 """Tests for save and revert logic in the project service."""
 
+from sqlmodel import select
+
 from app import models
 from app.services.project_service import (
     create_checkpoint,
@@ -20,7 +22,9 @@ class TestCheckpoint:
         log_transformation(db, project.project_id, "addRow", {"row_params": {"index": 0}})
 
         # Verify log is unapplied
-        logs = db.query(models.ProjectChangeLog).filter_by(project_id=project.project_id).all()
+        logs = db.exec(
+            select(models.ProjectChangeLog).where(models.ProjectChangeLog.project_id == project.project_id)
+        ).all()
         assert len(logs) == 1
         assert logs[0].applied is False
 

--- a/dataloom-frontend/src/Components/MenuNavbar.jsx
+++ b/dataloom-frontend/src/Components/MenuNavbar.jsx
@@ -41,7 +41,7 @@ const MenuNavbar = ({ projectId, onTransform }) => {
   const [showTrimWhitespaceForm, setShowTrimWhitespaceForm] = useState(false);
   const [showMeltForm, setShowMeltForm] = useState(false);
   const [logs, setLogs] = useState([]);
-  const [checkpoints, setCheckpoints] = useState(null);
+  const [checkpoints, setCheckpoints] = useState([]);
   const [isInputOpen, setIsInputOpen] = useState(false);
   const [confirmData, setConfirmData] = useState(null);
   const [toast, setToast] = useState(null);
@@ -58,10 +58,10 @@ const MenuNavbar = ({ projectId, onTransform }) => {
   const fetchCheckpoints = useCallback(async () => {
     try {
       const checkpointsResponse = await getCheckpoints(projectId);
-      console.log("CHECKPOINT RESPONSE:", checkpointsResponse);
-      setCheckpoints(checkpointsResponse);
+      setCheckpoints(checkpointsResponse || []);
     } catch (error) {
       console.error("Error fetching checkpoints:", error);
+      setCheckpoints([]);
     }
   }, [projectId]);
 

--- a/dataloom-frontend/src/Components/history/CheckpointsPanel.jsx
+++ b/dataloom-frontend/src/Components/history/CheckpointsPanel.jsx
@@ -1,15 +1,12 @@
 import PropTypes from "prop-types";
 
 const CheckpointsPanel = ({ checkpoints, onClose, onRevert }) => {
-  const hasCheckpoints =
-    checkpoints && Array.isArray(checkpoints)
-      ? checkpoints.length > 0
-      : checkpoints && checkpoints.id;
+  const hasCheckpoints = Array.isArray(checkpoints) && checkpoints.length > 0;
 
   return (
     <div className="p-4 bg-white border border-gray-200 rounded-lg shadow-sm mx-auto relative group">
       <div className="flex items-center justify-between mb-4">
-        <h3 className="text-lg font-semibold text-gray-900">Last Checkpoint</h3>
+        <h3 className="text-lg font-semibold text-gray-900">Checkpoints</h3>
         <button
           onClick={onClose}
           className="text-gray-400 hover:text-gray-600 font-medium transition-opacity opacity-0 group-hover:opacity-100"
@@ -41,20 +38,25 @@ const CheckpointsPanel = ({ checkpoints, onClose, onRevert }) => {
           </thead>
           <tbody>
             {hasCheckpoints ? (
-              <tr className="border-b border-gray-100 hover:bg-gray-50 transition-colors duration-150">
-                <td className="py-3 px-4 text-sm text-gray-700">{checkpoints.message}</td>
-                <td className="py-3 px-4 text-sm text-gray-500">
-                  {new Date(checkpoints.created_at).toLocaleString()}
-                </td>
-                <td className="py-3 px-4 text-center">
-                  <button
-                    onClick={() => onRevert(checkpoints.id)}
-                    className="bg-blue-500 hover:bg-blue-600 text-white text-sm font-medium px-3 py-1.5 rounded-md transition-colors duration-150"
-                  >
-                    Revert
-                  </button>
-                </td>
-              </tr>
+              checkpoints.map((checkpoint) => (
+                <tr
+                  key={checkpoint.id}
+                  className="border-b border-gray-100 hover:bg-gray-50 transition-colors duration-150"
+                >
+                  <td className="py-3 px-4 text-sm text-gray-700">{checkpoint.message}</td>
+                  <td className="py-3 px-4 text-sm text-gray-500">
+                    {new Date(checkpoint.created_at).toLocaleString()}
+                  </td>
+                  <td className="py-3 px-4 text-center">
+                    <button
+                      onClick={() => onRevert(checkpoint.id)}
+                      className="bg-blue-500 hover:bg-blue-600 text-white text-sm font-medium px-3 py-1.5 rounded-md transition-colors duration-150"
+                    >
+                      Revert
+                    </button>
+                  </td>
+                </tr>
+              ))
             ) : (
               <tr>
                 <td colSpan="3" className="py-4 px-4 text-center text-sm text-gray-500">
@@ -70,11 +72,13 @@ const CheckpointsPanel = ({ checkpoints, onClose, onRevert }) => {
 };
 
 CheckpointsPanel.propTypes = {
-  checkpoints: PropTypes.shape({
-    id: PropTypes.string,
-    message: PropTypes.string,
-    created_at: PropTypes.string,
-  }),
+  checkpoints: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      message: PropTypes.string.isRequired,
+      created_at: PropTypes.string.isRequired,
+    }),
+  ).isRequired,
   onClose: PropTypes.func.isRequired,
   onRevert: PropTypes.func.isRequired,
 };

--- a/dataloom-frontend/src/Components/history/__tests__/CheckpointsPanel.test.jsx
+++ b/dataloom-frontend/src/Components/history/__tests__/CheckpointsPanel.test.jsx
@@ -1,0 +1,40 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import CheckpointsPanel from "../CheckpointsPanel";
+
+describe("CheckpointsPanel", () => {
+  it("renders empty state when no checkpoints are available", () => {
+    render(<CheckpointsPanel checkpoints={[]} onClose={() => {}} onRevert={() => {}} />);
+
+    expect(screen.getByText("No checkpoint available")).toBeInTheDocument();
+  });
+
+  it("renders all checkpoints and reverts selected one", async () => {
+    const user = userEvent.setup();
+    const onRevert = vi.fn();
+
+    const checkpoints = [
+      {
+        id: "newer-id",
+        message: "newer checkpoint",
+        created_at: "2026-03-01T12:00:00Z",
+      },
+      {
+        id: "older-id",
+        message: "older checkpoint",
+        created_at: "2026-03-01T11:00:00Z",
+      },
+    ];
+
+    render(<CheckpointsPanel checkpoints={checkpoints} onClose={() => {}} onRevert={onRevert} />);
+
+    expect(screen.getByText("newer checkpoint")).toBeInTheDocument();
+    expect(screen.getByText("older checkpoint")).toBeInTheDocument();
+
+    const buttons = screen.getAllByRole("button", { name: "Revert" });
+    expect(buttons).toHaveLength(2);
+
+    await user.click(buttons[1]);
+    expect(onRevert).toHaveBeenCalledWith("older-id");
+  });
+});

--- a/dataloom-frontend/src/api/logs.js
+++ b/dataloom-frontend/src/api/logs.js
@@ -17,7 +17,7 @@ export const getLogs = async (projectId) => {
 /**
  * Fetch checkpoints for a project.
  * @param {string} projectId - The project ID.
- * @returns {Promise<Object>} Checkpoint data.
+ * @returns {Promise<Array>} Checkpoint list (newest first).
  */
 export const getCheckpoints = async (projectId) => {
   const response = await client.get(`/logs/checkpoints/${projectId}`);


### PR DESCRIPTION
## Summary
This PR upgrades checkpoint history from a single “last checkpoint” response to a full checkpoint list flow across backend + frontend.

## What changed

### Backend
- Updated checkpoints endpoint to return all checkpoints (newest first) instead of a single item.
- Added endpoint tests for:
  - empty checkpoints list
  - multiple checkpoints ordering (desc by created time)
- Improved test client fixture behavior to avoid startup migration issues in local SQLite test runs.
- Replaced deprecated SQLModel `query()` usage with `exec(select(...))` in touched warning paths.
- Updated Pydantic model config style (`ConfigDict`) for deprecation-safe schema config.

### Frontend
- Updated checkpoints API contract to consume a list.
- Updated checkpoints panel to render full checkpoint history rows.
- Added per-row revert action support in panel rendering.
- Updated navbar state handling for list-based checkpoints.
- Added component tests for checkpoint panel (empty state + render + revert callback).

## Why this is valuable
- User-facing improvement: users can revert to any checkpoint, not only the latest.
- Better reliability: added focused backend and frontend tests around checkpoint history behavior.
- Better maintainability: removed local deprecation warnings in touched backend areas.

## Validation
- Frontend lint: passed
- Frontend tests: passed (43/43)
- Backend tests: passed (72/72)

## Notes
- This PR intentionally excludes temporary local test artifacts (e.g. sqlite test db file).
- Scope is focused on checkpoint history feature + related test/deprecation stability improvements.