### PR TITLE
feat(ui): replace Filter/Sort column text input with dropdown

### DIFF
--- a/dataloom-frontend/src/Components/common/ColumnSelect.jsx
+++ b/dataloom-frontend/src/Components/common/ColumnSelect.jsx
@@ -1,0 +1,53 @@
+import PropTypes from "prop-types";
+
+const ColumnSelect = ({
+  id,
+  label,
+  name = "column",
+  value,
+  onChange,
+  columns,
+  required = false,
+}) => {
+  return (
+    <>
+      <label htmlFor={id} className="block mb-1 text-sm font-medium text-gray-700">
+        {label}
+      </label>
+      <select
+        id={id}
+        name={name}
+        value={value}
+        onChange={onChange}
+        disabled={!columns || columns.length === 0}
+        className="border border-gray-300 rounded-md px-3 py-2 w-full bg-white text-gray-900 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none disabled:bg-gray-100 disabled:text-gray-500"
+        required={required}
+      >
+        {!columns || columns.length === 0 ? (
+          <option value="">No columns available — load a dataset first</option>
+        ) : (
+          <>
+            <option value="">Select column…</option>
+            {columns.map((columnName, index) => (
+              <option key={`${index}-${columnName}`} value={columnName}>
+                {columnName}
+              </option>
+            ))}
+          </>
+        )}
+      </select>
+    </>
+  );
+};
+
+ColumnSelect.propTypes = {
+  id: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+  name: PropTypes.string,
+  value: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+  columns: PropTypes.arrayOf(PropTypes.string).isRequired,
+  required: PropTypes.bool,
+};
+
+export default ColumnSelect;

--- a/dataloom-frontend/src/Components/common/__tests__/ColumnSelect.test.jsx
+++ b/dataloom-frontend/src/Components/common/__tests__/ColumnSelect.test.jsx
@@ -1,0 +1,67 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { vi, beforeEach, expect, describe, test } from "vitest";
+import ColumnSelect from "../ColumnSelect";
+
+describe("ColumnSelect", () => {
+  const defaultProps = {
+    id: "test-select",
+    label: "Test Label",
+    value: "",
+    onChange: vi.fn(),
+    columns: ["col1", "col2", "col3"],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("renders placeholder and disabled select when columns is empty array", () => {
+    render(<ColumnSelect {...defaultProps} columns={[]} />);
+
+    expect(screen.getByText("No columns available — load a dataset first")).toBeInTheDocument();
+    expect(screen.getByRole("combobox")).toBeDisabled();
+  });
+
+  test("renders all column names as options when columns provided", () => {
+    render(<ColumnSelect {...defaultProps} />);
+
+    expect(screen.getByText("Select column…")).toBeInTheDocument();
+    expect(screen.getByText("col1")).toBeInTheDocument();
+    expect(screen.getByText("col2")).toBeInTheDocument();
+    expect(screen.getByText("col3")).toBeInTheDocument();
+  });
+
+  test("select is disabled when columns is null", () => {
+    render(<ColumnSelect {...defaultProps} columns={null} />);
+
+    expect(screen.getByRole("combobox")).toBeDisabled();
+  });
+
+  test("calls onChange when option selected", () => {
+    const mockOnChange = vi.fn();
+    render(<ColumnSelect {...defaultProps} onChange={mockOnChange} />);
+
+    const select = screen.getByRole("combobox");
+    fireEvent.change(select, { target: { value: "col2" } });
+
+    expect(mockOnChange).toHaveBeenCalledTimes(1);
+  });
+
+  test("required prop is forwarded to select element", () => {
+    render(<ColumnSelect {...defaultProps} required={true} />);
+
+    expect(screen.getByRole("combobox")).toBeRequired();
+  });
+
+  test("uses default name when not provided", () => {
+    const { container } = render(<ColumnSelect {...defaultProps} />);
+
+    expect(container.querySelector("select")).toHaveAttribute("name", "column");
+  });
+
+  test("uses custom name when provided", () => {
+    const { container } = render(<ColumnSelect {...defaultProps} name="custom-name" />);
+
+    expect(container.querySelector("select")).toHaveAttribute("name", "custom-name");
+  });
+});

--- a/dataloom-frontend/src/Components/forms/FilterForm.jsx
+++ b/dataloom-frontend/src/Components/forms/FilterForm.jsx
@@ -2,11 +2,15 @@ import { useState } from "react";
 import PropTypes from "prop-types";
 import { transformProject } from "../../api";
 import { FILTER } from "../../constants/operationTypes";
+import { useProjectContext } from "../../context/ProjectContext";
 import TransformResultPreview from "./TransformResultPreview";
 import useError from "../../hooks/useError";
 import FormErrorAlert from "../common/FormErrorAlert";
+import ColumnSelect from "../common/ColumnSelect";
 
 const FilterForm = ({ projectId, onClose }) => {
+  const { columns } = useProjectContext();
+  const safeColumns = columns ?? [];
   const [filterParams, setFilterParams] = useState({
     column: "",
     condition: "=",
@@ -49,19 +53,25 @@ const FilterForm = ({ projectId, onClose }) => {
         <h3 className="font-semibold text-gray-900 mb-2">Filter Dataset</h3>
         <div className="flex flex-wrap mb-4">
           <div className="w-full sm:w-1/3 mb-2">
-            <label className="block mb-1 text-sm font-medium text-gray-700">Column:</label>
-            <input
-              type="text"
+            <ColumnSelect
+              id="filter-column"
+              label="Column:"
               name="column"
               value={filterParams.column}
               onChange={handleInputChange}
-              className="border border-gray-300 rounded-md px-3 py-2 w-full bg-white text-gray-900 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none"
+              columns={safeColumns}
               required
             />
           </div>
           <div className="w-full sm:w-1/3 mb-2 pl-2">
-            <label className="block mb-1 text-sm font-medium text-gray-700">Condition:</label>
+            <label
+              htmlFor="filter-condition"
+              className="block mb-1 text-sm font-medium text-gray-700"
+            >
+              Condition:
+            </label>
             <select
+              id="filter-condition"
               name="condition"
               value={filterParams.condition}
               onChange={handleInputChange}
@@ -78,8 +88,11 @@ const FilterForm = ({ projectId, onClose }) => {
             </select>
           </div>
           <div className="w-full sm:w-1/3 mb-2 pl-2">
-            <label className="block mb-1 text-sm font-medium text-gray-700">Value:</label>
+            <label htmlFor="filter-value" className="block mb-1 text-sm font-medium text-gray-700">
+              Value:
+            </label>
             <input
+              id="filter-value"
               type="text"
               name="value"
               value={filterParams.value}
@@ -93,7 +106,7 @@ const FilterForm = ({ projectId, onClose }) => {
           <button
             type="submit"
             className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-md font-medium transition-colors duration-150"
-            disabled={loading}
+            disabled={loading || safeColumns.length === 0}
           >
             Apply Filter
           </button>

--- a/dataloom-frontend/src/Components/forms/SortForm.jsx
+++ b/dataloom-frontend/src/Components/forms/SortForm.jsx
@@ -2,11 +2,15 @@ import { useState } from "react";
 import PropTypes from "prop-types";
 import { transformProject } from "../../api";
 import { SORT } from "../../constants/operationTypes";
+import { useProjectContext } from "../../context/ProjectContext";
 import TransformResultPreview from "./TransformResultPreview";
 import useError from "../../hooks/useError";
 import FormErrorAlert from "../common/FormErrorAlert";
+import ColumnSelect from "../common/ColumnSelect";
 
 const SortForm = ({ projectId, onClose }) => {
+  const { columns } = useProjectContext();
+  const safeColumns = columns ?? [];
   const [column, setColumn] = useState("");
   const [ascending, setAscending] = useState(true);
   const [result, setResult] = useState(null);
@@ -42,18 +46,22 @@ const SortForm = ({ projectId, onClose }) => {
         <h3 className="font-semibold text-gray-900 mb-2">Sort Dataset</h3>
         <div className="flex flex-wrap mb-4">
           <div className="w-full sm:w-1/2 mb-2">
-            <label className="block mb-1 text-sm font-medium text-gray-700">Column:</label>
-            <input
-              type="text"
+            <ColumnSelect
+              id="sort-column"
+              label="Column:"
+              name="column"
               value={column}
               onChange={(e) => setColumn(e.target.value)}
-              className="border border-gray-300 rounded-md px-3 py-2 w-full bg-white text-gray-900 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none"
+              columns={safeColumns}
               required
             />
           </div>
           <div className="w-full sm:w-1/2 mb-2 pl-2">
-            <label className="block mb-1 text-sm font-medium text-gray-700">Order:</label>
+            <label htmlFor="sort-order" className="block mb-1 text-sm font-medium text-gray-700">
+              Order:
+            </label>
             <select
+              id="sort-order"
               value={ascending}
               onChange={(e) => setAscending(e.target.value === "true")}
               className="border border-gray-300 rounded-md px-3 py-2 w-full bg-white text-gray-900 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none"
@@ -67,9 +75,9 @@ const SortForm = ({ projectId, onClose }) => {
           <button
             type="submit"
             className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-md font-medium transition-colors duration-150"
-            disabled={loading}
+            disabled={loading || safeColumns.length === 0}
           >
-            Submit
+            Apply Sort
           </button>
           <button
             type="button"


### PR DESCRIPTION
## Summary
Replace manual **Column** text inputs with **dropdown selectors** 
populated from the current dataset columns in Filter and Sort forms.

## Why
- Prevents typos in column names
- Faster and more beginner-friendly
- Makes Filter and Sort consistent with each other

## Changes
- `FilterForm.jsx` — Column field replaced with dropdown
- `SortForm.jsx` — Column field replaced with dropdown
- Dropdown options sourced live from project context columns

## Validation
- `npm run lint` ✅
- `npm run test` ✅ (41/41)

## Screenshots

### Filter Form
| Before | After |
|--------|-------|
| ![filter-before](https://github.com/user-attachments/assets/3f5f3a48-4801-4559-817a-370dec04d904) | ![filter-after](https://github.com/user-attachments/assets/10aed605-11f4-4df2-813f-934ab5f8bfb4) |

### Sort Form
| Before | After |
|--------|-------|
| ![sort-before](https://github.com/user-attachments/assets/29479cb4-9d39-476c-a2aa-cd22503a454c) | ![sort-after](https://github.com/user-attachments/assets/f41983e2-f495-4fd2-b2b5-1f5f0ef23c5a) |

## Notes
- No backend changes
- No API contract changes