### PR TITLE
feat(export): add xlsx export support and Excel menu action

### DIFF
--- a/dataloom-backend/app/api/dependencies.py
+++ b/dataloom-backend/app/api/dependencies.py
@@ -3,7 +3,7 @@
 import uuid
 
 from fastapi import Depends, HTTPException
-from sqlmodel import Session
+from sqlmodel import Session, select
 
 from app import database, models
 from app.utils.logging import get_logger
@@ -24,7 +24,8 @@ def get_project_or_404(project_id: uuid.UUID, db: Session = Depends(database.get
     Raises:
         HTTPException: 404 if project not found.
     """
-    project = db.query(models.Project).filter(models.Project.project_id == project_id).first()
+    statement = select(models.Project).where(models.Project.project_id == project_id)
+    project = db.exec(statement).first()
     if not project:
         raise HTTPException(status_code=404, detail=f"Project with ID {project_id} not found")
     return project

--- a/dataloom-backend/app/api/endpoints/projects.py
+++ b/dataloom-backend/app/api/endpoints/projects.py
@@ -3,9 +3,13 @@
 Handles upload, retrieval, save (checkpoint), and revert operations.
 """
 
+import os
 import uuid
+from io import BytesIO
+from typing import Literal
+from urllib.parse import quote
 
-from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Response, UploadFile
 from fastapi.responses import FileResponse
 from sqlmodel import Session
 
@@ -207,10 +211,53 @@ async def revert_to_checkpoint(
 
 
 @router.get("/{project_id}/export")
-async def export_project(project_id: uuid.UUID, db: Session = Depends(database.get_db)):
-    """Download the current working copy of a project as a CSV file."""
+async def export_project(
+    project_id: uuid.UUID,
+    export_format: Literal["csv", "xlsx"] = Query(default="csv", alias="format"),
+    db: Session = Depends(database.get_db),
+):
+    """Download the current working copy of a project as CSV or XLSX."""
     project = get_project_or_404(project_id, db)
-    return FileResponse(project.file_path, media_type="text/csv", filename=f"{project.name}.csv")
+
+    if export_format == "csv":
+        ascii_name = project.name.encode("ascii", errors="replace").decode().replace('"', "'")
+        csv_headers = {
+            "Content-Disposition": (
+                f"attachment; filename=\"{ascii_name}.csv\"; filename*=UTF-8''{quote(project.name)}.csv"
+            )
+        }
+        return FileResponse(
+            project.file_path,
+            media_type="text/csv",
+            headers=csv_headers,
+        )
+
+    MAX_EXPORT_BYTES = 100 * 1024 * 1024  # 100 MB
+    file_size = os.path.getsize(project.file_path)
+    if file_size > MAX_EXPORT_BYTES:
+        raise HTTPException(status_code=413, detail="File too large to export as XLSX")
+
+    ascii_name = project.name.encode("ascii", errors="replace").decode().replace('"', "'")
+    headers = {
+        "Content-Disposition": (
+            f"attachment; filename=\"{ascii_name}.xlsx\"; filename*=UTF-8''{quote(project.name)}.xlsx"
+        )
+    }
+
+    try:
+        df = read_csv_safe(project.file_path)
+        output = BytesIO()
+        df.to_excel(output, index=False, engine="openpyxl")
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Project data file not found on disk") from exc
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail="Failed to generate XLSX export") from exc
+
+    return Response(
+        content=output.getvalue(),
+        media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        headers=headers,
+    )
 
 
 @router.delete("/{project_id}")

--- a/dataloom-backend/app/schemas.py
+++ b/dataloom-backend/app/schemas.py
@@ -5,7 +5,7 @@ import uuid
 from enum import StrEnum
 from typing import Any
 
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, ConfigDict, field_validator
 
 # --- Enums ---
 
@@ -306,6 +306,4 @@ class LastResponse(BaseModel):
     name: str
     description: str | None
     last_modified: datetime.datetime
-
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)

--- a/dataloom-backend/pyproject.toml
+++ b/dataloom-backend/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "psycopg2-binary>=2.9",
     "pydantic-settings>=2.0",
     "pandas>=2.1",
+    "openpyxl>=3.1",
     "python-dotenv>=1.0",
     "python-multipart>=0.0.6",
 ]

--- a/dataloom-backend/tests/test_new_features.py
+++ b/dataloom-backend/tests/test_new_features.py
@@ -1,6 +1,7 @@
 """Tests for new features: rename column, cast data type, export, and delete project."""
 
 import csv
+from io import BytesIO
 
 import pandas as pd
 import pytest
@@ -215,8 +216,9 @@ class TestAddDeleteColumnEndpoint:
 
 
 class TestExportEndpoint:
-    def test_export_project(self, client, sample_csv, db):
-        # Upload a project first
+    @pytest.fixture(scope="class")
+    def uploaded_project(self, client, sample_csv, db):
+        """Upload a project once for all tests in this class."""
         with open(sample_csv, "rb") as f:
             response = client.post(
                 "/projects/upload",
@@ -224,7 +226,11 @@ class TestExportEndpoint:
                 data={"projectName": "Export Test", "projectDescription": "Test export"},
             )
         assert response.status_code == 200
-        project_id = response.json()["project_id"]
+        return response.json()["project_id"]
+
+    def test_export_project(self, client, uploaded_project):
+        # Upload a project first (now using fixture)
+        project_id = uploaded_project
 
         # Export the project
         export_response = client.get(f"/projects/{project_id}/export")
@@ -241,6 +247,30 @@ class TestExportEndpoint:
     def test_export_nonexistent_project(self, client):
         response = client.get("/projects/00000000-0000-0000-0000-000000000000/export")
         assert response.status_code == 404
+
+    def test_export_project_xlsx(self, client, uploaded_project):
+        project_id = uploaded_project
+
+        export_response = client.get(f"/projects/{project_id}/export?format=xlsx")
+        assert export_response.status_code == 200
+        assert (
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+            in export_response.headers["content-type"]
+        )
+
+        exported_df = pd.read_excel(BytesIO(export_response.content))
+        assert list(exported_df.columns) == ["name", "age", "city"]
+        assert len(exported_df) == 4
+        assert exported_df.iloc[0]["name"] == "Alice"
+        assert exported_df.iloc[0]["age"] == 30
+        assert "filename=" in export_response.headers.get("content-disposition", "")
+
+    @pytest.mark.parametrize("bad_format", ["pdf", "json", "xls", ""])
+    def test_export_invalid_format(self, client, uploaded_project, bad_format):
+        project_id = uploaded_project
+
+        response = client.get(f"/projects/{project_id}/export?format={bad_format}")
+        assert response.status_code == 422
 
 
 # --- Delete Endpoint Tests ---

--- a/dataloom-frontend/src/Components/MenuNavbar.jsx
+++ b/dataloom-frontend/src/Components/MenuNavbar.jsx
@@ -83,17 +83,24 @@ const MenuNavbar = ({ projectId, onTransform }) => {
     }
   };
 
-  const handleExport = async () => {
+  const handleExport = async (format = "csv") => {
     try {
-      const blob = await exportProject(projectId);
+      const response = await exportProject(projectId, format);
+      const blob = response.data;
       const url = URL.createObjectURL(blob);
       const a = document.createElement("a");
+      const disposition = response.headers?.["content-disposition"] ?? "";
+      const rfc5987Match = disposition.match(/filename\*=UTF-8''([^;\n]+)/i);
+      const fallbackMatch = disposition.match(/filename[^;=\n]*=(["']?)([^'"\n;]*)\1/);
+      const filename = rfc5987Match
+        ? decodeURIComponent(rfc5987Match[1])
+        : (fallbackMatch?.[2] ?? (format === "xlsx" ? "export.xlsx" : "export.csv"));
       a.href = url;
-      a.download = "export.csv";
+      a.download = filename;
       document.body.appendChild(a);
       a.click();
       a.remove();
-      URL.revokeObjectURL(url);
+      setTimeout(() => URL.revokeObjectURL(url), 100);
     } catch {
       setToast({ message: "Failed to export project.", type: "error" });
     }
@@ -171,7 +178,8 @@ const MenuNavbar = ({ projectId, onTransform }) => {
         group: "Save",
         items: [
           { label: "Save", icon: LuSave, onClick: handleSave },
-          { label: "Export", icon: LuDownload, onClick: handleExport },
+          { label: "Export CSV", icon: LuDownload, onClick: () => handleExport("csv") },
+          { label: "Export Excel", icon: LuDownload, onClick: () => handleExport("xlsx") },
         ],
       },
       {

--- a/dataloom-frontend/src/api/projects.js
+++ b/dataloom-frontend/src/api/projects.js
@@ -4,6 +4,8 @@
  */
 import client from "./client";
 
+const VALID_FORMATS = ["csv", "xlsx"];
+
 /**
  * Upload a new project CSV file.
  * @param {File} file - The CSV file to upload.
@@ -64,15 +66,20 @@ export const revertToCheckpoint = async (projectId, checkpointId) => {
 };
 
 /**
- * Export the current working copy of a project as a CSV download.
+ * Export the current working copy of a project as a CSV or XLSX download.
  * @param {string} projectId - The project ID.
- * @returns {Promise<Blob>} The CSV file as a Blob.
+ * @param {"csv"|"xlsx"} format - Export format.
+ * @returns {Promise<import('axios').AxiosResponse<Blob>>} The full Axios response; access `.data` for Blob.
  */
-export const exportProject = async (projectId) => {
+export const exportProject = async (projectId, format = "csv") => {
+  if (!VALID_FORMATS.includes(format)) {
+    throw new Error(`Unsupported export format: "${format}"`);
+  }
   const response = await client.get(`/projects/${projectId}/export`, {
+    params: { format },
     responseType: "blob",
   });
-  return response.data;
+  return response;
 };
 
 /**


### PR DESCRIPTION
## Summary
Add Excel (.xlsx) export support end-to-end alongside the existing CSV export.

## Why
- CSV is the only export format currently supported
- Many users work primarily in Excel or Google Sheets
- `.xlsx` is a standard format expected in data tooling

## Backend Changes
- Updated `/projects/{project_id}/export` to accept `?format=csv|xlsx` query param
- CSV export unchanged — no breaking changes
- XLSX generated from current project data using `pandas` + `openpyxl`
- Cleaned deprecation warnings in touched backend code (`ConfigDict`, `session.exec(select(...))`)

## Frontend Changes
- Added **Export Excel** button in File tab alongside **Export CSV**
- Reuses same export API with `?format=xlsx`
- File downloads as `{project_name}.xlsx`

## Validation
- `pytest tests/test_new_features.py::TestExportEndpoint -q` ✅
- `npm run lint` ✅
- `npm run test` ✅

## Screenshots

### Export Excel button in toolbar
<img width="1132" height="708" alt="Screenshot 2026-03-02 022659" src="https://github.com/user-attachments/assets/d2b81c79-4d66-4d0a-b210-6e0944418ece" />

### Downloaded .xlsx opens correctly in Excel
<img width="839" height="314" alt="Screenshot 2026-03-02 022725" src="https://github.com/user-attachments/assets/bb6eebce-1172-4906-9442-14dab25d6817" />

## Notes
- `openpyxl` added as dependency for Excel file generation
- No breaking changes to existing CSV export