### PR TITLE
feat: add dropNa transformation operation

### DIFF
--- a/dataloom-backend/app/api/endpoints/transformations.py
+++ b/dataloom-backend/app/api/endpoints/transformations.py
@@ -125,12 +125,12 @@ def _handle_complex_transform(df, transformation_input, project, db, project_id)
             raise HTTPException(status_code=400, detail="Pivot parameters required")
         p = transformation_input.pivot_query
         return ts.pivot_table(df, p.index, p.value, p.column, p.aggfun), False
-    
+
     elif op == "dropNa":
-        if not transformation_input.drop_na_params:
-            raise HTTPException(status_code=400, detail="Drop NA parameters required")
-        p = transformation_input.drop_na_params
-        return ts.drop_na(df, p.columns), True
+        columns = None
+        if transformation_input.drop_na_params:
+            columns = transformation_input.drop_na_params.columns
+        return ts.drop_na(df, columns), True
 
     else:
         raise HTTPException(status_code=400, detail=f"Unsupported operation: {op}")

--- a/dataloom-backend/app/schemas.py
+++ b/dataloom-backend/app/schemas.py
@@ -5,7 +5,7 @@ import uuid
 from enum import StrEnum
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 # --- Enums ---
 
@@ -155,10 +155,19 @@ class TrimWhitespaceParams(BaseModel):
 
     column: str
 
+
 class DropNaParams(BaseModel):
     """Parameters for dropping rows with missing/NaN values."""
 
     columns: list[str] | None = None
+
+    @field_validator("columns")
+    @classmethod
+    def columns_must_not_be_empty(cls, v):
+        if v is not None and len(v) == 0:
+            raise ValueError("columns list must not be empty; omit the field to drop rows with any NaN")
+        return v
+
 
 # --- Complex transformation parameter schemas ---
 

--- a/dataloom-backend/app/services/transformation_service.py
+++ b/dataloom-backend/app/services/transformation_service.py
@@ -391,7 +391,8 @@ def pivot_table(df: pd.DataFrame, index: str, value: str, column: str = None, ag
     result.columns = result.columns.astype(str)
     return result.reset_index()
 
-def drop_na(df: pd.DataFrame, columns: list = None) -> pd.DataFrame:
+
+def drop_na(df: pd.DataFrame, columns: list[str] | None = None) -> pd.DataFrame:
     """Drop rows with missing/NaN values.
 
     Args:
@@ -402,15 +403,17 @@ def drop_na(df: pd.DataFrame, columns: list = None) -> pd.DataFrame:
     Returns:
         DataFrame with NaN rows removed.
     """
-    df = df.copy()
-    if columns:
+    if columns is not None:
+        if len(columns) == 0:
+            raise TransformationError("columns list must not be empty")
         missing = [c for c in columns if c not in df.columns]
         if missing:
-            raise TransformationError(
-                f"Columns {missing} not found in dataset"
-            )
-        return df.dropna(subset=columns)
-    return df.dropna()
+            raise TransformationError(f"Columns not found in dataset: {', '.join(missing)}")
+        df = df.copy()
+        return df.dropna(subset=columns).reset_index(drop=True)
+    df = df.copy()
+    return df.dropna().reset_index(drop=True)
+
 
 def apply_logged_transformation(df: pd.DataFrame, action_type: str, action_details: dict) -> pd.DataFrame:
     """Replay a logged transformation from its serialized form.
@@ -478,7 +481,7 @@ def apply_logged_transformation(df: pd.DataFrame, action_type: str, action_detai
     elif action_type == "trimWhitespace":
         column = action_details["trim_whitespace_params"]["column"]
         return trim_whitespace(df, column)
-    
+
     elif action_type == "dropNa":
         columns = action_details.get("drop_na_params", {}).get("columns")
         return drop_na(df, columns)


### PR DESCRIPTION
## Summary
Adds a new `dropNa` transformation operation to DataLoom, allowing users to drop rows with missing/NaN values from their dataset.

## Changes
- `app/services/transformation_service.py`: Added `drop_na()` function that drops rows with NaN values, optionally scoped to specific columns
- `app/api/endpoints/transformations.py`: Added `dropNa` to `COMPLEX_OPERATIONS` and handler in `_handle_complex_transform`
- `app/schemas.py`: Added `dropNa` to `OperationType` and `ActionTypes` enums, added `DropNaParams` schema, and added `drop_na_params` field to `TransformationInput`
- `app/services/transformation_service.py`: Added `dropNa` case to `apply_logged_transformation` for checkpoint replay support

## Usage
```json
{
  "operation_type": "dropNa",
  "drop_na_params": {
    "columns": ["age", "salary"]
  }
}
```
Omitting `columns` drops rows where ANY column has NaN.

## Related
Addresses the GSoC 2026 DataLoom goal: "Introduce additional data transformation operations"