### PR TITLE
fix: clear unapplied logs when reverting to original state

### DIFF
--- a/dataloom-backend/app/api/endpoints/projects.py
+++ b/dataloom-backend/app/api/endpoints/projects.py
@@ -7,6 +7,7 @@ import uuid
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
 from fastapi.responses import FileResponse
+from sqlalchemy.exc import SQLAlchemyError
 from sqlmodel import Session
 
 from app import database, models, schemas
@@ -193,8 +194,20 @@ async def revert_to_checkpoint(
         for log in logs:
             df = apply_logged_transformation(df, log.action_type, log.action_details)
 
+    # Write file first — if this fails, DB is unchanged and state remains consistent.
     save_csv_safe(df, project.file_path)
-    db.commit()
+    # Clear unapplied logs so a subsequent save cannot re-apply stale
+    # transformations on top of the reverted file state.
+    # Applies to all reverts (full and partial) to prevent stale log replay.
+    db.query(models.ProjectChangeLog).filter(
+        models.ProjectChangeLog.project_id == project_id,
+        models.ProjectChangeLog.applied.is_(False),
+    ).delete(synchronize_session="evaluate")
+    try:
+        db.commit()
+    except SQLAlchemyError:
+        db.rollback()
+        raise
 
     resp = dataframe_to_response(df)
     logger.info("Project reverted: id=%s, checkpoint_id=%s", project_id, checkpoint_id)


### PR DESCRIPTION
## Summary
Fixes #166

When reverting a project to its original state (no checkpoint_id),  the endpoint was correctly restoring the original file but leaving unapplied logs in the database. A subsequent save would then re-apply those stale transformations on top of the reverted state, silently corrupting the data.

## Root Cause
`revert_to_checkpoint` with `checkpoint_id=None` did not clear unapplied logs after restoring the working copy.

## Fix
Added a delete step to remove all unapplied logs for the project before committing the revert, ensuring the log state matches the restored file state.

## Testing
1. Upload a CSV project
2. Apply several transformations without saving
3. Call revert with no checkpoint_id
4. Call save - previously stale transformations are no longer re-applied