### PR TITLE
fix: add missing project 404 check to user_logs endpoints

### DIFF
--- a/dataloom-backend/app/api/endpoints/user_logs.py
+++ b/dataloom-backend/app/api/endpoints/user_logs.py
@@ -4,12 +4,31 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlmodel import Session
 
 from app import database, models, schemas
+from app.api.dependencies import get_project_or_404
 
 router = APIRouter()
 
 
+@router.get("/checkpoints/{project_id}", response_model=schemas.CheckpointResponse)
+def get_last_checkpoint(project_id: uuid.UUID, db: Session = Depends(database.get_db)):
+    get_project_or_404(project_id, db)
+    last_checkpoint = (
+        db.query(models.Checkpoint)
+        .filter(models.Checkpoint.project_id == project_id)
+        .order_by(models.Checkpoint.created_at.desc())
+        .first()
+    )
+    if not last_checkpoint:
+        raise HTTPException(status_code=404, detail=f"No checkpoints found for project ID {project_id}")
+
+    return schemas.CheckpointResponse(
+        id=last_checkpoint.id, message=last_checkpoint.message, created_at=last_checkpoint.created_at
+    )
+
+
 @router.get("/{project_id}", response_model=list[schemas.LogResponse])
 def get_logs(project_id: uuid.UUID, db: Session = Depends(database.get_db)):
+    get_project_or_404(project_id, db)
     logs = (
         db.query(models.ProjectChangeLog)
         .filter(models.ProjectChangeLog.project_id == project_id)
@@ -28,20 +47,3 @@ def get_logs(project_id: uuid.UUID, db: Session = Depends(database.get_db)):
         )
         for log in logs
     ]
-
-
-@router.get("/checkpoints/{project_id}", response_model=schemas.CheckpointResponse)
-def get_last_checkpoint(project_id: uuid.UUID, db: Session = Depends(database.get_db)):
-    last_checkpoint = (
-        db.query(models.Checkpoint)
-        .filter(models.Checkpoint.project_id == project_id)
-        .order_by(models.Checkpoint.created_at.desc())
-        .first()
-    )
-
-    if not last_checkpoint:
-        raise HTTPException(status_code=404, detail=f"No checkpoints found for project ID {project_id}")
-
-    return schemas.CheckpointResponse(
-        id=last_checkpoint.id, message=last_checkpoint.message, created_at=last_checkpoint.created_at
-    )


### PR DESCRIPTION
## Summary
Fixes #168

Both endpoints in `user_logs.py` were missing the `get_project_or_404` guard used consistently across all other endpoints in the codebase.
- `get_logs` returned `[]` with HTTP 200 for non-existent projects
- `get_last_checkpoint` would query checkpoints for a project that doesn't exist

## Fix
Added `get_project_or_404(project_id, db)` at the start of both endpoint functions, consistent with `projects.py` and 
`transformations.py`.

## Related
This inconsistency was found by reviewing the codebase - all other endpoints import and use `get_project_or_404` from `dependencies.py` but `user_logs.py` never imported it.