### PR TITLE
fix: reset modal form fields on close

### DIFF
--- a/dataloom-frontend/src/Components/Homescreen.jsx
+++ b/dataloom-frontend/src/Components/Homescreen.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { uploadProject, getRecentProjects, deleteProject } from "../api";
 import { useToast } from "../context/ToastContext";
@@ -59,6 +59,7 @@ const NewProjectCard = ({ onClick }) => (
 const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024; // 10 MB
 
 const HomeScreen = () => {
+  const fileInputRef = useRef(null);
   const [showModal, setShowModal] = useState(false);
   const [fileUpload, setFileUpload] = useState(null);
   const [projectName, setProjectName] = useState("");
@@ -87,6 +88,12 @@ const HomeScreen = () => {
 
   const handleCloseModal = () => {
     setShowModal(false);
+    setProjectName("");
+    setProjectDescription("");
+    setFileUpload(null);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
   };
 
   const handleSubmitModal = async (event) => {
@@ -124,7 +131,7 @@ const HomeScreen = () => {
       showToast(message, "error");
     }
 
-    setShowModal(false);
+    handleCloseModal();
     fetchRecentProjects();
   };
 
@@ -210,6 +217,7 @@ const HomeScreen = () => {
             <h2 className="text-2xl font-semibold text-gray-900 mb-4">Upload Dataset</h2>
             <input
               type="file"
+              ref={fileInputRef}
               className="block w-full text-lg text-gray-900 border border-gray-300 rounded-md px-3 py-2 bg-white cursor-pointer focus:outline-none mb-4"
               onChange={handleFileUpload}
             />


### PR DESCRIPTION
## Summary
Fixes #170

When the "New Project" modal was closed without submitting, the form fields (Project Name, Project Description, file upload) retained their values. Reopening the modal would show previously entered data instead of a blank form.

## Root Cause
`handleCloseModal` only called `setShowModal(false)` without resetting the three form state values.

## Fix
Added state resets to `handleCloseModal`:
- `setProjectName("")`
- `setProjectDescription("")`  
- `setFileUpload(null)`

This ensures a clean form every time the modal is opened.