### PR TITLE
fix: raise TransformationError instead of silently returning unmodified DataFrame in apply_logged_transformation

### DIFF
--- a/dataloom-backend/app/services/transformation_service.py
+++ b/dataloom-backend/app/services/transformation_service.py
@@ -503,4 +503,4 @@ def apply_logged_transformation(df: pd.DataFrame, action_type: str, action_detai
 
     else:
         logger.warning("Unknown action type in log replay: %s", action_type)
-        return df
+        raise TransformationError(f"Unknown action type in log replay: {action_type}")


### PR DESCRIPTION
## Summary
Fixes #172

## Change
`apply_logged_transformation()` previously logged a warning and silently returned the unmodified DataFrame for unknown action types, causing silent data corruption during checkpoint replay.

Now raises `TransformationError` so callers can detect and report the failure clearly to the user.