### PR TITLE
fix: block duplicate target names in rename column

### DIFF
--- a/dataloom-backend/app/services/transformation_service.py
+++ b/dataloom-backend/app/services/transformation_service.py
@@ -232,13 +232,26 @@ def rename_column(df: pd.DataFrame, col_index: int, new_name: str) -> pd.DataFra
 
     Returns:
         DataFrame with the column renamed.
+
+    Raises:
+        TransformationError: If new_name is empty or whitespace.
+        TransformationError: If col_index is out of range.
+        TransformationError: If new_name already exists in df.columns
+                             (unless new_name equals the current column name).
     """
     if col_index < 0 or col_index >= len(df.columns):
-        raise TransformationError(f"Column index {col_index} out of range (0-{len(df.columns) - 1})")
+        raise TransformationError(
+            f"Column index {col_index} is out of range (DataFrame has {len(df.columns)} columns)."
+        )
     if not new_name or not new_name.strip():
-        raise TransformationError("New column name cannot be empty")
+        raise TransformationError("New column name cannot be empty or whitespace.")
 
     old_name = df.columns[col_index]
+
+    # Check if new_name already exists and is different from current column name
+    if new_name in df.columns and new_name != old_name:
+        raise TransformationError(f"Column '{new_name}' already exists. Please choose a different name.")
+
     return df.rename(columns={old_name: new_name})
 
 

--- a/dataloom-backend/tests/test_transformations.py
+++ b/dataloom-backend/tests/test_transformations.py
@@ -16,6 +16,7 @@ from app.services.transformation_service import (
     drop_duplicates,
     fill_empty,
     pivot_table,
+    rename_column,
 )
 
 
@@ -185,3 +186,26 @@ class TestPivotTable:
         result = pivot_table(df, "city", "sales", aggfunc="sum")
         assert "city" in result.columns
         assert "sales" in result.columns
+
+
+class TestRenameColumn:
+    def test_rename_column_to_existing_name(self, sample_df):
+        with pytest.raises(TransformationError, match="already exists"):
+            rename_column(sample_df, 1, "name")  # Try to rename "age" to "name"
+
+    def test_rename_column_to_same_name(self, sample_df):
+        # Renaming to the same name should succeed (no-op)
+        result = rename_column(sample_df, 0, "name")
+        assert result.shape == sample_df.shape
+        pd.testing.assert_frame_equal(result, sample_df)
+
+    def test_rename_column_case_sensitive(self, sample_df):
+        # Renaming to different case should succeed (case-sensitive)
+        result = rename_column(sample_df, 1, "Age")  # Rename "age" to "Age"
+        assert list(result.columns) == ["name", "Age", "city"]
+        assert result.iloc[0]["Age"] == 30
+
+    def test_rename_column_with_preexisting_duplicate(self):
+        df = pd.DataFrame([[1, 2, 3]], columns=["name", "name", "age"])
+        with pytest.raises(TransformationError, match="already exists"):
+            rename_column(df, 2, "name")


### PR DESCRIPTION
## Problem
Currently a column can be renamed to a name that already exists in the dataframe.  
This creates duplicate column names, which leads to ambiguous behaviour and can break downstream operations.

## Fix
Added a duplicate-name check in `rename_column()` inside `transformation_service.py`.

Before applying the rename, the function now checks whether `new_name` already exists in `df.columns` (unless it’s the same column being renamed). If it does, the operation is rejected with a clear error message.

**Error returned**

```
Column '{new_name}' already exists. Please choose a different name.
```

## Behaviour
- Renaming to an existing column name → blocked with a clear error
- Renaming to the same name (no-op) → allowed
- Case-sensitive rename (e.g. `age` → `Age`) → allowed

## Tests
Added tests to cover the new behaviour:

- `test_rename_column_to_existing_name`
- `test_rename_column_to_same_name`
- `test_rename_column_case_sensitive`

## Validation
- `pytest` → all tests passing  
- `ruff check .`  
- `ruff format --check .`   

## Files Changed
- `dataloom-backend/app/services/transformation_service.py`
- `dataloom-backend/tests/test_new_features.py`

## Screenshots

### Original table
<img width="1907" height="493" alt="Screenshot 2026-03-10 161354" src="https://github.com/user-attachments/assets/b149e3a9-f83f-468e-bb8c-c862da78842b" />

### Table after rename attempt
<img width="1868" height="329" alt="Screenshot 2026-03-10 161404" src="https://github.com/user-attachments/assets/8ed35677-2da7-425f-9ddc-d703e6e4f92c" />

### Error message when duplicate name is used
<img width="1901" height="983" alt="Screenshot 2026-03-10 161247" src="https://github.com/user-attachments/assets/d69d3d41-1e2b-41cc-8a4e-5fcbdfe4a7fe" />

## Notes
- Backend-only change
- No schema or frontend changes
- Reuses the existing `TransformationError` for consistency