### PR TITLE
feat: migrate FilterForm from JSX to TypeScript

### DIFF
--- a/dataloom-frontend/package-lock.json
+++ b/dataloom-frontend/package-lock.json
@@ -19,8 +19,8 @@
         "@testing-library/jest-dom": "^6.4.2",
         "@testing-library/react": "^14.2.1",
         "@testing-library/user-event": "^14.5.2",
-        "@types/react": "^18.2.66",
-        "@types/react-dom": "^18.2.22",
+        "@types/react": "^18.3.28",
+        "@types/react-dom": "^18.3.7",
         "@vitejs/plugin-react": "^4.2.1",
         "autoprefixer": "^10.4.19",
         "eslint": "^8.57.0",
@@ -32,6 +32,7 @@
         "postcss": "^8.4.38",
         "prettier": "^3.2.5",
         "tailwindcss": "^3.4.4",
+        "typescript": "^5.9.3",
         "vite": "^5.2.0",
         "vitest": "^1.6.0"
       }
@@ -108,6 +109,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -457,6 +459,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -480,6 +483,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1633,6 +1637,7 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1855,6 +1860,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2288,6 +2294,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3157,6 +3164,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4582,6 +4590,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -4611,6 +4620,7 @@
       "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.0.1",
         "data-urls": "^5.0.0",
@@ -5476,6 +5486,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5773,6 +5784,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5785,6 +5797,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -6740,6 +6753,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6930,6 +6944,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/ufo": {
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
@@ -7031,6 +7059,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/dataloom-frontend/package.json
+++ b/dataloom-frontend/package.json
@@ -20,23 +20,24 @@
     "react-router-dom": "^6.24.0"
   },
   "devDependencies": {
-    "@types/react": "^18.2.66",
-    "@types/react-dom": "^18.2.22",
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/user-event": "^14.5.2",
+    "@types/react": "^18.3.28",
+    "@types/react-dom": "^18.3.7",
     "@vitejs/plugin-react": "^4.2.1",
     "autoprefixer": "^10.4.19",
     "eslint": "^8.57.0",
+    "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-react": "^7.34.1",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.6",
-    "postcss": "^8.4.38",
-    "tailwindcss": "^3.4.4",
-    "vite": "^5.2.0",
-    "vitest": "^1.6.0",
     "jsdom": "^24.0.0",
-    "eslint-config-prettier": "^9.1.0",
+    "postcss": "^8.4.38",
     "prettier": "^3.2.5",
-    "@testing-library/react": "^14.2.1",
-    "@testing-library/jest-dom": "^6.4.2",
-    "@testing-library/user-event": "^14.5.2"
+    "tailwindcss": "^3.4.4",
+    "typescript": "^5.9.3",
+    "vite": "^5.2.0",
+    "vitest": "^1.6.0"
   }
 }

--- a/dataloom-frontend/src/Components/forms/FilterForm.tsx
+++ b/dataloom-frontend/src/Components/forms/FilterForm.tsx
@@ -1,31 +1,48 @@
-import { useState } from "react";
-import PropTypes from "prop-types";
+import { useState, type ChangeEvent, type FormEvent } from "react";
 import { transformProject } from "../../api";
 import { FILTER } from "../../constants/operationTypes";
 import TransformResultPreview from "./TransformResultPreview";
 import useError from "../../hooks/useError";
 import FormErrorAlert from "../common/FormErrorAlert";
 
-const FilterForm = ({ projectId, onClose }) => {
-  const [filterParams, setFilterParams] = useState({
+interface FilterFormProps {
+  projectId: string;
+  onClose: () => void;
+}
+
+interface FilterParams {
+  column: string;
+  condition: string;
+  value: string;
+}
+
+
+interface TransformResult {
+  columns: string[];
+  rows: (string | null | undefined)[][];
+}
+
+const FilterForm = ({ projectId, onClose }: FilterFormProps) => {
+  const [filterParams, setFilterParams] = useState<FilterParams>({
     column: "",
     condition: "=",
     value: "",
   });
-  const [result, setResult] = useState(null);
-  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<TransformResult | null>(null);
+  const [loading, setLoading] = useState<boolean>(false);
   const { error, clearError, handleError } = useError();
 
-  const handleInputChange = (e) => {
+  const handleInputChange = (
+    e: ChangeEvent<HTMLInputElement | HTMLSelectElement>
+  ) => {
     setFilterParams({
       ...filterParams,
       [e.target.name]: e.target.value,
     });
   };
 
-  const handleSubmit = async (e) => {
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    console.log("Submitting filter with parameters:", filterParams);
     setLoading(true);
     clearError();
     try {
@@ -33,10 +50,8 @@ const FilterForm = ({ projectId, onClose }) => {
         operation_type: FILTER,
         parameters: filterParams,
       });
-      setResult(response);
-      console.log("Filter API response:", response);
+      setResult(response as TransformResult);
     } catch (err) {
-      console.error("Error applying filter:", err.response?.data || err.message);
       handleError(err);
     } finally {
       setLoading(false);
@@ -49,7 +64,9 @@ const FilterForm = ({ projectId, onClose }) => {
         <h3 className="font-semibold text-gray-900 mb-2">Filter Dataset</h3>
         <div className="flex flex-wrap mb-4">
           <div className="w-full sm:w-1/3 mb-2">
-            <label className="block mb-1 text-sm font-medium text-gray-700">Column:</label>
+            <label className="block mb-1 text-sm font-medium text-gray-700">
+              Column:
+            </label>
             <input
               type="text"
               name="column"
@@ -60,7 +77,9 @@ const FilterForm = ({ projectId, onClose }) => {
             />
           </div>
           <div className="w-full sm:w-1/3 mb-2 pl-2">
-            <label className="block mb-1 text-sm font-medium text-gray-700">Condition:</label>
+            <label className="block mb-1 text-sm font-medium text-gray-700">
+              Condition:
+            </label>
             <select
               name="condition"
               value={filterParams.condition}
@@ -78,7 +97,9 @@ const FilterForm = ({ projectId, onClose }) => {
             </select>
           </div>
           <div className="w-full sm:w-1/3 mb-2 pl-2">
-            <label className="block mb-1 text-sm font-medium text-gray-700">Value:</label>
+            <label className="block mb-1 text-sm font-medium text-gray-700">
+              Value:
+            </label>
             <input
               type="text"
               name="value"
@@ -107,14 +128,11 @@ const FilterForm = ({ projectId, onClose }) => {
         </div>
       </form>
       <FormErrorAlert message={error} />
-      {result && <TransformResultPreview columns={result.columns} rows={result.rows} />}
+      {result && (
+        <TransformResultPreview columns={result.columns} rows={result.rows} />
+      )}
     </div>
   );
-};
-
-FilterForm.propTypes = {
-  projectId: PropTypes.string.isRequired,
-  onClose: PropTypes.func.isRequired,
 };
 
 export default FilterForm;


### PR DESCRIPTION
Migrated FilterForm component to TypeScript as part of the planned JS → TS migration from the 2026 project scope.

What changed:
- Renamed FilterForm.jsx → FilterForm.tsx
- Added type interfaces (FilterFormProps, FilterParams, TransformResult)
- Replaced runtime PropTypes with compile-time type checking
- Removed console.log statements
- Added typescript, @types/react, @types/react-dom as dev dependencies

Verified: tsc --noEmit passes, all 48 tests pass, production build succeeds.

Happy to migrate more components if this approach looks good.