### PR TITLE
fix: move onClose to success path and add loading state in TrimWhitespaceForm

### DIFF
--- a/dataloom-frontend/src/Components/forms/TrimWhitespaceForm.jsx
+++ b/dataloom-frontend/src/Components/forms/TrimWhitespaceForm.jsx
@@ -10,9 +10,11 @@ const TrimWhitespaceForm = ({ projectId, onClose, onTransform }) => {
   const { showToast } = useToast();
 
   const [column, setColumn] = useState("");
+  const [loading, setLoading] = useState(false);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
+    setLoading(true);
 
     try {
       const response = await transformProject(projectId, {
@@ -23,13 +25,14 @@ const TrimWhitespaceForm = ({ projectId, onClose, onTransform }) => {
       });
 
       onTransform(response);
+      onClose();
     } catch (error) {
       console.error("Error trimming whitespace:", error);
 
       showToast(error.response?.data?.detail || "Failed to trim whitespace.", "error");
+    } finally {
+      setLoading(false);
     }
-
-    onClose();
   };
 
   return (
@@ -58,9 +61,10 @@ const TrimWhitespaceForm = ({ projectId, onClose, onTransform }) => {
         <div className="flex justify-between">
           <button
             type="submit"
-            className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-md font-medium transition-colors duration-150"
+            disabled={loading}
+            className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-md font-medium transition-colors duration-150 disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            Apply
+            {loading ? "Applying..." : "Apply"}
           </button>
 
           <button


### PR DESCRIPTION
## Problem
`TrimWhitespaceForm` called `onClose()` unconditionally after the try/catch block, so the form dismissed itself even when the API returned an error. The error toast would flash and disappear along with the form, forcing the user to reopen the menu and reselect their column to retry.

Additionally, the submit button had no loading guard, allowing multiple rapid submissions on slow networks.

## Fix
- Moved `onClose()` inside the `try` block (success path only)
- Added `loading` state with `setLoading(true/false)` around the API call
- Disabled the submit button during the request
- Added `disabled:opacity-50 disabled:cursor-not-allowed` styling
- Changed button label to `"Applying..."` while loading

## Screenshots

### Loading state - button disabled during API call
<img width="1883" height="982" alt="Screenshot 2026-03-13 012341" src="https://github.com/user-attachments/assets/496484b8-2dac-4b65-ac54-9d2725d69f33" />