### PR TITLE
fix: return 404 for logs endpoints when project does not exist

### DIFF
--- a/dataloom-backend/app/api/endpoints/user_logs.py
+++ b/dataloom-backend/app/api/endpoints/user_logs.py
@@ -4,12 +4,14 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlmodel import Session
 
 from app import database, models, schemas
+from app.api import dependencies
 
 router = APIRouter()
 
 
 @router.get("/{project_id}", response_model=list[schemas.LogResponse])
 def get_logs(project_id: uuid.UUID, db: Session = Depends(database.get_db)):
+    _project = dependencies.get_project_or_404(project_id, db)
     logs = (
         db.query(models.ProjectChangeLog)
         .filter(models.ProjectChangeLog.project_id == project_id)
@@ -32,6 +34,7 @@ def get_logs(project_id: uuid.UUID, db: Session = Depends(database.get_db)):
 
 @router.get("/checkpoints/{project_id}", response_model=schemas.CheckpointResponse)
 def get_last_checkpoint(project_id: uuid.UUID, db: Session = Depends(database.get_db)):
+    _project = dependencies.get_project_or_404(project_id, db)
     last_checkpoint = (
         db.query(models.Checkpoint)
         .filter(models.Checkpoint.project_id == project_id)

--- a/dataloom-backend/tests/test_user_logs.py
+++ b/dataloom-backend/tests/test_user_logs.py
@@ -1,0 +1,44 @@
+import uuid
+
+
+class TestLogsEndpoint:
+    def test_get_logs_nonexistent_project_returns_404(self, client):
+        nonexistent_id = uuid.uuid4()
+        response = client.get(f"/logs/{nonexistent_id}")
+        assert response.status_code == 404
+        detail = response.json()["detail"]
+        assert isinstance(detail, str)
+        assert "not found" in detail.lower()
+
+    def test_get_checkpoints_nonexistent_project_returns_404(self, client):
+        nonexistent_id = uuid.uuid4()
+        response = client.get(f"/logs/checkpoints/{nonexistent_id}")
+        assert response.status_code == 404
+        detail = response.json()["detail"]
+        assert isinstance(detail, str)
+        assert "not found" in detail.lower()
+
+    def test_get_logs_existing_project_returns_200(self, client):
+        # Create a project first
+        create_response = client.post(
+            "/projects/",
+            json={"name": "logs-test-project"},
+        )
+        assert create_response.status_code == 200
+        project_id = create_response.json()["id"]
+
+        response = client.get(f"/logs/{project_id}")
+        assert response.status_code == 200
+        assert isinstance(response.json(), list)
+
+    def test_get_logs_existing_project_no_logs_returns_empty_list(self, client):
+        create_response = client.post(
+            "/projects/",
+            json={"name": "logs-empty-project"},
+        )
+        assert create_response.status_code == 200
+        project_id = create_response.json()["id"]
+
+        response = client.get(f"/logs/{project_id}")
+        assert response.status_code == 200
+        assert response.json() == []


### PR DESCRIPTION
## Problem

`GET /logs/{project_id}` and `GET /logs/checkpoints/{project_id}` returned `HTTP 200` with an empty list `[]` for any random UUID that doesn't exist in the database.

Every other project endpoint (`get_project_details`, `save_project`, `revert_to_checkpoint`, `export_project`, `delete_project`) already uses `get_project_or_404` from `dependencies.py` to return a proper `404 Not Found`. The logs routes were the only ones skipping this check entirely - silently returning success for invalid project IDs instead of surfacing the error.

This inconsistency can mask frontend routing bugs where a stale or incorrect project ID is used - the UI would receive an empty logs list and show nothing instead of getting a clear error to handle.

## Fix

- Added `from app.api import dependencies` import to `user_logs.py`
- Added `dependencies.get_project_or_404(project_id, db)` as the first call in both `get_logs` and `get_last_checkpoint` handlers
- Added 2 regression tests verifying both endpoints return `404` with the correct error message for a non-existent project UUID

## Screenshots

### After fix — `GET /logs/{project_id}` with non-existent project returns `404`
<img width="1784" height="986" alt="Screenshot 2026-03-13 013746" src="https://github.com/user-attachments/assets/3f68c0a9-ff4b-4360-91be-ebfb01fda612" />