### PR TITLE
Fix: Allow dynamic CORS origins to support frontend port fallback (3200 & 3201)

### DIFF
--- a/dataloom-backend/app/config.py
+++ b/dataloom-backend/app/config.py
@@ -6,6 +6,7 @@ Provides a cached get_settings() function for efficient access throughout the ap
 
 from functools import lru_cache
 
+from pydantic import field_validator
 from pydantic_settings import BaseSettings
 
 
@@ -25,8 +26,23 @@ class Settings(BaseSettings):
     upload_dir: str = "uploads"
     max_upload_size_bytes: int = 10_485_760  # 10 MB
     allowed_extensions: list[str] = [".csv"]
-    cors_origins: list[str] = ["http://localhost:3200"]
+    cors_origins: list[str] = ["http://localhost:3200", "http://localhost:3201"]
     debug: bool = False
+
+    @field_validator("cors_origins", mode="before")
+    @classmethod
+    def assemble_cors_origins(cls, v: object) -> list[str]:
+        if isinstance(v, str):
+            if v.startswith("["):
+                import json
+                try:
+                    return json.loads(v)
+                except ValueError:
+                    pass
+            return [i.strip() for i in v.split(",") if i.strip()]
+        if isinstance(v, list):
+            return v
+        return ["http://localhost:3200", "http://localhost:3201"]
 
     model_config = {
         "env_file": ".env",

--- a/dataloom-backend/app/main.py
+++ b/dataloom-backend/app/main.py
@@ -44,7 +44,7 @@ app.add_middleware(
     CORSMiddleware,
     allow_origins=get_settings().cors_origins,
     allow_credentials=True,
-    allow_methods=["GET", "POST", "PUT", "DELETE"],
+    allow_methods=["*"],
     allow_headers=["*"],
 )
 


### PR DESCRIPTION
## Description
This PR addresses the restrictive CORS configuration that was blocking requests when the frontend application fell back to port `3201`. 

Specifically, this update:
1. Updates the `CORS_ORIGINS` variable in `.env` to a JSON array containing both the primary port 3200 and fallback port 3201, explicitly supporting `localhost` and `127.0.0.1` contexts.
2. Updates `Settings` in `app/config.py` default list mapping to fallback cleanly to `3200` & `3201`.
3. Expands the CORS middleware in `app/main.py` to allow all HTTP methods (`allow_methods=["*"]`) ensuring `OPTIONS` or `PATCH` requests do not inadvertently fail.

Fixes # (insert-issue-number-here)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] Started the FastAPI backend.
- [x] Navigated to `http://localhost:3200` and verified successful data fetches.
- [x] Navigated to `http://localhost:3201` and verified successful data fetches, resolving the CORS restriction.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings


fixes: #195 