### PR TITLE
feat(frontend): add staged jsdoc checkjs type safety (issue #106)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ The frontend development server will start at `http://localhost:3200`.
    - **Frontend:** `cd dataloom-frontend && npm run test`
 3. Lint and format your code:
    - **Backend:** `uv run ruff check .` and `uv run ruff format .`
-   - **Frontend:** `npm run lint` and `npm run format`
+   - **Frontend:** `npm run lint`, `npm run typecheck`, and `npm run format`
 4. Commit your changes with a clear, descriptive commit message.
 5. Push your branch to your fork and open a pull request against the `main` branch.
 
@@ -62,6 +62,7 @@ The frontend development server will start at `http://localhost:3200`.
 ### Frontend
 
 - **ESLint** is used for linting. Run `npm run lint` to check for issues.
+- **TypeScript checkJs + JSDoc** are used as an intermediate type-safety step toward TS migration. Run `npm run typecheck`.
 - **Prettier** is used for formatting. Run `npm run format` to auto-format files.
 - Follow existing patterns in the codebase for component structure and naming.
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ cd dataloom-backend && uv run pytest
 
 # Frontend
 cd dataloom-frontend && npm run test
+
+# Frontend type-checking (staged JS migration)
+cd dataloom-frontend && npm run typecheck
 ```
 
 ## Project Structure

--- a/dataloom-frontend/package-lock.json
+++ b/dataloom-frontend/package-lock.json
@@ -32,6 +32,7 @@
         "postcss": "^8.4.38",
         "prettier": "^3.2.5",
         "tailwindcss": "^3.4.4",
+        "typescript": "^5.6.3",
         "vite": "^5.2.0",
         "vitest": "^1.6.0"
       }
@@ -108,6 +109,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -457,6 +459,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -480,6 +483,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1633,6 +1637,7 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1855,6 +1860,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2288,6 +2294,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3157,6 +3164,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4582,6 +4590,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -4611,6 +4620,7 @@
       "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.0.1",
         "data-urls": "^5.0.0",
@@ -5476,6 +5486,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5773,6 +5784,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5785,6 +5797,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -6740,6 +6753,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6930,6 +6944,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/ufo": {
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
@@ -7031,6 +7059,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/dataloom-frontend/package.json
+++ b/dataloom-frontend/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
+    "typecheck": "tsc -p tsconfig.checkjs.json",
     "format": "prettier --write \"src/**/*.{js,jsx,css,md}\"",
     "preview": "vite preview",
     "test": "vitest run"
@@ -30,6 +31,7 @@
     "eslint-plugin-react-refresh": "^0.4.6",
     "postcss": "^8.4.38",
     "tailwindcss": "^3.4.4",
+    "typescript": "^5.6.3",
     "vite": "^5.2.0",
     "vitest": "^1.6.0",
     "jsdom": "^24.0.0",

--- a/dataloom-frontend/src/Components/common/Toast.jsx
+++ b/dataloom-frontend/src/Components/common/Toast.jsx
@@ -12,7 +12,7 @@ const TYPE_CLASSES = {
  * @param {Object} props
  * @param {string} props.message - Toast message text.
  * @param {'success'|'error'|'info'|'warning'} [props.type='info'] - Toast visual type.
- * @param {Function} props.onDismiss - Callback when toast should be removed.
+ * @param {() => void} props.onDismiss - Callback when toast should be removed.
  * @param {number} [props.duration=3000] - Auto-dismiss duration in ms.
  */
 export default function Toast({ message, type = "info", onDismiss, duration = 3000 }) {

--- a/dataloom-frontend/src/api/client.js
+++ b/dataloom-frontend/src/api/client.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * Configured Axios HTTP client for DataLoom API communication.
  * @module api/client
@@ -15,6 +17,7 @@ const client = axios.create({
 
 client.interceptors.response.use(
   (response) => response,
+  /** @param {import("axios").AxiosError<{ detail?: string }>} error */
   (error) => {
     const { config, response } = error;
     console.error("[API Error]", {

--- a/dataloom-frontend/src/api/logs.js
+++ b/dataloom-frontend/src/api/logs.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * API functions for activity logs and checkpoints.
  * @module api/logs
@@ -7,7 +9,7 @@ import client from "./client";
 /**
  * Fetch transformation logs for a project.
  * @param {string} projectId - The project ID.
- * @returns {Promise<Array>} List of log entries.
+ * @returns {Promise<import("./types").LogResponse[]>} List of log entries.
  */
 export const getLogs = async (projectId) => {
   const response = await client.get(`/logs/${projectId}`);
@@ -17,7 +19,7 @@ export const getLogs = async (projectId) => {
 /**
  * Fetch checkpoints for a project.
  * @param {string} projectId - The project ID.
- * @returns {Promise<Object>} Checkpoint data.
+ * @returns {Promise<import("./types").CheckpointResponse>} Checkpoint data.
  */
 export const getCheckpoints = async (projectId) => {
   const response = await client.get(`/logs/checkpoints/${projectId}`);

--- a/dataloom-frontend/src/api/projects.js
+++ b/dataloom-frontend/src/api/projects.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * API functions for project CRUD operations.
  * @module api/projects
@@ -9,7 +11,7 @@ import client from "./client";
  * @param {File} file - The CSV file to upload.
  * @param {string} projectName - Name for the new project.
  * @param {string} projectDescription - Description for the new project.
- * @returns {Promise<Object>} The created project response.
+ * @returns {Promise<import("./types").ProjectResponse>} The created project response.
  */
 export const uploadProject = async (file, projectName, projectDescription) => {
   const formData = new FormData();
@@ -23,7 +25,7 @@ export const uploadProject = async (file, projectName, projectDescription) => {
 /**
  * Fetch full project details including rows and columns.
  * @param {string} projectId - The project ID.
- * @returns {Promise<Object>} Project details with columns and rows.
+ * @returns {Promise<import("./types").ProjectResponse>} Project details with columns and rows.
  */
 export const getProjectDetails = async (projectId) => {
   const response = await client.get(`/projects/get/${projectId}`);
@@ -32,7 +34,7 @@ export const getProjectDetails = async (projectId) => {
 
 /**
  * Fetch the most recently modified projects.
- * @returns {Promise<Array>} List of recent project summaries.
+ * @returns {Promise<import("./types").RecentProjectResponse[]>} List of recent project summaries.
  */
 export const getRecentProjects = async () => {
   const response = await client.get("/projects/recent");
@@ -43,7 +45,7 @@ export const getRecentProjects = async () => {
  * Save the current project state as a checkpoint.
  * @param {string} projectId - The project ID.
  * @param {string} commitMessage - Description of changes.
- * @returns {Promise<Object>} Updated project response.
+ * @returns {Promise<import("./types").ProjectResponse>} Updated project response.
  */
 export const saveProject = async (projectId, commitMessage) => {
   const response = await client.post(
@@ -56,7 +58,7 @@ export const saveProject = async (projectId, commitMessage) => {
  * Revert project to a previous checkpoint.
  * @param {string} projectId - The project ID.
  * @param {string} checkpointId - The checkpoint ID to revert to.
- * @returns {Promise<Object>} Reverted project response.
+ * @returns {Promise<import("./types").ProjectResponse>} Reverted project response.
  */
 export const revertToCheckpoint = async (projectId, checkpointId) => {
   const response = await client.post(`/projects/${projectId}/revert?checkpoint_id=${checkpointId}`);
@@ -78,7 +80,7 @@ export const exportProject = async (projectId) => {
 /**
  * Delete a project and its associated files.
  * @param {string} projectId - The project ID.
- * @returns {Promise<Object>} Success confirmation.
+ * @returns {Promise<{ success: boolean, message: string }>} Success confirmation.
  */
 export const deleteProject = async (projectId) => {
   const response = await client.delete(`/projects/${projectId}`);

--- a/dataloom-frontend/src/api/transforms.js
+++ b/dataloom-frontend/src/api/transforms.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * API functions for project transformation operations.
  * @module api/transforms
@@ -7,8 +9,8 @@ import client from "./client";
 /**
  * Apply a transformation (filter, sort, add/delete row/column, pivot, etc).
  * @param {string} projectId - The project ID.
- * @param {Object} transformationInput - The transformation parameters including operation_type.
- * @returns {Promise<Object>} Transformation result with updated rows and columns.
+ * @param {import("./types").TransformationInput} transformationInput - The transformation parameters including operation_type.
+ * @returns {Promise<import("./types").BasicQueryResponse>} Transformation result with updated rows and columns.
  */
 export const transformProject = async (projectId, transformationInput) => {
   const response = await client.post(`/projects/${projectId}/transform`, transformationInput);

--- a/dataloom-frontend/src/api/types.js
+++ b/dataloom-frontend/src/api/types.js
@@ -1,0 +1,56 @@
+/**
+ * Shared JSDoc typedefs for frontend API responses/requests.
+ * @module api/types
+ */
+
+/**
+ * @typedef {Object} ProjectResponse
+ * @property {string} filename
+ * @property {string} file_path
+ * @property {string} project_id
+ * @property {string[]} columns
+ * @property {number} row_count
+ * @property {unknown[][]} rows
+ * @property {Record<string, string>} dtypes
+ */
+
+/**
+ * @typedef {Object} BasicQueryResponse
+ * @property {string} project_id
+ * @property {string} operation_type
+ * @property {number} row_count
+ * @property {string[]} columns
+ * @property {unknown[][]} rows
+ * @property {Record<string, string>} dtypes
+ */
+
+/**
+ * @typedef {Object} RecentProjectResponse
+ * @property {string} project_id
+ * @property {string} name
+ * @property {string | null} description
+ * @property {string} last_modified
+ */
+
+/**
+ * @typedef {Object} CheckpointResponse
+ * @property {string} id
+ * @property {string} message
+ * @property {string} created_at
+ */
+
+/**
+ * @typedef {Object} LogResponse
+ * @property {number} id
+ * @property {string} action_type
+ * @property {Record<string, unknown>} action_details
+ * @property {string} timestamp
+ * @property {string | null} checkpoint_id
+ * @property {boolean} applied
+ */
+
+/**
+ * @typedef {{ operation_type: string } & Record<string, unknown>} TransformationInput
+ */
+
+export {};

--- a/dataloom-frontend/src/hooks/useProject.js
+++ b/dataloom-frontend/src/hooks/useProject.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * Hook to fetch and manage project data by ID.
  * @module hooks/useProject
@@ -7,8 +9,8 @@ import { getProjectDetails } from "../api";
 
 /**
  * Fetch project data by ID.
- * @param {number|string} projectId - The project ID.
- * @returns {{ columns: string[], rows: Array[], loading: boolean, error: string|null, refresh: Function }}
+ * @param {string|null|undefined} projectId - The project ID.
+ * @returns {{ columns: string[], rows: unknown[][], loading: boolean, error: string|null, refresh: () => Promise<void> }}
  */
 export function useProject(projectId) {
   const [columns, setColumns] = useState([]);

--- a/dataloom-frontend/src/hooks/useTransform.js
+++ b/dataloom-frontend/src/hooks/useTransform.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * Hook providing project transformation operations with toast feedback.
  * @module hooks/useTransform
@@ -8,9 +10,9 @@ import { useToast } from "../context/ToastContext";
 
 /**
  * Provides transformation operations for a project.
- * @param {number} projectId - The project ID.
- * @param {Function} onDataUpdate - Callback with (columns, rows) after a successful transform.
- * @returns {{ applyTransform: Function, loading: boolean, error: string|null }}
+ * @param {string|null|undefined} projectId - The project ID.
+ * @param {((columns: string[], rows: unknown[][]) => void) | undefined} onDataUpdate - Callback with (columns, rows) after a successful transform.
+ * @returns {{ applyTransform: (transformInput: import("../api/types").TransformationInput) => Promise<import("../api/types").BasicQueryResponse | undefined>, loading: boolean, error: string|null }}
  */
 export function useTransform(projectId, onDataUpdate) {
   const [loading, setLoading] = useState(false);

--- a/dataloom-frontend/src/vite-env.d.ts
+++ b/dataloom-frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/dataloom-frontend/tsconfig.checkjs.json
+++ b/dataloom-frontend/tsconfig.checkjs.json
@@ -1,0 +1,20 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "strict": false,
+    "noEmit": true
+  },
+  "include": [
+    "src/api/**/*.js",
+    "src/hooks/useProject.js",
+    "src/hooks/useTransform.js",
+    "src/vite-env.d.ts"
+  ],
+  "exclude": [
+    "src/**/__tests__/**",
+    "src/**/*.test.js",
+    "src/**/*.test.jsx"
+  ]
+}


### PR DESCRIPTION
## Description

Implements a staged frontend type-safety step toward JS→TS migration by adopting JSDoc + TypeScript `checkJs` without converting the codebase to `.ts/.tsx` yet.

Changes included:
- Added frontend typecheck command (`npm run typecheck`)
- Added staged config (`tsconfig.checkjs.json`) with `checkJs: true` and `strict: false`
- Added shared JSDoc API typedefs and enabled `// @ts-check` in core API/hook files
- Updated documentation to include the new typecheck workflow
- Applied minimal typing fixes needed for `checkJs` to pass

Fixes #106

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## How Has This Been Tested?

Describe the tests you ran to verify your changes.

- [x] Existing tests pass
- [ ] New tests added
- [ ] Manual testing

Executed locally:
- `npm run typecheck`
- `npm run lint`
- `npm run test`

## Screenshots (if applicable)

N/A (tooling/configuration/documentation-focused changes)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally