### PR TITLE
fix(docker): add Dockerfile and .dockerignore for frontend and backend

### DIFF
--- a/dataloom-backend/.dockerignore
+++ b/dataloom-backend/.dockerignore
@@ -1,0 +1,4 @@
+__pycache__
+*.pyc
+.venv
+.pytest_cache

--- a/dataloom-frontend/.dockerignore
+++ b/dataloom-frontend/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/dataloom-frontend/Dockerfile
+++ b/dataloom-frontend/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:20-slim
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
+EXPOSE 3200
+
+CMD ["npm", "run", "preview", "--", "--host", "0.0.0.0"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ services:
       - "4200:4200"
     environment:
       DATABASE_URL: postgresql://postgres:postgres@db:5432/dataloom
+    volumes:
+      - uploads:/app/uploads
     depends_on:
       - db
 
@@ -31,3 +33,4 @@ services:
 
 volumes:
   pgdata:
+  uploads:


### PR DESCRIPTION
Fixes #61

## Description

- Add missing frontend Dockerfile (`node:20-slim`, `vite preview`) and `.dockerignore` files so `docker compose up` builds and runs the full stack successfully. 
- Also adds a named volume for /app/uploads so uploaded files persist across container restarts.

### Note:
This PR depends on fixing the fresh-database migration issue (#141) first.
There is already a PR created for the above issue: #142.

## Type of Change

- [X] Bug fix
- [X] New feature
- [X] Breaking change
- [X] Documentation update

## How Has This Been Tested?

Tested both scenarios:

1. With migration fix applied:
`docker compose down -v`
`docker compose up --build`
> All three services (db, backend, frontend) start successfully.

2. Without migration fix (current main):
`docker compose up --build`
> Frontend and db start correctly. Backend fails on migration (see #141).

- [X] Existing tests pass
- [ ] New tests added
- [X] Manual testing

## Checklist

- [X] My code follows the project's style guidelines
- [X] I have performed a self-review
- [X] I have added/updated documentation as needed
- [X] My changes generate no new warnings
- [X] Tests pass locally