### PR TITLE
fix(backend): preserve response semantics and harden addCol validation

### DIFF
--- a/dataloom-backend/app/api/endpoints/transformations.py
+++ b/dataloom-backend/app/api/endpoints/transformations.py
@@ -168,7 +168,7 @@ async def transform_project(
 
     if should_save:
         save_csv_safe(result_df, project.file_path)
-        log_transformation(db, project_id, transformation_input.operation_type, transformation_input.dict())
+        log_transformation(db, project_id, transformation_input.operation_type, transformation_input.model_dump())
 
     resp = dataframe_to_response(result_df)
     return {

--- a/dataloom-backend/app/schemas.py
+++ b/dataloom-backend/app/schemas.py
@@ -5,7 +5,7 @@ import uuid
 from enum import StrEnum
 from typing import Any
 
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, ConfigDict, field_validator
 
 # --- Enums ---
 
@@ -115,7 +115,14 @@ class AddColumn(BaseModel):
     """
 
     index: int
-    name: str | None = None
+    name: str
+
+    @field_validator("name")
+    @classmethod
+    def name_must_not_be_blank(cls, v):
+        if not v or not v.strip():
+            raise ValueError("name must not be empty or whitespace")
+        return v
 
 
 class DeleteColumn(BaseModel):
@@ -322,5 +329,4 @@ class LastResponse(BaseModel):
     description: str | None
     last_modified: datetime.datetime
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)

--- a/dataloom-backend/app/utils/pandas_helpers.py
+++ b/dataloom-backend/app/utils/pandas_helpers.py
@@ -1,5 +1,6 @@
 """Pandas utility functions for safe CSV operations and response building."""
 
+import math
 from pathlib import Path
 from typing import Any
 
@@ -60,6 +61,36 @@ def _map_dtype(dtype) -> str:
         return "unknown"
 
 
+def _normalize_response_value(value: Any) -> Any:
+    """Normalize a DataFrame cell for JSON response serialization.
+
+    Preserves real empty strings while converting missing or non-finite
+    values to ``None`` so the API can distinguish ``null`` from ``""``.
+    """
+    if value is None:
+        return None
+
+    try:
+        missing = pd.isna(value)
+        # pd.isna can return array-like values for non-scalar inputs
+        # (for example, lists). Only treat scalar truthy results as missing.
+        if isinstance(missing, bool):
+            if missing:
+                return None
+        elif getattr(missing, "ndim", None) == 0 and bool(missing):
+            return None
+    except (TypeError, ValueError):
+        pass
+
+    try:
+        if math.isinf(value):
+            return None
+    except (TypeError, ValueError):
+        pass
+
+    return value
+
+
 def dataframe_to_response(df: pd.DataFrame) -> dict[str, Any]:
     """Convert a DataFrame to an API response dict.
 
@@ -70,10 +101,8 @@ def dataframe_to_response(df: pd.DataFrame) -> dict[str, Any]:
         Dict with columns (list of str), rows (list of lists), row_count, and dtypes.
     """
     dtypes = {col: _map_dtype(dtype) for col, dtype in df.dtypes.items()}
-    df = df.fillna("")
-    df = df.replace([float("inf"), float("-inf")], "")
     columns = df.columns.tolist()
-    rows = df.values.tolist()
+    rows = [[_normalize_response_value(value) for value in row] for row in df.astype(object).values.tolist()]
     return {"columns": columns, "rows": rows, "row_count": len(rows), "dtypes": dtypes}
 
 

--- a/dataloom-backend/tests/test_dtypes.py
+++ b/dataloom-backend/tests/test_dtypes.py
@@ -65,3 +65,34 @@ class TestDataframeToResponse:
         assert response["columns"] == ["name", "age", "city"]
         assert response["row_count"] == 3
         assert len(response["rows"]) == 3
+
+    def test_preserves_nulls_without_coercing_them_to_empty_strings(self):
+        df = pd.DataFrame(
+            {
+                "maybe_missing": [None, ""],
+                "score": [float("inf"), 5.5],
+                "when": pd.to_datetime(["2024-01-01", None]),
+            }
+        )
+
+        response = dataframe_to_response(df)
+
+        assert response["rows"][0][0] is None
+        assert response["rows"][1][0] == ""
+        assert response["rows"][0][1] is None
+        assert response["rows"][1][1] == 5.5
+        assert response["rows"][0][2] == pd.Timestamp("2024-01-01")
+        assert response["rows"][1][2] is None
+
+    def test_preserves_non_scalar_cells_without_isna_truthiness_errors(self):
+        df = pd.DataFrame(
+            {
+                "payload": [[1, 2], [None], {"ok": True}],
+            }
+        )
+
+        response = dataframe_to_response(df)
+
+        assert response["rows"][0][0] == [1, 2]
+        assert response["rows"][1][0] == [None]
+        assert response["rows"][2][0] == {"ok": True}

--- a/dataloom-backend/tests/test_response_serialization.py
+++ b/dataloom-backend/tests/test_response_serialization.py
@@ -1,0 +1,27 @@
+"""Regression tests for API response serialization semantics."""
+
+import csv
+
+
+def test_upload_response_preserves_missing_values_as_null(client, tmp_path, db):
+    csv_path = tmp_path / "missing_values.csv"
+    with open(csv_path, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["name", "age", "city"])
+        writer.writerow(["Alice", "", "New York"])
+        writer.writerow(["Bob", "25", "Los Angeles"])
+
+    with open(csv_path, "rb") as f:
+        response = client.post(
+            "/projects/upload",
+            files={"file": ("missing_values.csv", f, "text/csv")},
+            data={
+                "projectName": "Missing Values Project",
+                "projectDescription": "Regression fixture for response null semantics",
+            },
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["rows"][0][1] is None
+    assert payload["rows"][1][1] == 25.0


### PR DESCRIPTION
## Summary

This PR fixes two backend contract problems discovered while auditing the current transform and serialization flows:

1. shared API response serialization was collapsing missing values into empty strings, which destroyed the distinction between `null` and `""` across upload, project fetch, and transform responses
2. `addCol` requests without a `name` were slipping past schema validation and failing later as response-validation errors instead of being rejected at the request boundary

## What changed

### Response serialization
- updated `dataframe_to_response()` to preserve real empty strings while normalizing missing and non-finite values to `null`
- added a focused regression test in `tests/test_dtypes.py`
- added an upload-endpoint regression test in `tests/test_response_serialization.py`

### addCol validation hardening
- made `AddColumn.name` required in `schemas.py`
- reject blank or whitespace-only names at schema validation time
- switched the transform logging path from deprecated `dict()` to `model_dump()` while touching that code

## Why this matters

Preserving null semantics improves correctness for downstream profiling, quality checks, formulas, and export/report work. Tightening `addCol` validation fixes a pre-existing backend failure and keeps the full test suite green.

Closes #220

## Validation

### Backend
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest -q`

### Frontend
- `npm run lint`
- `npm run test`

All of the above pass locally.
