### PR TITLE
fix: handle None drop_na_params during replay to prevent AttributeError

### DIFF
--- a/dataloom-backend/app/services/transformation_service.py
+++ b/dataloom-backend/app/services/transformation_service.py
@@ -557,7 +557,7 @@ def apply_logged_transformation(df: pd.DataFrame, action_type: str, action_detai
         return trim_whitespace(df, column)
 
     elif action_type == "dropNa":
-        columns = action_details.get("drop_na_params", {}).get("columns")
+        columns = (action_details.get("drop_na_params") or {}).get("columns")
         return drop_na(df, columns)
 
     elif action_type == "melt":


### PR DESCRIPTION
## Fixes 
#199

## Type of Change
- [x] Bug fix

## Problem
Projects containing a `dropNa` transformation without parameters cannot be saved or reverted. When `drop_na_params` is serialized as `None` by Pydantic, the replay handler calls `.get("columns")` on `None`, causing an `AttributeError`.

## Root Cause
The line:
```python
columns = action_details.get("drop_na_params", {}).get("columns")
```
The default `{}` only applies when the key is **missing**. When the key exists with value `None`, `.get()` returns `None`, and calling `.get("columns")` on `None` crashes.

## Fix
```python
columns = (action_details.get("drop_na_params") or {}).get("columns")
```
Using `or {}` converts `None` to an empty dict, so `.get("columns")` always works.

## Testing
- [x] Manual testing
- [x] Existing tests pass

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] My changes generate no new warnings

