### PR TITLE
fix(frontend): prevent invalid file uploads from triggering API calls

### DIFF
--- a/dataloom-frontend/src/Components/Homescreen.jsx
+++ b/dataloom-frontend/src/Components/Homescreen.jsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { uploadProject, getRecentProjects, deleteProject } from "../api";
 import { useToast } from "../context/ToastContext";
 import ConfirmDialog from "./common/ConfirmDialog";
+import { validateFile, ACCEPT_STRING } from "../utils/fileValidation";
 
 const ProjectCard = ({ project, onClick, onDelete }) => {
   const modified = new Date(project.last_modified).toLocaleDateString(undefined, {
@@ -103,7 +104,12 @@ const HomeScreen = () => {
       showToast("Please select a file to upload", "warning");
       return;
     }
-
+    const validation = validateFile(fileUpload);
+    if (!validation.valid) {
+      showToast(validation.error, "error");
+      setFileUpload(null);
+      return;
+    }
     if (!projectName.trim()) {
       showToast("Project Name cannot be empty", "warning");
       return;
@@ -137,13 +143,28 @@ const HomeScreen = () => {
 
   const handleFileUpload = (event) => {
     const file = event.target.files[0];
-    if (file && file.size > MAX_FILE_SIZE_BYTES) {
+
+    if (!file) {
+      setFileUpload(null);
+      return;
+    }
+
+    const validation = validateFile(file);
+    if (!validation.valid) {
+      showToast(validation.error, "error");
+      event.target.value = "";
+      setFileUpload(null);
+      return;
+    }
+
+    if (file.size > MAX_FILE_SIZE_BYTES) {
       const sizeMB = (file.size / (1024 * 1024)).toFixed(1);
       showToast(`File too large (${sizeMB} MB). Maximum allowed size is 10 MB.`, "warning");
       event.target.value = "";
       setFileUpload(null);
       return;
     }
+
     setFileUpload(file);
   };
 
@@ -217,6 +238,7 @@ const HomeScreen = () => {
             <h2 className="text-2xl font-semibold text-gray-900 mb-4">Upload Dataset</h2>
             <input
               type="file"
+              accept={ACCEPT_STRING}
               ref={fileInputRef}
               className="block w-full text-lg text-gray-900 border border-gray-300 rounded-md px-3 py-2 bg-white cursor-pointer focus:outline-none mb-4"
               onChange={handleFileUpload}

--- a/dataloom-frontend/src/utils/fileValidation.js
+++ b/dataloom-frontend/src/utils/fileValidation.js
@@ -1,0 +1,34 @@
+const ALLOWED_EXTENSIONS = [".csv", ".xlsx", ".json", ".parquet", ".tsv"];
+
+export function validateFile(file) {
+  if (!file) {
+    return { valid: false, error: "No file selected." };
+  }
+
+  if (file.size === 0) {
+    return { valid: false, error: "File is empty (0 bytes)." };
+  }
+
+  const name = file.name || "";
+  const dotIndex = name.lastIndexOf(".");
+
+  if (dotIndex <= 0 || dotIndex === name.length - 1) {
+    return {
+      valid: false,
+      error: `File has no valid extension. Supported: ${ALLOWED_EXTENSIONS.join(", ")}`,
+    };
+  }
+
+  const ext = name.slice(dotIndex).toLowerCase();
+
+  if (!ALLOWED_EXTENSIONS.includes(ext)) {
+    return {
+      valid: false,
+      error: `File type "${ext}" is not supported. Supported: ${ALLOWED_EXTENSIONS.join(", ")}`,
+    };
+  }
+
+  return { valid: true };
+}
+
+export const ACCEPT_STRING = ALLOWED_EXTENSIONS.join(",");


### PR DESCRIPTION
### Fix: Prevent unnecessary API calls for invalid file uploads

Previously, selecting an unsupported or invalid file still triggered an API request to `/projects/upload`, which resulted in a backend 400 error. This caused unnecessary network calls and a poor user experience.

### Changes

* Added client-side file validation (extension + empty file check)
* Prevents API calls for invalid files
* Displays errors using toast notifications instead of relying on backend responses
* Added `accept` attribute to file input for better UX
* Added defensive validation before form submission

### Supported formats

.csv, .xlsx, .json, .parquet, .tsv

### Impact

* Improves UX by validating inputs early
* Reduces unnecessary backend load
* Keeps implementation minimal and consistent with existing codebase
* Aligns frontend behavior with supported dataset formats
