### PR TITLE
Dropdown column selectors for all transform forms

### DIFF
--- a/dataloom-backend/app/services/project_service.py
+++ b/dataloom-backend/app/services/project_service.py
@@ -6,6 +6,7 @@ from sqlmodel import Session
 
 from app import models
 from app.utils.logging import get_logger
+from datetime import datetime, timezone
 
 logger = get_logger(__name__)
 
@@ -85,6 +86,10 @@ def log_transformation(db: Session, project_id: uuid.UUID, operation_type: str, 
         action_details=details,
     )
     db.add(log)
+    project = db.query(models.Project).filter(models.Project.project_id == project_id).first()
+    if project:
+        project.last_modified = datetime.now(timezone.utc)
+        db.add(project)
     db.commit()
     logger.debug("Logged transformation: project_id=%s, type=%s", project_id, operation_type)
 

--- a/dataloom-backend/app/services/project_service.py
+++ b/dataloom-backend/app/services/project_service.py
@@ -6,7 +6,6 @@ from sqlmodel import Session
 
 from app import models
 from app.utils.logging import get_logger
-from datetime import datetime, timezone
 
 logger = get_logger(__name__)
 
@@ -86,10 +85,6 @@ def log_transformation(db: Session, project_id: uuid.UUID, operation_type: str, 
         action_details=details,
     )
     db.add(log)
-    project = db.query(models.Project).filter(models.Project.project_id == project_id).first()
-    if project:
-        project.last_modified = datetime.now(timezone.utc)
-        db.add(project)
     db.commit()
     logger.debug("Logged transformation: project_id=%s, type=%s", project_id, operation_type)
 

--- a/dataloom-frontend/src/Components/common/ColumnSelect.jsx
+++ b/dataloom-frontend/src/Components/common/ColumnSelect.jsx
@@ -1,11 +1,17 @@
-import PropTypes from 'prop-types';
-import { useProjectContext } from '../../context/ProjectContext';
+import PropTypes from "prop-types";
+import { useProjectContext } from "../../context/ProjectContext";
 
 /**
  * A <select> dropdown populated with the current project's column names.
  * Reads columns from ProjectContext — no extra API call needed.
  */
-const ColumnSelect = ({ name, value, onChange, required = true, placeholder = 'Select column...' }) => {
+const ColumnSelect = ({
+  name,
+  value,
+  onChange,
+  required = true,
+  placeholder = "Select column...",
+}) => {
   const { columns } = useProjectContext();
 
   return (
@@ -16,9 +22,13 @@ const ColumnSelect = ({ name, value, onChange, required = true, placeholder = 'S
       required={required}
       className="border border-gray-300 rounded-md px-3 py-2 w-full bg-white text-gray-900 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none"
     >
-      <option value="" disabled>{placeholder}</option>
+      <option value="" disabled>
+        {placeholder}
+      </option>
       {columns.map((col) => (
-        <option key={col} value={col}>{col}</option>
+        <option key={col} value={col}>
+          {col}
+        </option>
       ))}
     </select>
   );

--- a/dataloom-frontend/src/Components/common/ColumnSelect.jsx
+++ b/dataloom-frontend/src/Components/common/ColumnSelect.jsx
@@ -14,9 +14,7 @@ const ColumnSelect = ({ name, value, onChange, required = true, placeholder = 'S
       value={value}
       onChange={onChange}
       required={required}
-      className="border border-gray-300 rounded-md px-3 py-2 w-full bg-white
-                 text-gray-900 focus:ring-2 focus:ring-blue-500 focus:border-blue-500
-                 focus:outline-none"
+      className="border border-gray-300 rounded-md px-3 py-2 w-full bg-white text-gray-900 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none"
     >
       <option value="" disabled>{placeholder}</option>
       {columns.map((col) => (

--- a/dataloom-frontend/src/Components/common/ColumnSelect.jsx
+++ b/dataloom-frontend/src/Components/common/ColumnSelect.jsx
@@ -1,0 +1,37 @@
+import PropTypes from 'prop-types';
+import { useProjectContext } from '../../context/ProjectContext';
+
+/**
+ * A <select> dropdown populated with the current project's column names.
+ * Reads columns from ProjectContext — no extra API call needed.
+ */
+const ColumnSelect = ({ name, value, onChange, required = true, placeholder = 'Select column...' }) => {
+  const { columns } = useProjectContext();
+
+  return (
+    <select
+      name={name}
+      value={value}
+      onChange={onChange}
+      required={required}
+      className="border border-gray-300 rounded-md px-3 py-2 w-full bg-white
+                 text-gray-900 focus:ring-2 focus:ring-blue-500 focus:border-blue-500
+                 focus:outline-none"
+    >
+      <option value="" disabled>{placeholder}</option>
+      {columns.map((col) => (
+        <option key={col} value={col}>{col}</option>
+      ))}
+    </select>
+  );
+};
+
+ColumnSelect.propTypes = {
+  name: PropTypes.string,
+  value: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+  required: PropTypes.bool,
+  placeholder: PropTypes.string,
+};
+
+export default ColumnSelect;

--- a/dataloom-frontend/src/Components/forms/CastDataTypeForm.jsx
+++ b/dataloom-frontend/src/Components/forms/CastDataTypeForm.jsx
@@ -2,13 +2,12 @@ import { useState } from "react";
 import PropTypes from "prop-types";
 import { transformProject } from "../../api";
 import { CAST_DATA_TYPE } from "../../constants/operationTypes";
-import { useProjectContext } from "../../context/ProjectContext";
 import { useToast } from "../../context/ToastContext";
 import useError from "../../hooks/useError";
 import FormErrorAlert from "../common/FormErrorAlert";
+import ColumnSelect from "../common/ColumnSelect";
 
 const CastDataTypeForm = ({ projectId, onClose, onTransform }) => {
-  const { columns } = useProjectContext();
   const { showToast } = useToast();
 
   const [column, setColumn] = useState("");
@@ -45,19 +44,11 @@ const CastDataTypeForm = ({ projectId, onClose, onTransform }) => {
         <div className="flex space-x-2 mb-4">
           <div className="flex-1">
             <label className="block text-sm font-medium text-gray-700">Column:</label>
-            <select
+            <ColumnSelect
               value={column}
               onChange={(e) => setColumn(e.target.value)}
-              className="border border-gray-300 rounded-md w-full px-3 py-2 bg-white text-gray-900 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none"
-              required
-            >
-              <option value="">Select column...</option>
-              {columns.map((col) => (
-                <option key={col} value={col}>
-                  {col}
-                </option>
-              ))}
-            </select>
+              placeholder="Select column..."
+            />
           </div>
 
           <div className="flex-1">

--- a/dataloom-frontend/src/Components/forms/FilterForm.jsx
+++ b/dataloom-frontend/src/Components/forms/FilterForm.jsx
@@ -5,6 +5,7 @@ import { FILTER } from "../../constants/operationTypes";
 import TransformResultPreview from "./TransformResultPreview";
 import useError from "../../hooks/useError";
 import FormErrorAlert from "../common/FormErrorAlert";
+import ColumnSelect from "../common/ColumnSelect";
 
 const FilterForm = ({ projectId, onClose }) => {
   const [filterParams, setFilterParams] = useState({
@@ -50,13 +51,11 @@ const FilterForm = ({ projectId, onClose }) => {
         <div className="flex flex-wrap mb-4">
           <div className="w-full sm:w-1/3 mb-2">
             <label className="block mb-1 text-sm font-medium text-gray-700">Column:</label>
-            <input
-              type="text"
+            <ColumnSelect
               name="column"
               value={filterParams.column}
               onChange={handleInputChange}
-              className="border border-gray-300 rounded-md px-3 py-2 w-full bg-white text-gray-900 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none"
-              required
+              placeholder="Select column to filter..."
             />
           </div>
           <div className="w-full sm:w-1/3 mb-2 pl-2">

--- a/dataloom-frontend/src/Components/forms/PivotTableForm.jsx
+++ b/dataloom-frontend/src/Components/forms/PivotTableForm.jsx
@@ -5,6 +5,7 @@ import { transformProject } from "../../api";
 import { PIVOT_TABLES } from "../../constants/operationTypes";
 import useError from "../../hooks/useError";
 import FormErrorAlert from "../common/FormErrorAlert";
+import ColumnSelect from "../common/ColumnSelect";
 
 const PivotTableForm = ({ projectId, onClose }) => {
   const [index, setIndex] = useState("");
@@ -52,24 +53,20 @@ const PivotTableForm = ({ projectId, onClose }) => {
           </div>
           <div className="flex-1">
             <label className="block text-sm font-medium text-gray-700">Column:</label>
-            <input
-              type="text"
+            <ColumnSelect
               value={column}
               onChange={(e) => setColumn(e.target.value)}
-              className="border border-gray-300 rounded-md w-full px-3 py-2 bg-white text-gray-900 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none"
-              required
+              placeholder="Select column..."
             />
           </div>
         </div>
         <div className="flex space-x-2 mb-4">
           <div className="flex-1">
             <label className="block text-sm font-medium text-gray-700">Value:</label>
-            <input
-              type="text"
+            <ColumnSelect
               value={value}
               onChange={(e) => setValue(e.target.value)}
-              className="border border-gray-300 rounded-md w-full px-3 py-2 bg-white text-gray-900 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none"
-              required
+              placeholder="Select column..."
             />
           </div>
           <div className="flex-1">

--- a/dataloom-frontend/src/Components/forms/SortForm.jsx
+++ b/dataloom-frontend/src/Components/forms/SortForm.jsx
@@ -5,6 +5,7 @@ import { SORT } from "../../constants/operationTypes";
 import TransformResultPreview from "./TransformResultPreview";
 import useError from "../../hooks/useError";
 import FormErrorAlert from "../common/FormErrorAlert";
+import ColumnSelect from "../common/ColumnSelect";
 
 const SortForm = ({ projectId, onClose }) => {
   const [column, setColumn] = useState("");
@@ -43,12 +44,10 @@ const SortForm = ({ projectId, onClose }) => {
         <div className="flex flex-wrap mb-4">
           <div className="w-full sm:w-1/2 mb-2">
             <label className="block mb-1 text-sm font-medium text-gray-700">Column:</label>
-            <input
-              type="text"
+            <ColumnSelect
               value={column}
               onChange={(e) => setColumn(e.target.value)}
-              className="border border-gray-300 rounded-md px-3 py-2 w-full bg-white text-gray-900 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none"
-              required
+              placeholder="Select column to sort by..."
             />
           </div>
           <div className="w-full sm:w-1/2 mb-2 pl-2">


### PR DESCRIPTION
## Description

Replaces free-text column name inputs with `<select>` dropdowns in all 6 transform forms. Column names are sourced from `ProjectContext` (already available globally) so no extra API calls are needed.

Issue Link: Fixes #242

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

Describe the tests you ran to verify your changes.

- [x] Existing tests pass
- [ ] New tests added
- [x] Manual testing

## Screenshots (if applicable)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [ ] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally
