### PR TITLE
COM: last_modified not updating after transforms

### DIFF
--- a/dataloom-backend/app/services/project_service.py
+++ b/dataloom-backend/app/services/project_service.py
@@ -1,12 +1,12 @@
 """Database operations for projects, logs, and checkpoints."""
 
 import uuid
+from datetime import UTC, datetime
 
 from sqlmodel import Session
 
 from app import models
 from app.utils.logging import get_logger
-from datetime import datetime, timezone
 
 logger = get_logger(__name__)
 
@@ -88,7 +88,7 @@ def log_transformation(db: Session, project_id: uuid.UUID, operation_type: str, 
     db.add(log)
     project = db.query(models.Project).filter(models.Project.project_id == project_id).first()
     if project:
-        project.last_modified = datetime.now(timezone.utc)
+        project.last_modified = datetime.now(UTC)
         db.add(project)
     db.commit()
     logger.debug("Logged transformation: project_id=%s, type=%s", project_id, operation_type)

--- a/dataloom-backend/app/services/project_service.py
+++ b/dataloom-backend/app/services/project_service.py
@@ -6,6 +6,7 @@ from sqlmodel import Session
 
 from app import models
 from app.utils.logging import get_logger
+from datetime import datetime, timezone
 
 logger = get_logger(__name__)
 
@@ -85,6 +86,10 @@ def log_transformation(db: Session, project_id: uuid.UUID, operation_type: str, 
         action_details=details,
     )
     db.add(log)
+    project = db.query(models.Project).filter(models.Project.project_id == project_id).first()
+    if project:
+        project.last_modified = datetime.now(timezone.utc)
+        db.add(project)
     db.commit()
     logger.debug("Logged transformation: project_id=%s, type=%s", project_id, operation_type)
 

--- a/dataloom-backend/tests/test_last_modified.py
+++ b/dataloom-backend/tests/test_last_modified.py
@@ -6,7 +6,7 @@ from conftest.py (via the `db` fixture) and call project_service functions direc
 """
 
 import time
-from datetime import datetime, timezone
+from datetime import datetime
 
 import pytest
 from sqlmodel import Session, SQLModel, create_engine
@@ -20,7 +20,7 @@ from app.services.project_service import (
 
 # ── Lightweight in-memory engine (no Alembic) ────────────────────────────────
 
-TEST_DB_URL = "sqlite://"   # pure in-memory, no file
+TEST_DB_URL = "sqlite://"  # pure in-memory, no file
 
 
 @pytest.fixture
@@ -44,6 +44,7 @@ def _make_project(db, name="Test"):
 
 # ── Tests ─────────────────────────────────────────────────────────────────────
 
+
 class TestLastModifiedUpdatesOnTransform:
     """last_modified must advance each time log_transformation() is called."""
 
@@ -63,9 +64,7 @@ class TestLastModifiedUpdatesOnTransform:
         mem_db.refresh(project)
         ts_after = project.last_modified
 
-        assert ts_after > ts_before, (
-            f"last_modified was not updated: before={ts_before}, after={ts_after}"
-        )
+        assert ts_after > ts_before, f"last_modified was not updated: before={ts_before}, after={ts_after}"
 
     def test_last_modified_advances_after_multiple_transforms(self, mem_db):
         project = _make_project(mem_db, "LM Multi")
@@ -82,9 +81,7 @@ class TestLastModifiedUpdatesOnTransform:
             mem_db.refresh(project)
             timestamps.append(project.last_modified)
 
-        assert timestamps[0] < timestamps[1] < timestamps[2], (
-            f"Timestamps did not strictly increase: {timestamps}"
-        )
+        assert timestamps[0] < timestamps[1] < timestamps[2], f"Timestamps did not strictly increase: {timestamps}"
 
     def test_last_modified_is_set_to_utc_datetime(self, mem_db):
         project = _make_project(mem_db, "LM UTC")
@@ -120,9 +117,7 @@ class TestLastModifiedUpdatesOnTransform:
         idx_a = ids.index(str(project_a.project_id))
         idx_b = ids.index(str(project_b.project_id))
 
-        assert idx_a < idx_b, (
-            f"Project A (last transformed) should appear before B. Order: {ids}"
-        )
+        assert idx_a < idx_b, f"Project A (last transformed) should appear before B. Order: {ids}"
 
     def test_log_transformation_creates_change_log_entry(self, mem_db):
         """log_transformation must still write the ProjectChangeLog row."""
@@ -132,9 +127,7 @@ class TestLastModifiedUpdatesOnTransform:
         log_transformation(mem_db, project.project_id, "addRow", details)
 
         logs = (
-            mem_db.query(models.ProjectChangeLog)
-            .filter(models.ProjectChangeLog.project_id == project.project_id)
-            .all()
+            mem_db.query(models.ProjectChangeLog).filter(models.ProjectChangeLog.project_id == project.project_id).all()
         )
         assert len(logs) == 1
         assert logs[0].action_type == "addRow"
@@ -142,6 +135,7 @@ class TestLastModifiedUpdatesOnTransform:
     def test_log_transformation_with_unknown_project_id_does_not_raise(self, mem_db):
         """If the project_id is not in the DB, the timestamp update is skipped gracefully."""
         import uuid
+
         fake_id = uuid.uuid4()
         # Should not raise — the `if project:` guard handles the None case
         log_transformation(mem_db, fake_id, "addRow", {"row_params": {"index": 0}})

--- a/dataloom-backend/tests/test_last_modified.py
+++ b/dataloom-backend/tests/test_last_modified.py
@@ -1,0 +1,147 @@
+"""Tests for the last_modified timestamp fix in project_service.log_transformation().
+
+Tests are written at the service layer to avoid the Alembic/SQLite FK-constraint
+incompatibility in the SQLite CI environment. They use the in-memory SQLite engine
+from conftest.py (via the `db` fixture) and call project_service functions directly.
+"""
+
+import time
+from datetime import datetime, timezone
+
+import pytest
+from sqlmodel import Session, SQLModel, create_engine
+
+from app import models
+from app.services.project_service import (
+    create_project,
+    get_recent_projects,
+    log_transformation,
+)
+
+# ── Lightweight in-memory engine (no Alembic) ────────────────────────────────
+
+TEST_DB_URL = "sqlite://"   # pure in-memory, no file
+
+
+@pytest.fixture
+def mem_engine():
+    engine = create_engine(TEST_DB_URL, connect_args={"check_same_thread": False})
+    SQLModel.metadata.create_all(engine)
+    yield engine
+    SQLModel.metadata.drop_all(engine)
+
+
+@pytest.fixture
+def mem_db(mem_engine):
+    with Session(mem_engine) as session:
+        yield session
+
+
+def _make_project(db, name="Test"):
+    """Create a minimal Project row with a fake file_path."""
+    return create_project(db, name=name, file_path=f"/tmp/{name}.csv", description="test")
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+class TestLastModifiedUpdatesOnTransform:
+    """last_modified must advance each time log_transformation() is called."""
+
+    def test_last_modified_advances_after_one_transform(self, mem_db):
+        project = _make_project(mem_db, "LM Basic")
+        ts_before = project.last_modified
+
+        time.sleep(0.05)
+
+        log_transformation(
+            mem_db,
+            project.project_id,
+            "addRow",
+            {"operation_type": "addRow", "row_params": {"index": 0}},
+        )
+
+        mem_db.refresh(project)
+        ts_after = project.last_modified
+
+        assert ts_after > ts_before, (
+            f"last_modified was not updated: before={ts_before}, after={ts_after}"
+        )
+
+    def test_last_modified_advances_after_multiple_transforms(self, mem_db):
+        project = _make_project(mem_db, "LM Multi")
+        timestamps = []
+
+        for i in range(3):
+            time.sleep(0.05)
+            log_transformation(
+                mem_db,
+                project.project_id,
+                "addRow",
+                {"operation_type": "addRow", "row_params": {"index": i}},
+            )
+            mem_db.refresh(project)
+            timestamps.append(project.last_modified)
+
+        assert timestamps[0] < timestamps[1] < timestamps[2], (
+            f"Timestamps did not strictly increase: {timestamps}"
+        )
+
+    def test_last_modified_is_set_to_utc_datetime(self, mem_db):
+        project = _make_project(mem_db, "LM UTC")
+        time.sleep(0.02)
+        log_transformation(
+            mem_db,
+            project.project_id,
+            "addRow",
+            {"operation_type": "addRow", "row_params": {"index": 0}},
+        )
+        mem_db.refresh(project)
+        # Should be a datetime, not None
+        assert isinstance(project.last_modified, datetime)
+
+    def test_most_recently_transformed_project_appears_first_in_recent(self, mem_db):
+        """Project A, created first but transformed last, should lead /recent."""
+        project_a = _make_project(mem_db, "LM Order A")
+        time.sleep(0.05)
+        project_b = _make_project(mem_db, "LM Order B")
+
+        # Transform A after B was created — A should bubble to top
+        time.sleep(0.05)
+        log_transformation(
+            mem_db,
+            project_a.project_id,
+            "addRow",
+            {"operation_type": "addRow", "row_params": {"index": 0}},
+        )
+
+        recent = get_recent_projects(mem_db, limit=10)
+        ids = [str(p.project_id) for p in recent]
+
+        idx_a = ids.index(str(project_a.project_id))
+        idx_b = ids.index(str(project_b.project_id))
+
+        assert idx_a < idx_b, (
+            f"Project A (last transformed) should appear before B. Order: {ids}"
+        )
+
+    def test_log_transformation_creates_change_log_entry(self, mem_db):
+        """log_transformation must still write the ProjectChangeLog row."""
+        project = _make_project(mem_db, "LM Log")
+        details = {"operation_type": "addRow", "row_params": {"index": 0}}
+
+        log_transformation(mem_db, project.project_id, "addRow", details)
+
+        logs = (
+            mem_db.query(models.ProjectChangeLog)
+            .filter(models.ProjectChangeLog.project_id == project.project_id)
+            .all()
+        )
+        assert len(logs) == 1
+        assert logs[0].action_type == "addRow"
+
+    def test_log_transformation_with_unknown_project_id_does_not_raise(self, mem_db):
+        """If the project_id is not in the DB, the timestamp update is skipped gracefully."""
+        import uuid
+        fake_id = uuid.uuid4()
+        # Should not raise — the `if project:` guard handles the None case
+        log_transformation(mem_db, fake_id, "addRow", {"row_params": {"index": 0}})


### PR DESCRIPTION
## Description

The Project model has a last_modified column used to order the homescreen 'Recently Modified' list. Before this fix, last_modified was only stamped at project creation - it was never updated when a transformation was applied. This meant the homescreen always ordered projects by upload time, not by actual activity. Projects you were actively working on would sink below projects that were uploaded more recently but untouched.

## Root Cause
The root cause was in project_service.log_transformation(): it wrote a ProjectChangeLog row and committed, but never touched the parent Project row. The fix adds four lines that fetch the parent Project and stamp last_modified = datetime.now(timezone.utc) in the same commit.

Fixes #244

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?
A new test file has been added: tests/test_last_modified.py - 6 tests at the service layer 
- test_last_modified_advances_after_one_transform - timestamp strictly later after one logged transform
- test_last_modified_advances_after_multiple_transforms - timestamps increase strictly across 3 sequential transforms
- test_last_modified_is_set_to_utc_datetime - value is a Python datetime, not None
- test_most_recently_transformed_project_appears_first_in_recent - project A, transformed after project B was created, leads /recent
- test_log_transformation_creates_change_log_entry - the ProjectChangeLog row is still written correctly
- test_log_transformation_with_unknown_project_id_does_not_raise - the if project: guard is safe for non-existent IDs

Describe the tests you ran to verify your changes.

- [x] Existing tests pass
- [x] New tests added
- [x] Manual testing

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [ ] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally
