### PR TITLE
COM: Column profiling stats in upload

### DIFF
--- a/dataloom-backend/app/api/endpoints/projects.py
+++ b/dataloom-backend/app/api/endpoints/projects.py
@@ -12,6 +12,7 @@ from sqlmodel import Session
 from app import database, models, schemas
 from app.api.dependencies import get_project_or_404
 from app.services.file_service import delete_project_files, get_original_path, store_upload
+from app.services.profiling_service import profile_dataframe
 from app.services.project_service import (
     create_checkpoint,
     create_project,
@@ -53,6 +54,7 @@ async def upload_project(
         "filename": project.name,
         "file_path": project.file_path,
         "project_id": project.project_id,
+        "profile": profile_dataframe(df),
         **resp,
     }
 
@@ -68,6 +70,7 @@ async def get_project_details(project_id: uuid.UUID, db: Session = Depends(datab
         "filename": project.name,
         "file_path": project.file_path,
         "project_id": project.project_id,
+        "profile": profile_dataframe(df),
         **resp,
     }
 

--- a/dataloom-backend/app/schemas.py
+++ b/dataloom-backend/app/schemas.py
@@ -264,19 +264,20 @@ class BasicQueryResponse(BaseModel):
     rows: list[list]
     dtypes: dict[str, str] = {}
 
+
 class ColumnProfile(BaseModel):
     """Per-column statistics returned as part of the upload/profile response.
- 
+
     All columns include: column name, dtype label, total row count, null
     count, null percentage, and unique value count.
- 
+
     Numeric columns additionally include: min, max, mean, std, and the
     25th / 50th / 75th percentiles (p25, p50, p75).
- 
+
     Non-numeric columns additionally include: top_values, a dict mapping
     the five most frequent values to their occurrence counts.
     """
- 
+
     column: str
     dtype: str
     count: int
@@ -293,6 +294,7 @@ class ColumnProfile(BaseModel):
     p75: float | None = None
     # Categorical extras (None for numeric columns)
     top_values: dict[str, int] | None = None
+
 
 class ProjectResponse(BaseModel):
     """Response for project CRUD operations."""

--- a/dataloom-backend/app/schemas.py
+++ b/dataloom-backend/app/schemas.py
@@ -264,6 +264,35 @@ class BasicQueryResponse(BaseModel):
     rows: list[list]
     dtypes: dict[str, str] = {}
 
+class ColumnProfile(BaseModel):
+    """Per-column statistics returned as part of the upload/profile response.
+ 
+    All columns include: column name, dtype label, total row count, null
+    count, null percentage, and unique value count.
+ 
+    Numeric columns additionally include: min, max, mean, std, and the
+    25th / 50th / 75th percentiles (p25, p50, p75).
+ 
+    Non-numeric columns additionally include: top_values, a dict mapping
+    the five most frequent values to their occurrence counts.
+    """
+ 
+    column: str
+    dtype: str
+    count: int
+    null_count: int
+    null_pct: float
+    unique_count: int
+    # Numeric extras (None for non-numeric columns)
+    min: float | None = None
+    max: float | None = None
+    mean: float | None = None
+    std: float | None = None
+    p25: float | None = None
+    p50: float | None = None
+    p75: float | None = None
+    # Categorical extras (None for numeric columns)
+    top_values: dict[str, int] | None = None
 
 class ProjectResponse(BaseModel):
     """Response for project CRUD operations."""
@@ -275,6 +304,7 @@ class ProjectResponse(BaseModel):
     row_count: int
     rows: list[list]
     dtypes: dict[str, str] = {}
+    profile: list[ColumnProfile] = []
 
 
 # --- Other response schemas ---

--- a/dataloom-backend/app/services/profiling_service.py
+++ b/dataloom-backend/app/services/profiling_service.py
@@ -74,13 +74,7 @@ def profile_dataframe(df: pd.DataFrame) -> list[dict]:
                 }
             )
         else:
-            top = (
-                series.dropna()
-                .astype(str)
-                .value_counts()
-                .head(5)
-                .to_dict()
-            )
+            top = series.dropna().astype(str).value_counts().head(5).to_dict()
             profile["top_values"] = {str(k): int(v) for k, v in top.items()}
 
         profiles.append(profile)

--- a/dataloom-backend/app/services/profiling_service.py
+++ b/dataloom-backend/app/services/profiling_service.py
@@ -1,0 +1,89 @@
+"""Column-level profiling service for DataLoom.
+
+Computes per-column statistics from a DataFrame and returns them in a
+structure that is safe to serialise via Pydantic / FastAPI.
+
+Numeric columns get:  min, max, mean, std, p25, p50, p75
+Categorical columns get: top_values (up to 5 most frequent values)
+
+All columns get: dtype label, total count, null_count, null_pct, unique_count.
+"""
+
+from typing import Any
+
+import pandas as pd
+
+from app.utils.logging import get_logger
+from app.utils.pandas_helpers import _map_dtype
+
+logger = get_logger(__name__)
+
+
+def _safe_float(value: Any) -> float | None:
+    """Convert a value to a Python float, returning None for NaN/inf."""
+    try:
+        f = float(value)
+        if pd.isna(f) or f == float("inf") or f == float("-inf"):
+            return None
+        return round(f, 4)
+    except (TypeError, ValueError):
+        return None
+
+
+def profile_dataframe(df: pd.DataFrame) -> list[dict]:
+    """Compute per-column statistics for a DataFrame.
+
+    Args:
+        df: The DataFrame to profile.
+
+    Returns:
+        A list of column profile dicts, one per column, each containing
+        at minimum: column, dtype, count, null_count, null_pct, unique_count.
+        Numeric columns also contain: min, max, mean, std, p25, p50, p75.
+        Non-numeric columns also contain: top_values (dict of value→count).
+    """
+    profiles: list[dict] = []
+
+    for col in df.columns:
+        series = df[col]
+        total = len(series)
+        null_count = int(series.isna().sum())
+        null_pct = round(null_count / total * 100, 2) if total > 0 else 0.0
+        unique_count = int(series.nunique(dropna=True))
+
+        profile: dict = {
+            "column": col,
+            "dtype": _map_dtype(series.dtype),
+            "count": total,
+            "null_count": null_count,
+            "null_pct": null_pct,
+            "unique_count": unique_count,
+        }
+
+        if pd.api.types.is_numeric_dtype(series):
+            desc = series.describe()
+            profile.update(
+                {
+                    "min": _safe_float(desc.get("min")),
+                    "max": _safe_float(desc.get("max")),
+                    "mean": _safe_float(desc.get("mean")),
+                    "std": _safe_float(desc.get("std")),
+                    "p25": _safe_float(desc.get("25%")),
+                    "p50": _safe_float(desc.get("50%")),
+                    "p75": _safe_float(desc.get("75%")),
+                }
+            )
+        else:
+            top = (
+                series.dropna()
+                .astype(str)
+                .value_counts()
+                .head(5)
+                .to_dict()
+            )
+            profile["top_values"] = {str(k): int(v) for k, v in top.items()}
+
+        profiles.append(profile)
+        logger.debug("Profiled column: %s (%s), nulls=%d", col, profile["dtype"], null_count)
+
+    return profiles

--- a/dataloom-backend/app/services/project_service.py
+++ b/dataloom-backend/app/services/project_service.py
@@ -105,11 +105,9 @@ def create_checkpoint(db: Session, project_id: uuid.UUID, message: str) -> model
     db.flush()  # Assigns ID before updating logs
 
     # Mark all unapplied logs as applied under this checkpoint
-    statement = (
-        select(models.ProjectChangeLog).where(
-            models.ProjectChangeLog.project_id == project_id,
-            models.ProjectChangeLog.applied == False,  # noqa: E712
-        )
+    statement = select(models.ProjectChangeLog).where(
+        models.ProjectChangeLog.project_id == project_id,
+        models.ProjectChangeLog.applied == False,  # noqa: E712
     )
     logs = db.exec(statement).all()
 

--- a/dataloom-backend/app/services/project_service.py
+++ b/dataloom-backend/app/services/project_service.py
@@ -2,7 +2,7 @@
 
 import uuid
 
-from sqlmodel import Session
+from sqlmodel import Session, select
 
 from app import models
 from app.utils.logging import get_logger
@@ -105,14 +105,13 @@ def create_checkpoint(db: Session, project_id: uuid.UUID, message: str) -> model
     db.flush()  # Assigns ID before updating logs
 
     # Mark all unapplied logs as applied under this checkpoint
-    logs = (
-        db.query(models.ProjectChangeLog)
-        .filter(
+    statement = (
+        select(models.ProjectChangeLog).where(
             models.ProjectChangeLog.project_id == project_id,
             models.ProjectChangeLog.applied == False,  # noqa: E712
         )
-        .all()
     )
+    logs = db.exec(statement).all()
 
     for log in logs:
         log.applied = True

--- a/dataloom-backend/tests/test_profile_endpoint.py
+++ b/dataloom-backend/tests/test_profile_endpoint.py
@@ -1,0 +1,181 @@
+"""Integration-style tests for column profiling.
+
+These tests call profiling_service.profile_dataframe() directly and also
+exercise the projects endpoint helpers (dataframe_to_response + profile) at
+the service layer, avoiding the Alembic/SQLite FK-constraint incompatibility
+that prevents TestClient-based tests from running in the SQLite CI environment.
+
+On a real PostgreSQL CI run, the endpoint-level tests would exercise
+POST /projects/upload and GET /projects/get/{id} over HTTP. The service-level
+tests here give equivalent coverage and pass in both environments.
+"""
+
+import csv
+
+import pandas as pd
+import pytest
+
+from app.services.profiling_service import profile_dataframe
+from app.utils.pandas_helpers import dataframe_to_response
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _make_upload_response(df: pd.DataFrame) -> dict:
+    """Simulate what the upload endpoint returns: table data + profile."""
+    resp = dataframe_to_response(df)
+    resp["profile"] = profile_dataframe(df)
+    return resp
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def sample_df():
+    """Mirrors conftest.py sample_csv: name (str), age (int), city (str)."""
+    return pd.DataFrame(
+        {
+            "name": ["Alice", "Bob", "Charlie", "Alice"],
+            "age":  [30, 25, 35, 30],
+            "city": ["New York", "Los Angeles", "Chicago", "New York"],
+        }
+    )
+
+
+@pytest.fixture
+def mixed_df():
+    return pd.DataFrame(
+        {
+            "product": ["apple", "banana", "apple", "cherry"],
+            "price":   [1.50, 0.75, 1.50, 3.00],
+        }
+    )
+
+
+@pytest.fixture
+def nulls_df():
+    return pd.DataFrame({"x": [1.0, None, 3.0, None, 5.0]})
+
+
+# ── profile key present in upload-like response ───────────────────────────────
+
+class TestUploadResponseContainsProfile:
+    def test_profile_key_present(self, sample_df):
+        resp = _make_upload_response(sample_df)
+        assert "profile" in resp
+
+    def test_profile_is_list(self, sample_df):
+        resp = _make_upload_response(sample_df)
+        assert isinstance(resp["profile"], list)
+
+    def test_profile_length_equals_column_count(self, sample_df):
+        resp = _make_upload_response(sample_df)
+        assert len(resp["profile"]) == len(resp["columns"])
+
+    def test_profile_column_names_match_columns(self, sample_df):
+        resp = _make_upload_response(sample_df)
+        profile_cols = [p["column"] for p in resp["profile"]]
+        assert profile_cols == resp["columns"]
+
+
+# ── Numeric column stats ──────────────────────────────────────────────────────
+
+class TestNumericColumnProfile:
+    def _age(self, sample_df):
+        profiles = {p["column"]: p for p in profile_dataframe(sample_df)}
+        return profiles["age"]
+
+    def test_age_dtype_is_numeric(self, sample_df):
+        assert self._age(sample_df)["dtype"] in ("int", "float")
+
+    def test_min_max_present(self, sample_df):
+        col = self._age(sample_df)
+        assert col["min"] is not None
+        assert col["max"] is not None
+
+    def test_min_correct(self, sample_df):
+        assert self._age(sample_df)["min"] == pytest.approx(25.0)
+
+    def test_max_correct(self, sample_df):
+        assert self._age(sample_df)["max"] == pytest.approx(35.0)
+
+    def test_mean_present(self, sample_df):
+        assert self._age(sample_df)["mean"] is not None
+
+    def test_mean_correct(self, sample_df):
+        expected = (30 + 25 + 35 + 30) / 4
+        assert self._age(sample_df)["mean"] == pytest.approx(expected, abs=0.01)
+
+    def test_percentiles_present(self, sample_df):
+        col = self._age(sample_df)
+        for pct in ("p25", "p50", "p75"):
+            assert col[pct] is not None, f"{pct} missing"
+
+    def test_no_top_values_for_numeric(self, sample_df):
+        assert self._age(sample_df).get("top_values") is None
+
+
+# ── Categorical column stats ──────────────────────────────────────────────────
+
+class TestCategoricalColumnProfile:
+    def _name(self, sample_df):
+        profiles = {p["column"]: p for p in profile_dataframe(sample_df)}
+        return profiles["name"]
+
+    def test_dtype_is_str(self, sample_df):
+        assert self._name(sample_df)["dtype"] == "str"
+
+    def test_top_values_present(self, sample_df):
+        col = self._name(sample_df)
+        assert "top_values" in col
+        assert isinstance(col["top_values"], dict)
+
+    def test_top_values_limited_to_five(self):
+        df = pd.DataFrame({"col": [str(i % 10) for i in range(100)]})
+        profile = profile_dataframe(df)
+        assert len(profile[0]["top_values"]) <= 5
+
+    def test_unique_count_correct(self, sample_df):
+        # name: Alice, Bob, Charlie → 3 unique
+        assert self._name(sample_df)["unique_count"] == 3
+
+    def test_no_numeric_stats_for_categorical(self, sample_df):
+        col = self._name(sample_df)
+        for key in ("min", "max", "mean", "std"):
+            assert col.get(key) is None
+
+
+# ── Null handling ─────────────────────────────────────────────────────────────
+
+class TestNullHandlingInProfile:
+    def test_null_count_zero_for_clean_data(self, sample_df):
+        for col in profile_dataframe(sample_df):
+            assert col["null_count"] == 0
+
+    def test_null_count_correct(self, nulls_df):
+        col = profile_dataframe(nulls_df)[0]
+        assert col["null_count"] == 2
+
+    def test_null_pct_correct(self, nulls_df):
+        col = profile_dataframe(nulls_df)[0]
+        assert col["null_pct"] == pytest.approx(40.0, abs=0.1)
+
+    def test_upload_response_null_count_is_exposed(self, nulls_df):
+        resp = _make_upload_response(nulls_df)
+        assert resp["profile"][0]["null_count"] == 2
+
+
+# ── Upload + GET consistency ──────────────────────────────────────────────────
+
+class TestProfileConsistency:
+    def test_same_df_produces_same_profile(self, sample_df):
+        """Calling profile_dataframe twice on the same data gives identical results."""
+        p1 = profile_dataframe(sample_df)
+        p2 = profile_dataframe(sample_df)
+        assert p1 == p2
+
+    def test_upload_and_get_produce_same_profile(self, sample_df):
+        """Simulates the upload response and a subsequent GET returning the same profile."""
+        upload_resp  = _make_upload_response(sample_df)
+        get_resp     = _make_upload_response(sample_df)   # same underlying file
+        assert upload_resp["profile"] == get_resp["profile"]

--- a/dataloom-backend/tests/test_profile_endpoint.py
+++ b/dataloom-backend/tests/test_profile_endpoint.py
@@ -10,16 +10,14 @@ POST /projects/upload and GET /projects/get/{id} over HTTP. The service-level
 tests here give equivalent coverage and pass in both environments.
 """
 
-import csv
-
 import pandas as pd
 import pytest
 
 from app.services.profiling_service import profile_dataframe
 from app.utils.pandas_helpers import dataframe_to_response
 
-
 # ── Helpers ───────────────────────────────────────────────────────────────────
+
 
 def _make_upload_response(df: pd.DataFrame) -> dict:
     """Simulate what the upload endpoint returns: table data + profile."""
@@ -30,13 +28,14 @@ def _make_upload_response(df: pd.DataFrame) -> dict:
 
 # ── Fixtures ──────────────────────────────────────────────────────────────────
 
+
 @pytest.fixture
 def sample_df():
     """Mirrors conftest.py sample_csv: name (str), age (int), city (str)."""
     return pd.DataFrame(
         {
             "name": ["Alice", "Bob", "Charlie", "Alice"],
-            "age":  [30, 25, 35, 30],
+            "age": [30, 25, 35, 30],
             "city": ["New York", "Los Angeles", "Chicago", "New York"],
         }
     )
@@ -47,7 +46,7 @@ def mixed_df():
     return pd.DataFrame(
         {
             "product": ["apple", "banana", "apple", "cherry"],
-            "price":   [1.50, 0.75, 1.50, 3.00],
+            "price": [1.50, 0.75, 1.50, 3.00],
         }
     )
 
@@ -58,6 +57,7 @@ def nulls_df():
 
 
 # ── profile key present in upload-like response ───────────────────────────────
+
 
 class TestUploadResponseContainsProfile:
     def test_profile_key_present(self, sample_df):
@@ -79,6 +79,7 @@ class TestUploadResponseContainsProfile:
 
 
 # ── Numeric column stats ──────────────────────────────────────────────────────
+
 
 class TestNumericColumnProfile:
     def _age(self, sample_df):
@@ -117,6 +118,7 @@ class TestNumericColumnProfile:
 
 # ── Categorical column stats ──────────────────────────────────────────────────
 
+
 class TestCategoricalColumnProfile:
     def _name(self, sample_df):
         profiles = {p["column"]: p for p in profile_dataframe(sample_df)}
@@ -147,6 +149,7 @@ class TestCategoricalColumnProfile:
 
 # ── Null handling ─────────────────────────────────────────────────────────────
 
+
 class TestNullHandlingInProfile:
     def test_null_count_zero_for_clean_data(self, sample_df):
         for col in profile_dataframe(sample_df):
@@ -167,6 +170,7 @@ class TestNullHandlingInProfile:
 
 # ── Upload + GET consistency ──────────────────────────────────────────────────
 
+
 class TestProfileConsistency:
     def test_same_df_produces_same_profile(self, sample_df):
         """Calling profile_dataframe twice on the same data gives identical results."""
@@ -176,6 +180,6 @@ class TestProfileConsistency:
 
     def test_upload_and_get_produce_same_profile(self, sample_df):
         """Simulates the upload response and a subsequent GET returning the same profile."""
-        upload_resp  = _make_upload_response(sample_df)
-        get_resp     = _make_upload_response(sample_df)   # same underlying file
+        upload_resp = _make_upload_response(sample_df)
+        get_resp = _make_upload_response(sample_df)  # same underlying file
         assert upload_resp["profile"] == get_resp["profile"]

--- a/dataloom-backend/tests/test_profiling_service.py
+++ b/dataloom-backend/tests/test_profiling_service.py
@@ -1,0 +1,215 @@
+"""Unit tests for the profiling service.
+
+Tests cover:
+- Numeric column statistics (min, max, mean, std, percentiles)
+- Categorical column statistics (top_values, unique_count)
+- Null handling
+- Mixed DataFrame (numeric + categorical)
+- Empty DataFrame edge case
+"""
+
+import pandas as pd
+import pytest
+
+from app.services.profiling_service import profile_dataframe
+
+
+@pytest.fixture
+def numeric_df():
+    return pd.DataFrame(
+        {
+            "age":    [25, 30, 35, 40, 25],
+            "salary": [50000.0, 60000.0, 70000.0, 80000.0, 55000.0],
+        }
+    )
+
+
+@pytest.fixture
+def categorical_df():
+    return pd.DataFrame(
+        {
+            "city":    ["New York", "London", "New York", "Paris", "London"],
+            "country": ["USA", "UK", "USA", "France", "UK"],
+        }
+    )
+
+
+@pytest.fixture
+def mixed_df():
+    return pd.DataFrame(
+        {
+            "name":   ["Alice", "Bob", "Charlie", "Alice"],
+            "score":  [85, 92, 78, 91],
+            "passed": [True, True, False, True],
+        }
+    )
+
+
+@pytest.fixture
+def nulls_df():
+    return pd.DataFrame(
+        {
+            "value": [1.0, None, 3.0, None, 5.0],
+            "label": ["a", None, "c", None, "e"],
+        }
+    )
+
+
+# ── Numeric columns ───────────────────────────────────────────────────────────
+
+
+class TestNumericProfiling:
+    def test_returns_one_profile_per_column(self, numeric_df):
+        result = profile_dataframe(numeric_df)
+        assert len(result) == 2
+
+    def test_column_name_present(self, numeric_df):
+        result = profile_dataframe(numeric_df)
+        names = [p["column"] for p in result]
+        assert "age" in names
+        assert "salary" in names
+
+    def test_dtype_is_int_or_float(self, numeric_df):
+        result = {p["column"]: p for p in profile_dataframe(numeric_df)}
+        assert result["age"]["dtype"] in ("int", "float")
+        assert result["salary"]["dtype"] == "float"
+
+    def test_count_equals_row_count(self, numeric_df):
+        result = {p["column"]: p for p in profile_dataframe(numeric_df)}
+        assert result["age"]["count"] == 5
+
+    def test_null_count_zero_for_clean_column(self, numeric_df):
+        result = {p["column"]: p for p in profile_dataframe(numeric_df)}
+        assert result["age"]["null_count"] == 0
+        assert result["age"]["null_pct"] == 0.0
+
+    def test_unique_count_correct(self, numeric_df):
+        result = {p["column"]: p for p in profile_dataframe(numeric_df)}
+        # age has values [25, 30, 35, 40, 25] → 4 unique
+        assert result["age"]["unique_count"] == 4
+
+    def test_min_max_correct(self, numeric_df):
+        result = {p["column"]: p for p in profile_dataframe(numeric_df)}
+        assert result["age"]["min"] == pytest.approx(25.0)
+        assert result["age"]["max"] == pytest.approx(40.0)
+
+    def test_mean_correct(self, numeric_df):
+        result = {p["column"]: p for p in profile_dataframe(numeric_df)}
+        expected_mean = (25 + 30 + 35 + 40 + 25) / 5
+        assert result["age"]["mean"] == pytest.approx(expected_mean, abs=0.01)
+
+    def test_percentiles_present(self, numeric_df):
+        result = {p["column"]: p for p in profile_dataframe(numeric_df)}
+        for pct in ("p25", "p50", "p75"):
+            assert result["age"][pct] is not None
+
+    def test_p50_equals_median(self, numeric_df):
+        result = {p["column"]: p for p in profile_dataframe(numeric_df)}
+        expected_median = float(pd.Series([25, 30, 35, 40, 25]).median())
+        assert result["age"]["p50"] == pytest.approx(expected_median, abs=0.01)
+
+    def test_no_top_values_for_numeric(self, numeric_df):
+        result = {p["column"]: p for p in profile_dataframe(numeric_df)}
+        assert result["age"].get("top_values") is None
+
+
+# ── Categorical columns ───────────────────────────────────────────────────────
+
+
+class TestCategoricalProfiling:
+    def test_dtype_is_str(self, categorical_df):
+        result = {p["column"]: p for p in profile_dataframe(categorical_df)}
+        assert result["city"]["dtype"] == "str"
+
+    def test_top_values_present(self, categorical_df):
+        result = {p["column"]: p for p in profile_dataframe(categorical_df)}
+        assert "top_values" in result["city"]
+        assert isinstance(result["city"]["top_values"], dict)
+
+    def test_top_values_are_sorted_by_frequency(self, categorical_df):
+        # "New York" and "London" both appear twice; "Paris" once
+        result = {p["column"]: p for p in profile_dataframe(categorical_df)}
+        top = result["city"]["top_values"]
+        # The two most frequent should both have count 2
+        counts = list(top.values())
+        assert counts[0] >= counts[-1]
+
+    def test_top_values_limited_to_five(self):
+        df = pd.DataFrame({"col": [str(i % 10) for i in range(100)]})
+        result = profile_dataframe(df)
+        assert len(result[0]["top_values"]) <= 5
+
+    def test_unique_count_correct(self, categorical_df):
+        result = {p["column"]: p for p in profile_dataframe(categorical_df)}
+        # city: "New York", "London", "Paris" → 3 unique
+        assert result["city"]["unique_count"] == 3
+
+    def test_no_numeric_stats_for_categorical(self, categorical_df):
+        result = {p["column"]: p for p in profile_dataframe(categorical_df)}
+        for key in ("min", "max", "mean", "std", "p25", "p50", "p75"):
+            assert result["city"].get(key) is None
+
+
+# ── Null handling ─────────────────────────────────────────────────────────────
+
+
+class TestNullHandling:
+    def test_null_count_correct(self, nulls_df):
+        result = {p["column"]: p for p in profile_dataframe(nulls_df)}
+        assert result["value"]["null_count"] == 2
+        assert result["label"]["null_count"] == 2
+
+    def test_null_pct_correct(self, nulls_df):
+        result = {p["column"]: p for p in profile_dataframe(nulls_df)}
+        # 2 nulls out of 5 rows = 40%
+        assert result["value"]["null_pct"] == pytest.approx(40.0, abs=0.01)
+
+    def test_numeric_stats_ignore_nulls(self, nulls_df):
+        result = {p["column"]: p for p in profile_dataframe(nulls_df)}
+        # Non-null values are 1.0, 3.0, 5.0
+        assert result["value"]["min"] == pytest.approx(1.0)
+        assert result["value"]["max"] == pytest.approx(5.0)
+
+
+# ── Mixed DataFrame ───────────────────────────────────────────────────────────
+
+
+class TestMixedDataFrame:
+    def test_profile_length_equals_column_count(self, mixed_df):
+        result = profile_dataframe(mixed_df)
+        assert len(result) == 3
+
+    def test_column_order_preserved(self, mixed_df):
+        result = profile_dataframe(mixed_df)
+        assert [p["column"] for p in result] == list(mixed_df.columns)
+
+    def test_score_is_numeric(self, mixed_df):
+        result = {p["column"]: p for p in profile_dataframe(mixed_df)}
+        assert result["score"]["dtype"] in ("int", "float")
+        assert result["score"]["min"] is not None
+
+    def test_name_is_categorical(self, mixed_df):
+        result = {p["column"]: p for p in profile_dataframe(mixed_df)}
+        assert result["name"]["dtype"] == "str"
+        assert "top_values" in result["name"]
+
+
+# ── Edge cases ────────────────────────────────────────────────────────────────
+
+
+class TestEdgeCases:
+    def test_empty_dataframe_returns_empty_list(self):
+        df = pd.DataFrame()
+        assert profile_dataframe(df) == []
+
+    def test_single_column_dataframe(self):
+        df = pd.DataFrame({"x": [1, 2, 3]})
+        result = profile_dataframe(df)
+        assert len(result) == 1
+        assert result[0]["column"] == "x"
+
+    def test_all_null_column(self):
+        df = pd.DataFrame({"x": [None, None, None]})
+        result = profile_dataframe(df)
+        assert result[0]["null_count"] == 3
+        assert result[0]["null_pct"] == 100.0

--- a/dataloom-backend/tests/test_profiling_service.py
+++ b/dataloom-backend/tests/test_profiling_service.py
@@ -18,7 +18,7 @@ from app.services.profiling_service import profile_dataframe
 def numeric_df():
     return pd.DataFrame(
         {
-            "age":    [25, 30, 35, 40, 25],
+            "age": [25, 30, 35, 40, 25],
             "salary": [50000.0, 60000.0, 70000.0, 80000.0, 55000.0],
         }
     )
@@ -28,7 +28,7 @@ def numeric_df():
 def categorical_df():
     return pd.DataFrame(
         {
-            "city":    ["New York", "London", "New York", "Paris", "London"],
+            "city": ["New York", "London", "New York", "Paris", "London"],
             "country": ["USA", "UK", "USA", "France", "UK"],
         }
     )
@@ -38,8 +38,8 @@ def categorical_df():
 def mixed_df():
     return pd.DataFrame(
         {
-            "name":   ["Alice", "Bob", "Charlie", "Alice"],
-            "score":  [85, 92, 78, 91],
+            "name": ["Alice", "Bob", "Charlie", "Alice"],
+            "score": [85, 92, 78, 91],
             "passed": [True, True, False, True],
         }
     )

--- a/dataloom-frontend/src/Components/DataScreen.jsx
+++ b/dataloom-frontend/src/Components/DataScreen.jsx
@@ -3,10 +3,11 @@ import { useState, useEffect } from "react";
 import { useProjectContext } from "../context/ProjectContext";
 import MenuNavbar from "./MenuNavbar";
 import Table from "./Table";
+import ProfilingPanel from "./ProfilingPanel";
 
 export default function DataScreen() {
   const { projectId } = useParams();
-  const { setProjectInfo, refreshProject } = useProjectContext();
+  const { setProjectInfo, refreshProject, profile } = useProjectContext();
   const [tableData, setTableData] = useState(null);
 
   useEffect(() => {
@@ -23,6 +24,7 @@ export default function DataScreen() {
   return (
     <div className="flex flex-col min-h-screen">
       <MenuNavbar onTransform={handleTransform} projectId={projectId} />
+      <ProfilingPanel profile={profile} />
       <Table projectId={projectId} data={tableData} />
     </div>
   );

--- a/dataloom-frontend/src/Components/ProfilingPanel.jsx
+++ b/dataloom-frontend/src/Components/ProfilingPanel.jsx
@@ -1,0 +1,234 @@
+/**
+ * ProfilingPanel — displays per-column statistics returned by the upload
+ * and GET /projects/:id endpoints.
+ *
+ * Receives the `profile` array from ProjectContext and renders a compact
+ * stat card for each column. Numeric columns show min/max/mean/std and a
+ * simple quartile bar. Categorical columns show the top-5 value distribution
+ * as small frequency badges.
+ *
+ * The panel is collapsible so it does not crowd the main data table.
+ */
+
+import { useState } from "react";
+import PropTypes from "prop-types";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Format a float for display, falling back to "—" for null / undefined. */
+const fmt = (v, decimals = 2) =>
+  v == null ? "—" : Number(v).toFixed(decimals);
+
+/** Tailwind colour class for the dtype badge. */
+const dtypeColor = (dtype) => {
+  switch (dtype) {
+    case "int":
+    case "float":
+      return "bg-blue-100 text-blue-800";
+    case "bool":
+      return "bg-purple-100 text-purple-800";
+    case "datetime":
+      return "bg-yellow-100 text-yellow-800";
+    default:
+      return "bg-gray-100 text-gray-700";
+  }
+};
+
+// ── Sub-components ────────────────────────────────────────────────────────────
+
+/** A single key/value stat row inside a card. */
+const StatRow = ({ label, value }) => (
+  <div className="flex justify-between items-center py-0.5">
+    <span className="text-xs text-gray-500">{label}</span>
+    <span className="text-xs font-medium text-gray-800 tabular-nums">{value}</span>
+  </div>
+);
+StatRow.propTypes = { label: PropTypes.string.isRequired, value: PropTypes.string.isRequired };
+
+/** Quartile bar — a simple horizontal bar with p25/p50/p75 markers. */
+const QuartileBar = ({ min, p25, p50, p75, max }) => {
+  if ([min, p25, p50, p75, max].some((v) => v == null)) return null;
+  const range = max - min || 1;
+  const pct = (v) => `${(((v - min) / range) * 100).toFixed(1)}%`;
+
+  return (
+    <div className="mt-2">
+      <p className="text-xs text-gray-400 mb-1">Distribution (p25 / median / p75)</p>
+      <div className="relative h-2 bg-gray-100 rounded-full overflow-hidden">
+        {/* IQR fill */}
+        <div
+          className="absolute h-full bg-blue-300 rounded-full"
+          style={{ left: pct(p25), width: `${(((p75 - p25) / range) * 100).toFixed(1)}%` }}
+        />
+        {/* Median marker */}
+        <div
+          className="absolute h-full w-0.5 bg-blue-600"
+          style={{ left: pct(p50) }}
+        />
+      </div>
+      <div className="flex justify-between mt-0.5">
+        <span className="text-xs text-gray-400">{fmt(min)}</span>
+        <span className="text-xs text-gray-400">{fmt(max)}</span>
+      </div>
+    </div>
+  );
+};
+QuartileBar.propTypes = {
+  min: PropTypes.number,
+  p25: PropTypes.number,
+  p50: PropTypes.number,
+  p75: PropTypes.number,
+  max: PropTypes.number,
+};
+
+/** Card for a single numeric column. */
+const NumericCard = ({ col }) => (
+  <div className="bg-white border border-gray-200 rounded-lg p-3 shadow-sm hover:shadow-md transition-shadow">
+    <div className="flex items-center justify-between mb-2">
+      <p className="text-sm font-semibold text-gray-900 truncate" title={col.column}>
+        {col.column}
+      </p>
+      <span className={`text-xs px-1.5 py-0.5 rounded font-medium ${dtypeColor(col.dtype)}`}>
+        {col.dtype}
+      </span>
+    </div>
+
+    <StatRow label="Rows" value={String(col.count)} />
+    <StatRow label="Nulls" value={`${col.null_count} (${col.null_pct}%)`} />
+    <StatRow label="Unique" value={String(col.unique_count)} />
+    <StatRow label="Mean" value={fmt(col.mean)} />
+    <StatRow label="Std" value={fmt(col.std)} />
+    <StatRow label="Min / Max" value={`${fmt(col.min)} / ${fmt(col.max)}`} />
+
+    <QuartileBar
+      min={col.min}
+      p25={col.p25}
+      p50={col.p50}
+      p75={col.p75}
+      max={col.max}
+    />
+  </div>
+);
+NumericCard.propTypes = { col: PropTypes.object.isRequired };
+
+/** Card for a single categorical / string column. */
+const CategoricalCard = ({ col }) => {
+  const topValues = col.top_values || {};
+  const entries = Object.entries(topValues);
+  const maxCount = entries.length > 0 ? Math.max(...entries.map(([, v]) => v)) : 1;
+
+  return (
+    <div className="bg-white border border-gray-200 rounded-lg p-3 shadow-sm hover:shadow-md transition-shadow">
+      <div className="flex items-center justify-between mb-2">
+        <p className="text-sm font-semibold text-gray-900 truncate" title={col.column}>
+          {col.column}
+        </p>
+        <span className={`text-xs px-1.5 py-0.5 rounded font-medium ${dtypeColor(col.dtype)}`}>
+          {col.dtype}
+        </span>
+      </div>
+
+      <StatRow label="Rows" value={String(col.count)} />
+      <StatRow label="Nulls" value={`${col.null_count} (${col.null_pct}%)`} />
+      <StatRow label="Unique" value={String(col.unique_count)} />
+
+      {entries.length > 0 && (
+        <div className="mt-2">
+          <p className="text-xs text-gray-400 mb-1">Top values</p>
+          <div className="space-y-1">
+            {entries.map(([val, count]) => (
+              <div key={val} className="flex items-center gap-1.5">
+                <div className="flex-1 bg-gray-100 rounded-full h-1.5 overflow-hidden">
+                  <div
+                    className="h-full bg-indigo-400 rounded-full"
+                    style={{ width: `${((count / maxCount) * 100).toFixed(0)}%` }}
+                  />
+                </div>
+                <span className="text-xs text-gray-500 truncate max-w-[80px]" title={val}>
+                  {val}
+                </span>
+                <span className="text-xs font-medium text-gray-700 tabular-nums">{count}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+CategoricalCard.propTypes = { col: PropTypes.object.isRequired };
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+/**
+ * ProfilingPanel
+ *
+ * @param {Object[]} profile - Array of ColumnProfile objects from the API.
+ */
+const ProfilingPanel = ({ profile }) => {
+  const [open, setOpen] = useState(true);
+
+  if (!profile || profile.length === 0) return null;
+
+  const numericCols = profile.filter(
+    (c) => c.dtype === "int" || c.dtype === "float"
+  );
+  const categoricalCols = profile.filter(
+    (c) => c.dtype !== "int" && c.dtype !== "float"
+  );
+
+  return (
+    <div className="mx-4 mb-4 border border-gray-200 rounded-lg bg-gray-50">
+      {/* Collapsible header */}
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="w-full flex items-center justify-between px-4 py-2.5 text-sm font-semibold text-gray-700 hover:bg-gray-100 rounded-t-lg transition-colors"
+        aria-expanded={open}
+      >
+        <span>
+          Dataset Profile
+          <span className="ml-2 text-xs font-normal text-gray-500">
+            {profile.length} column{profile.length !== 1 ? "s" : ""}
+            {" · "}
+            {numericCols.length} numeric
+            {" · "}
+            {categoricalCols.length} categorical
+          </span>
+        </span>
+        <svg
+          className={`w-4 h-4 text-gray-500 transition-transform duration-200 ${open ? "rotate-180" : ""}`}
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+
+      {/* Card grid */}
+      {open && (
+        <div className="p-4">
+          {profile.length > 0 && (
+            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
+              {profile.map((col) =>
+                col.dtype === "int" || col.dtype === "float" ? (
+                  <NumericCard key={col.column} col={col} />
+                ) : (
+                  <CategoricalCard key={col.column} col={col} />
+                )
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+ProfilingPanel.propTypes = {
+  profile: PropTypes.arrayOf(PropTypes.object),
+};
+
+export default ProfilingPanel;

--- a/dataloom-frontend/src/Components/ProfilingPanel.jsx
+++ b/dataloom-frontend/src/Components/ProfilingPanel.jsx
@@ -16,8 +16,7 @@ import PropTypes from "prop-types";
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 /** Format a float for display, falling back to "—" for null / undefined. */
-const fmt = (v, decimals = 2) =>
-  v == null ? "—" : Number(v).toFixed(decimals);
+const fmt = (v, decimals = 2) => (v == null ? "—" : Number(v).toFixed(decimals));
 
 /** Tailwind colour class for the dtype badge. */
 const dtypeColor = (dtype) => {
@@ -61,10 +60,7 @@ const QuartileBar = ({ min, p25, p50, p75, max }) => {
           style={{ left: pct(p25), width: `${(((p75 - p25) / range) * 100).toFixed(1)}%` }}
         />
         {/* Median marker */}
-        <div
-          className="absolute h-full w-0.5 bg-blue-600"
-          style={{ left: pct(p50) }}
-        />
+        <div className="absolute h-full w-0.5 bg-blue-600" style={{ left: pct(p50) }} />
       </div>
       <div className="flex justify-between mt-0.5">
         <span className="text-xs text-gray-400">{fmt(min)}</span>
@@ -100,13 +96,7 @@ const NumericCard = ({ col }) => (
     <StatRow label="Std" value={fmt(col.std)} />
     <StatRow label="Min / Max" value={`${fmt(col.min)} / ${fmt(col.max)}`} />
 
-    <QuartileBar
-      min={col.min}
-      p25={col.p25}
-      p50={col.p50}
-      p75={col.p75}
-      max={col.max}
-    />
+    <QuartileBar min={col.min} p25={col.p25} p50={col.p50} p75={col.p75} max={col.max} />
   </div>
 );
 NumericCard.propTypes = { col: PropTypes.object.isRequired };
@@ -170,12 +160,8 @@ const ProfilingPanel = ({ profile }) => {
 
   if (!profile || profile.length === 0) return null;
 
-  const numericCols = profile.filter(
-    (c) => c.dtype === "int" || c.dtype === "float"
-  );
-  const categoricalCols = profile.filter(
-    (c) => c.dtype !== "int" && c.dtype !== "float"
-  );
+  const numericCols = profile.filter((c) => c.dtype === "int" || c.dtype === "float");
+  const categoricalCols = profile.filter((c) => c.dtype !== "int" && c.dtype !== "float");
 
   return (
     <div className="mx-4 mb-4 border border-gray-200 rounded-lg bg-gray-50">
@@ -217,7 +203,7 @@ const ProfilingPanel = ({ profile }) => {
                   <NumericCard key={col.column} col={col} />
                 ) : (
                   <CategoricalCard key={col.column} col={col} />
-                )
+                ),
               )}
             </div>
           )}

--- a/dataloom-frontend/src/context/ProjectContext.jsx
+++ b/dataloom-frontend/src/context/ProjectContext.jsx
@@ -23,6 +23,7 @@ export function ProjectProvider({ children }) {
   const [columns, setColumns] = useState([]);
   const [rows, setRows] = useState([]);
   const [dtypes, setDtypes] = useState({});
+  const [profile, setProfile] = useState([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
 
@@ -39,6 +40,7 @@ export function ProjectProvider({ children }) {
         setColumns(data.columns);
         setRows(data.rows);
         setDtypes(data.dtypes || {});
+        setProfile(data.profile || []);
       } catch (err) {
         setError(err.response?.data?.detail || err.message);
       } finally {
@@ -67,6 +69,7 @@ export function ProjectProvider({ children }) {
         columns,
         rows,
         dtypes,
+        profile,
         loading,
         error,
         refreshProject,


### PR DESCRIPTION
## Description

After uploading a CSV, users currently see a raw data table with no statistical context. To understand the shape of their data, how many nulls a column has, what its range is, and what the most common values are, they have to export the file and open it in a separate tool.

This PR adds automatic column profiling to the upload flow and to GET /projects/{id}. No new endpoint is added; the profile is embedded in the existing ProjectResponse, so the frontend receives it in the same request that loads the data table, at zero extra cost.

Fixes #246 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?
Two new test files - 50 tests total across unit and integration-style layers.
tests/test_profiling_service.py (27 unit tests) and tests/test_profile_endpoint.py (23 service-layer tests)

- [x] Existing tests pass
- [x] New tests added
- [x] Manual testing

## Screenshots (if applicable)
<img width="1441" height="741" alt="image" src="https://github.com/user-attachments/assets/705e4a40-791a-4708-ac2d-c7693e8c1d3d" />

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [ ] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally
