### PR TITLE
ci: add parallel backend and frontend CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,78 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Backend — Python 3.12 / uv / pytest
+  # ---------------------------------------------------------------------------
+  backend:
+    name: Backend Tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: dataloom-backend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Cache uv virtualenv
+        uses: actions/cache@v4
+        with:
+          path: dataloom-backend/.venv
+          key: uv-${{ runner.os }}-py3.12-${{ hashFiles('dataloom-backend/uv.lock') }}
+          restore-keys: |
+            uv-${{ runner.os }}-py3.12-
+
+      - name: Install dependencies
+        run: uv sync --frozen --extra dev
+
+      - name: Run tests
+        run: uv run pytest
+        env:
+          DATABASE_URL: sqlite:///./test.db
+
+  # ---------------------------------------------------------------------------
+  # Frontend — Node 18 / npm / vite build + vitest
+  # ---------------------------------------------------------------------------
+  frontend:
+    name: Frontend Build & Test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: dataloom-frontend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js 18
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+          cache-dependency-path: dataloom-frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm run test


### PR DESCRIPTION
## Description

Adds `.github/workflows/ci.yml` — a parallel CI workflow that runs backend tests and a frontend build + test on every push and pull request to `main`.

The repo already has `lint.yml` for code style checks; this workflow adds the missing test/build gate.

Fixes #(issue number)

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

The workflow was validated locally against the project structure:
- Backend: `uv sync --frozen --extra dev && uv run pytest` — confirmed all tests pass with `DATABASE_URL=sqlite:///./test.db`.
- Frontend: `npm ci && npm run build && npm run test` — confirmed `vitest run` script exists in `package.json`.

- [ ] Existing tests pass
- [ ] New tests added
- [x] Manual testing

## Workflow details

**`backend` job** (Python 3.12 / uv / pytest)
- Uses `astral-sh/setup-uv@v4` — consistent with the existing `lint.yml`.
- Caches `.venv` keyed on `uv.lock` hash for fast subsequent runs.
- `uv sync --frozen --extra dev` installs production + dev deps (pytest, httpx, ruff).
- `uv run pytest` with `DATABASE_URL=sqlite:///./test.db` (required by `conftest.py`).

**`frontend` job** (Node 18 / npm / Vite / Vitest)
- `actions/setup-node@v4` with `cache: npm` keyed on `package-lock.json` — consistent with `lint.yml`.
- `npm ci` for reproducible installs.
- `npm run build` (Vite build).
- `npm run test` (`vitest run` — already defined in `package.json`).

Both jobs run in parallel. `concurrency` cancels stale runs on new pushes to the same ref.

## Screenshots (if applicable)

N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally
