### PR TITLE
fix: use correct param keys for add and delete column ops

### DIFF
--- a/dataloom-frontend/src/Components/Table.jsx
+++ b/dataloom-frontend/src/Components/Table.jsx
@@ -91,7 +91,7 @@ const Table = ({ projectId, data: externalData }) => {
         try {
           const response = await transformProject(projectId, {
             operation_type: ADD_COLUMN,
-            col_params: { index, name: newColumnName },
+            add_col_params: { index, name: newColumnName },
           });
           updateTableData(response);
         } catch {
@@ -169,7 +169,7 @@ const Table = ({ projectId, data: externalData }) => {
     try {
       const response = await transformProject(projectId, {
         operation_type: DELETE_COLUMN,
-        col_params: { index: index - 1 },
+        del_col_params: { index: index - 1 },
       });
       updateTableData(response);
     } catch {


### PR DESCRIPTION

## Description
 
The right-click context menu for adding and deleting columns was silently broken for every user. Both `handleAddColumn` and `handleDeleteColumn` in `Table.jsx` were sending the request body with the key `col_params`, but the backend `TransformationInput` schema expects `add_col_params` and `del_col_params` respectively. FastAPI would set those fields to `None` and the handler would throw a 400. This fixes the fix is two key renames: `col_params` → `add_col_params` in `handleAddColumn` and `col_params` → `del_col_params` in `handleDeleteColumn`.
 
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
 
## How Has This Been Tested?
 
Ran `npm run test` (48 frontend tests pass), `npm run lint`, and `npm run build` — all clean. Ran `uv run pytest` on the backend — 92 tests pass. The one pre-existing failure (`test_add_column_without_name_returns_422`) was confirmed to exist on main before this branch and is tracked separately as issue #4. Manually verified that right-clicking a column header and choosing "Add Column" and "Delete Column" now succeeds instead of showing the error toast.
 
- [x] Existing tests pass
- [ ] New tests added
- [x] Manual testing
 
 Fixes #257 
## Screenshots (if applicable)
**After fix:**


https://github.com/user-attachments/assets/d2546d2a-3f43-45a6-8e6e-de9010783baf


 
## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally