### PR TITLE
fix: reject col_index 0 in change_cell_value bounds check

### DIFF
--- a/dataloom-backend/app/services/transformation_service.py
+++ b/dataloom-backend/app/services/transformation_service.py
@@ -192,7 +192,7 @@ def change_cell_value(df: pd.DataFrame, row_index: int, col_index: int, value) -
     """
     df = df.copy()
 
-    if row_index >= len(df) or col_index >= len(df.columns) + 1:
+    if row_index >= len(df) or col_index < 1 or col_index >= len(df.columns) + 1:
         raise TransformationError("Row or column index out of bounds")
 
     # col_index is 1-based from frontend (accounting for S.No. column)

--- a/dataloom-backend/tests/test_transformations.py
+++ b/dataloom-backend/tests/test_transformations.py
@@ -131,6 +131,19 @@ class TestChangeCellValue:
         result = change_cell_value(sample_df, 0, 1, "Alice Updated")
         assert result.iloc[0]["name"] == "Alice Updated"
 
+    def test_col_index_zero_raises(self, sample_df):
+        with pytest.raises(TransformationError, match="out of bounds"):
+            change_cell_value(sample_df, 0, 0, "should fail")
+
+    def test_col_index_zero_does_not_edit_last_column(self, sample_df):
+        with pytest.raises(TransformationError):
+            change_cell_value(sample_df, 0, 0, "silent corruption")
+        assert sample_df.iloc[0]["city"] == "New York"
+
+    def test_col_index_negative_raises(self, sample_df):
+        with pytest.raises(TransformationError, match="out of bounds"):
+            change_cell_value(sample_df, 0, -1, "should fail")
+
 
 class TestFillEmpty:
     def test_fill_all_columns(self):


### PR DESCRIPTION
## Description

`change_cell_value` in `transformation_service.py` only had an upper-bound guard on `col_index` — it checked `col_index >= len(df.columns) + 1` but never checked `col_index < 1`. Since `col_index` is 1-based from the frontend, a value of `0` would compute `df.columns[0 - 1]` = `df.columns[-1]`, silently writing to the last column instead of raising an error. This could happen from a frontend bug or a direct API call. This fixes #7 by adding `col_index < 1` to the existing guard condition on line 194. Also added three tests covering `col_index=0`, `col_index=-1`, and confirming the last column is not corrupted when `col_index=0` is sent.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

Ran `uv run pytest` — 95 tests pass. Three new unit tests added to `TestChangeCellValue`: `test_col_index_zero_raises`, `test_col_index_zero_does_not_edit_last_column`, and `test_col_index_negative_raises`. All three fail on main without the fix and pass with it. Ran `uv run ruff check .` — no issues.

- [x] Existing tests pass
- [x] New tests added
- [ ] Manual testing

## Related issue
Fixes #259 

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally