### PR TITLE
refactor(utils): remove unused validate_row_index and validate_column_index

### DIFF
--- a/dataloom-backend/app/utils/pandas_helpers.py
+++ b/dataloom-backend/app/utils/pandas_helpers.py
@@ -75,37 +75,3 @@ def dataframe_to_response(df: pd.DataFrame) -> dict[str, Any]:
     columns = df.columns.tolist()
     rows = df.values.tolist()
     return {"columns": columns, "rows": rows, "row_count": len(rows), "dtypes": dtypes}
-
-
-def validate_row_index(df: pd.DataFrame, index: int) -> None:
-    """Validate that a row index is within DataFrame bounds.
-
-    Args:
-        df: Source DataFrame.
-        index: Row index to validate.
-
-    Raises:
-        HTTPException: If index is out of range.
-    """
-    if index < 0 or index >= len(df):
-        raise HTTPException(
-            status_code=400,
-            detail=f"Row index {index} out of range (0-{len(df) - 1})",
-        )
-
-
-def validate_column_index(df: pd.DataFrame, index: int) -> None:
-    """Validate that a column index is within DataFrame bounds.
-
-    Args:
-        df: Source DataFrame.
-        index: Column index to validate.
-
-    Raises:
-        HTTPException: If index is out of range.
-    """
-    if index < 0 or index >= len(df.columns):
-        raise HTTPException(
-            status_code=400,
-            detail=f"Column index {index} out of range (0-{len(df.columns) - 1})",
-        )


### PR DESCRIPTION
## Description

`pandas_helpers.py` had two exported functions — `validate_row_index` and `validate_column_index` — that were never imported or called anywhere in the codebase. All bounds checking is done inline inside the service functions. On top of being dead code, both functions raised `HTTPException` directly, which is wrong for a utility module that should have no knowledge of HTTP. This fixes deleting both functions. The `from fastapi import HTTPException` import was kept because `read_csv_safe` and `save_csv_safe` still use it.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

Ran `uv run pytest` — 92 tests pass, same count as main. No tests referenced either deleted function. Ran `uv run ruff check .` — clean. Also grepped the entire codebase to confirm zero callers before deleting.

- [x] Existing tests pass
- [ ] New tests added
- [ ] Manual testing

## Related issue:
Fixes #261 

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally