### PR TITLE
refactor(services): remove unused get_project_by_id

### DIFF
--- a/dataloom-backend/app/services/project_service.py
+++ b/dataloom-backend/app/services/project_service.py
@@ -30,19 +30,6 @@ def create_project(db: Session, name: str, file_path: str, description: str) -> 
     return project
 
 
-def get_project_by_id(db: Session, project_id: uuid.UUID) -> models.Project | None:
-    """Fetch a project by its primary key.
-
-    Args:
-        db: Database session.
-        project_id: The project primary key.
-
-    Returns:
-        The Project model instance or None if not found.
-    """
-    return db.query(models.Project).filter(models.Project.project_id == project_id).first()
-
-
 def get_recent_projects(db: Session, limit: int = 3) -> list[models.Project]:
     """Fetch the most recently modified projects.
 


### PR DESCRIPTION
## Description

`get_project_by_id` in `project_service.py` was never called anywhere. Every endpoint uses `get_project_or_404` from `dependencies.py` instead, which has the same query but also raises a 404 if not found. Having both created confusion about which lookup path to use. This fixes #10 by deleting the unused function. The `uuid` import was kept since `log_transformation` and `create_checkpoint` still use `uuid.UUID` in their signatures.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

Grepped the entire codebase to confirm zero callers before deleting. Ran `uv run pytest` — 92 tests pass, same count as main. Ran `uv run ruff check .` and `uv run ruff format --check .` — both clean.

- [x] Existing tests pass
- [ ] New tests added
- [ ] Manual testing

## Related issue:
Fixes #263 

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally