### PR TITLE
fix(backend): update last_modified on checkpoint create

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,14 @@ Desktop.ini
 .env
 .env.local
 .env.*.local
+
+# Python bytecode (root-level scratch scripts, tools, etc.)
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Binary artifacts and scratch output
+*.pdf
+*.pid
+tmp/
+output/

--- a/dataloom-backend/app/services/project_service.py
+++ b/dataloom-backend/app/services/project_service.py
@@ -123,6 +123,11 @@ def create_checkpoint(db: Session, project_id: uuid.UUID, message: str) -> model
         log.applied = True
         log.checkpoint_id = checkpoint.id
 
+    project = db.query(models.Project).filter(models.Project.project_id == project_id).first()
+    if project:
+        project.last_modified = datetime.now(UTC)
+        db.add(project)
+
     db.commit()
     logger.info("Checkpoint created: id=%s, project_id=%s, logs_applied=%d", checkpoint.id, project_id, len(logs))
     return checkpoint

--- a/dataloom-backend/tests/test_last_modified.py
+++ b/dataloom-backend/tests/test_last_modified.py
@@ -13,6 +13,7 @@ from sqlmodel import Session, SQLModel, create_engine
 
 from app import models
 from app.services.project_service import (
+    create_checkpoint,
     create_project,
     get_recent_projects,
     log_transformation,
@@ -139,3 +140,79 @@ class TestLastModifiedUpdatesOnTransform:
         fake_id = uuid.uuid4()
         # Should not raise — the `if project:` guard handles the None case
         log_transformation(mem_db, fake_id, "addRow", {"row_params": {"index": 0}})
+
+
+class TestLastModifiedUpdatesOnCheckpoint:
+    """last_modified must advance each time create_checkpoint() is called."""
+
+    def test_last_modified_advances_after_checkpoint(self, mem_db):
+        project = _make_project(mem_db, "CP Basic")
+        ts_before = project.last_modified
+
+        time.sleep(0.05)
+        create_checkpoint(mem_db, project.project_id, "first save")
+
+        mem_db.refresh(project)
+        ts_after = project.last_modified
+
+        assert ts_after > ts_before, f"last_modified was not updated: before={ts_before}, after={ts_after}"
+
+    def test_checkpoint_after_transform_advances_timestamp(self, mem_db):
+        """A checkpoint following a transform should push last_modified forward again."""
+        project = _make_project(mem_db, "CP After Transform")
+
+        time.sleep(0.05)
+        log_transformation(
+            mem_db,
+            project.project_id,
+            "addRow",
+            {"operation_type": "addRow", "row_params": {"index": 0}},
+        )
+        mem_db.refresh(project)
+        ts_after_transform = project.last_modified
+
+        time.sleep(0.05)
+        create_checkpoint(mem_db, project.project_id, "save after transform")
+        mem_db.refresh(project)
+        ts_after_checkpoint = project.last_modified
+
+        assert ts_after_checkpoint > ts_after_transform, (
+            f"checkpoint did not advance last_modified: "
+            f"transform={ts_after_transform}, checkpoint={ts_after_checkpoint}"
+        )
+
+    def test_most_recently_checkpointed_project_appears_first_in_recent(self, mem_db):
+        """Project A, created first but checkpointed last, should lead /recent."""
+        project_a = _make_project(mem_db, "CP Order A")
+        time.sleep(0.05)
+        project_b = _make_project(mem_db, "CP Order B")
+
+        time.sleep(0.05)
+        create_checkpoint(mem_db, project_a.project_id, "save A")
+
+        recent = get_recent_projects(mem_db, limit=10)
+        ids = [str(p.project_id) for p in recent]
+
+        idx_a = ids.index(str(project_a.project_id))
+        idx_b = ids.index(str(project_b.project_id))
+
+        assert idx_a < idx_b, f"Project A (last checkpointed) should appear before B. Order: {ids}"
+
+    def test_checkpoint_still_marks_pending_logs_applied(self, mem_db):
+        """Adding last_modified update must not break the existing applied-logs behavior."""
+        project = _make_project(mem_db, "CP Logs")
+        log_transformation(
+            mem_db,
+            project.project_id,
+            "addRow",
+            {"operation_type": "addRow", "row_params": {"index": 0}},
+        )
+
+        checkpoint = create_checkpoint(mem_db, project.project_id, "save logs")
+
+        logs = (
+            mem_db.query(models.ProjectChangeLog).filter(models.ProjectChangeLog.project_id == project.project_id).all()
+        )
+        assert len(logs) == 1
+        assert logs[0].applied is True
+        assert logs[0].checkpoint_id == checkpoint.id


### PR DESCRIPTION
## Summary
Resubmit of closed PR #134 as a focused change.

While PR #134 was pending review, another contributor's fix for #66 (covering `log_transformation()` only) was merged to `main` on 2026-03-30. This PR submits the remaining half of the original fix — `create_checkpoint()` still leaves `last_modified` untouched, so saving a project does not bubble it to the top of Recent Projects. Pattern mirrors the already-merged `log_transformation()` update exactly.

## Changes
- `app/services/project_service.py`: update `last_modified` inside `create_checkpoint()`, mirroring the `log_transformation()` pattern already on `main`.
- `tests/test_last_modified.py`: add `TestLastModifiedUpdatesOnCheckpoint` with four cases — basic advance, transform→checkpoint ordering, `/recent` ordering, and applied-logs preservation.
- Root `.gitignore`: add `__pycache__/`, `*.py[cod]`, `*.pdf`, `*.pid`, `tmp/`, `output/`. These directly cover the contamination paths that closed PR #134 (root-level `tmp/pdfs/**`, `output/pdf/*.pdf`, `tmp/pdfs/__pycache__/`, `dataloom-backend/app.pid`). Backend `.gitignore` already covers bytecode inside the backend subtree; these rules extend coverage to repo root.

Fixes the checkpoint half of #66.

## Branch hygiene
- Branched from current `main` (no inherited history from PR #134).
- Single focused commit, +93 / -0 lines across 3 files.
- No PDFs, bytecode, `tmp/`, `uploads/`, or other binary artifacts in the diff.

## Test plan
- [x] `pytest tests/test_last_modified.py -v` — 10/10 pass (6 existing transform cases + 4 new checkpoint cases)
- [x] `ruff check` + `ruff format --check` on both touched files — clean
- [ ] Manual: create project → save → verify project jumps to top of Recent Projects