### PR TITLE
fix(backend): ensure SQLModel metadata is populated via model import

### DIFF
--- a/dataloom-backend/app/database.py
+++ b/dataloom-backend/app/database.py
@@ -4,6 +4,7 @@ from collections.abc import Generator
 from sqlalchemy.exc import OperationalError
 from sqlmodel import Session, create_engine, text
 
+import app.models  # noqa: F401 — ensures SQLModel.metadata is populated
 from app.config import get_settings
 
 settings = get_settings()


### PR DESCRIPTION
Fix: Ensure SQLModel metadata is consistently populated

Although Alembic env.py imports app.models, database.py did not. This creates a subtle risk where SQLModel.metadata may remain empty if database.py is imported independently (e.g., in tests or scripts).

### Change
- Added import app.models in database.py to guarantee model registration

### Impact
- Prevents missing metadata in non-Alembic contexts
- Improves robustness without altering architecture

### Note
Re-submitting as a fresh PR after previous PR (#240) was closed due to outdated base.