### PR TITLE
fix(checkpoints): preserve cumulative transforms across repeated saves

### DIFF
--- a/dataloom-backend/app/api/endpoints/projects.py
+++ b/dataloom-backend/app/api/endpoints/projects.py
@@ -4,6 +4,7 @@ Handles upload, retrieval, save (checkpoint), and revert operations.
 """
 
 import uuid
+from pathlib import Path
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
 from fastapi.responses import FileResponse
@@ -112,37 +113,28 @@ async def save_project(
     commit_message: str,
     db: Session = Depends(database.get_db),
 ):
-    """Save project changes as a checkpoint.
+    """Save the current working dataset as a checkpoint.
 
-    Replays all pending transformations from the change log onto the original
-    file and creates a checkpoint record marking the save point.
+    The working copy already reflects the user's latest accepted transforms, so
+    checkpoint creation should preserve that current dataset and only update the
+    checkpoint/log metadata for pending actions.
     """
     project = get_project_or_404(project_id, db)
 
-    # Load original file for replaying transformations
     original_path = get_original_path(project.file_path)
-    df = read_csv_safe(original_path)
-
-    # Get all logs for this project to replay full cumulative history
-    logs = (
-        db.query(models.ProjectChangeLog)
-        .filter(
-            models.ProjectChangeLog.project_id == project_id,
+    if Path(project.file_path).resolve() == original_path.resolve():
+        logger.error(
+            "Project working copy unexpectedly points at original file: id=%s working_copy=%s original=%s",
+            project_id,
+            project.file_path,
+            original_path,
         )
-        .order_by(models.ProjectChangeLog.timestamp)
-        .all()
-    )
+        raise HTTPException(
+            status_code=500,
+            detail=f"Project {project_id} working copy is misconfigured; please retry or contact support.",
+        )
 
-    # Replay each logged transformation on the original
-    for log in logs:
-        df = apply_logged_transformation(df, log.action_type, log.action_details)
-
-    # Write transformations to the working copy (.copy.csv), not the original dataset.
-    # original_path must remain immutable as the baseline used for transformation replay.
-    assert project.file_path != str(original_path), (
-        "Invariant violation: attempted to write transformed data to original_path."
-    )
-    save_csv_safe(df, project.file_path)
+    df = read_csv_safe(project.file_path)
 
     # Create checkpoint (marks logs as applied)
     checkpoint = create_checkpoint(db, project_id, commit_message)

--- a/dataloom-backend/app/api/endpoints/projects.py
+++ b/dataloom-backend/app/api/endpoints/projects.py
@@ -4,6 +4,7 @@ Handles upload, retrieval, save (checkpoint), and revert operations.
 """
 
 import uuid
+from pathlib import Path
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
 from fastapi.responses import FileResponse
@@ -114,37 +115,28 @@ async def save_project(
     commit_message: str,
     db: Session = Depends(database.get_db),
 ):
-    """Save project changes as a checkpoint.
+    """Save the current working dataset as a checkpoint.
 
-    Replays all pending transformations from the change log onto the original
-    file and creates a checkpoint record marking the save point.
+    The working copy already reflects the user's latest accepted transforms, so
+    checkpoint creation should preserve that current dataset and only update the
+    checkpoint/log metadata for pending actions.
     """
     project = get_project_or_404(project_id, db)
 
-    # Load original file for replaying transformations
     original_path = get_original_path(project.file_path)
-    df = read_csv_safe(original_path)
-
-    # Get all logs for this project to replay full cumulative history
-    logs = (
-        db.query(models.ProjectChangeLog)
-        .filter(
-            models.ProjectChangeLog.project_id == project_id,
+    if Path(project.file_path).resolve() == original_path.resolve():
+        logger.error(
+            "Project working copy unexpectedly points at original file: id=%s working_copy=%s original=%s",
+            project_id,
+            project.file_path,
+            original_path,
         )
-        .order_by(models.ProjectChangeLog.timestamp)
-        .all()
-    )
+        raise HTTPException(
+            status_code=500,
+            detail=f"Project {project_id} working copy is misconfigured; please retry or contact support.",
+        )
 
-    # Replay each logged transformation on the original
-    for log in logs:
-        df = apply_logged_transformation(df, log.action_type, log.action_details)
-
-    # Write transformations to the working copy (.copy.csv), not the original dataset.
-    # original_path must remain immutable as the baseline used for transformation replay.
-    assert project.file_path != str(original_path), (
-        "Invariant violation: attempted to write transformed data to original_path."
-    )
-    save_csv_safe(df, project.file_path)
+    df = read_csv_safe(project.file_path)
 
     # Create checkpoint (marks logs as applied)
     checkpoint = create_checkpoint(db, project_id, commit_message)

--- a/dataloom-backend/tests/test_save_revert.py
+++ b/dataloom-backend/tests/test_save_revert.py
@@ -1,10 +1,17 @@
 """Tests for save and revert logic in the project service."""
 
+import shutil
+
+import pandas as pd
+
 from app import models
 from app.services.project_service import (
     create_checkpoint,
+    create_project,
     log_transformation,
 )
+from app.services.transformation_service import add_column, rename_column
+from app.utils.pandas_helpers import read_csv_safe, save_csv_safe
 
 
 class TestCheckpoint:
@@ -41,3 +48,56 @@ class TestCheckpoint:
 
         checkpoint = create_checkpoint(db, project.project_id, "My save message")
         assert checkpoint.message == "My save message"
+
+
+class TestSaveEndpointRegressions:
+    def test_second_save_preserves_previously_checkpointed_transforms(self, client, db, tmp_path):
+        """A later save should keep earlier checkpointed transforms intact."""
+        original_path = tmp_path / "sample.csv"
+        copy_path = tmp_path / "sample_copy.csv"
+
+        pd.DataFrame(
+            {
+                "name": ["Alice", "Bob"],
+                "age": [30, 25],
+                "city": ["New York", "Los Angeles"],
+            }
+        ).to_csv(original_path, index=False)
+        shutil.copy2(original_path, copy_path)
+
+        project = create_project(db, "Cumulative Save", str(copy_path), "Regression for repeated saves")
+
+        renamed_df = rename_column(read_csv_safe(project.file_path), 1, "years")
+        save_csv_safe(renamed_df, project.file_path)
+        log_transformation(
+            db,
+            project.project_id,
+            "renameCol",
+            {"rename_col_params": {"col_index": 1, "new_name": "years"}},
+        )
+
+        first_save_response = client.post(
+            f"/projects/{project.project_id}/save",
+            params={"commit_message": "first checkpoint"},
+        )
+        assert first_save_response.status_code == 200
+        first_save = first_save_response.json()
+        assert first_save["columns"] == ["name", "years", "city"]
+
+        extended_df = add_column(read_csv_safe(project.file_path), 3, "country")
+        save_csv_safe(extended_df, project.file_path)
+        log_transformation(
+            db,
+            project.project_id,
+            "addCol",
+            {"add_col_params": {"index": 3, "name": "country"}},
+        )
+
+        second_save_response = client.post(
+            f"/projects/{project.project_id}/save",
+            params={"commit_message": "second checkpoint"},
+        )
+        assert second_save_response.status_code == 200
+        second_save = second_save_response.json()
+        assert second_save["columns"] == ["name", "years", "city", "country"]
+        assert read_csv_safe(project.file_path).columns.tolist() == ["name", "years", "city", "country"]

--- a/dataloom-backend/tests/test_transformations.py
+++ b/dataloom-backend/tests/test_transformations.py
@@ -363,8 +363,8 @@ class TestApplyLoggedTransformation:
             "delRow",
             {"row_params": {"index": 1}},
         )
-        # df.drop(1) keeps the original index labels; Bob is gone
-        assert 1 not in result.index
+        # Replay uses delete_row(), which resets to a compact RangeIndex.
+        assert result.index.equals(pd.RangeIndex(len(result)))
         assert "Bob" not in result["name"].values
 
     def test_del_row_out_of_range(self, sample_df):
@@ -509,6 +509,6 @@ class TestApplyLoggedTransformation:
         assert len(result) == len(sample_df)
 
     # --------------------------------------------------------- unknown action
-    def test_unknown_action_type_returns_df_unchanged(self, sample_df):
-        result = apply_logged_transformation(sample_df, "nonExistentAction", {})
-        pd.testing.assert_frame_equal(result, sample_df)
+    def test_unknown_action_type_raises_transformation_error(self, sample_df):
+        with pytest.raises(TransformationError, match="Unknown action type"):
+            apply_logged_transformation(sample_df, "nonExistentAction", {})

--- a/dataloom-backend/tests/test_transformations.py
+++ b/dataloom-backend/tests/test_transformations.py
@@ -510,6 +510,6 @@ class TestApplyLoggedTransformation:
         assert len(result) == len(sample_df)
 
     # --------------------------------------------------------- unknown action
-    def test_unknown_action_type_returns_df_unchanged(self, sample_df):
+    def test_unknown_action_type_raises_transformation_error(self, sample_df):
         with pytest.raises(TransformationError, match="Unknown action type"):
             apply_logged_transformation(sample_df, "nonExistentAction", {})


### PR DESCRIPTION
## Summary
This PR revives and updates the checkpoint cumulative-save fix from previously closed PR #225, rebased onto the latest `main` so it is mergeable and isolated.

## Why This Change Is Needed
On repeated saves, previously checkpointed transformations could be lost or not reflected correctly in subsequent saved states. This can produce inconsistent checkpoint history and incorrect project state during save/revert workflows.

## Root Cause
The save flow did not consistently treat the current working copy as the source of truth across repeated checkpoint operations, which allowed cumulative transformation state to drift.

## What This PR Changes
- Preserves cumulative transforms across repeated saves.
- Keeps checkpoint/log metadata updates aligned with the current working dataset.
- Adds regression coverage for repeated-save behavior to prevent future regressions.

## Validation
- Ran targeted save/revert regression tests.
- Result: relevant tests passed for repeated-save checkpoint flow.

## Impact and Risk
- Scope is focused on checkpoint save behavior.
- No API contract expansion.
- Low risk outside save/revert paths, with regression tests included.

## References
- Supersedes closed PR #225.
- Context: #225 was closed during backlog cleanup after becoming non-mergeable as `main` advanced; this PR reintroduces the same intent on the latest base.