### PR TITLE
feat: redesign transformation forms UI, add data export, and fix filter persistence

### DIFF
--- a/dataloom-backend/app/api/endpoints/transformations.py
+++ b/dataloom-backend/app/api/endpoints/transformations.py
@@ -38,7 +38,7 @@ def _handle_basic_transform(df, transformation_input, project, db, project_id):
         if not transformation_input.parameters:
             raise HTTPException(status_code=400, detail="Filter parameters required")
         p = transformation_input.parameters
-        return ts.apply_filter(df, p.column, p.condition, p.value), False
+        return ts.apply_filter(df, p.column, p.condition, p.value), transformation_input.persist
 
     elif op == "sort":
         if not transformation_input.sort_params:

--- a/dataloom-backend/app/schemas.py
+++ b/dataloom-backend/app/schemas.py
@@ -262,6 +262,7 @@ class TransformationInput(BaseModel):
 
     groupby_params: GroupByParams | None = None
     operation_type: OperationType
+    persist: bool = True
     parameters: FilterParameters | None = None
     sort_params: SortParameters | None = None
     row_params: AddOrDeleteRow | None = None

--- a/dataloom-backend/app/services/transformation_service.py
+++ b/dataloom-backend/app/services/transformation_service.py
@@ -566,6 +566,10 @@ def apply_logged_transformation(df: pd.DataFrame, action_type: str, action_detai
         keep = action_details["drop_duplicate"]["keep"]
         return drop_duplicates(df, columns, keep)
 
+    elif action_type == "filter":
+        params = action_details["parameters"]
+        return apply_filter(df, params["column"], params["condition"], params["value"])
+
     elif action_type == "renameCol":
         col_index = action_details["rename_col_params"]["col_index"]
         new_name = action_details["rename_col_params"]["new_name"]

--- a/dataloom-backend/tests/test_save_project.py
+++ b/dataloom-backend/tests/test_save_project.py
@@ -48,3 +48,36 @@ class TestSaveNeverModifiesOriginal:
         # Original file must be byte-identical
         hash_after = _file_sha256(original_path)
         assert hash_before == hash_after, "original_path was modified by a save operation"
+
+
+class TestSaveWithFilterReplay:
+    """Save should successfully replay and persist logged filter transformations."""
+
+    def test_save_after_filter_keeps_filtered_rows(self, client, sample_csv):
+        with open(sample_csv, "rb") as f:
+            upload_resp = client.post(
+                "/projects/upload",
+                files={"file": ("test.csv", f, "text/csv")},
+                data={"projectName": "Filter Save Test", "projectDescription": "filter replay"},
+            )
+        assert upload_resp.status_code == 200
+        project_id = upload_resp.json()["project_id"]
+
+        filter_resp = client.post(
+            f"/projects/{project_id}/transform",
+            json={
+                "operation_type": "filter",
+                "parameters": {"column": "name", "condition": "=", "value": "Alice"},
+            },
+        )
+        assert filter_resp.status_code == 200
+        assert len(filter_resp.json()["rows"]) == 2
+
+        save_resp = client.post(f"/projects/{project_id}/save?commit_message=save-filter")
+        assert save_resp.status_code == 200
+
+        details_resp = client.get(f"/projects/get/{project_id}")
+        assert details_resp.status_code == 200
+        details = details_resp.json()
+        assert details["total_rows"] == 2
+        assert all(row[0] == "Alice" for row in details["rows"])

--- a/dataloom-backend/tests/test_transformations.py
+++ b/dataloom-backend/tests/test_transformations.py
@@ -363,9 +363,9 @@ class TestApplyLoggedTransformation:
             "delRow",
             {"row_params": {"index": 1}},
         )
-        # df.drop(1) keeps the original index labels; Bob is gone
-        assert 1 not in result.index
+        # delete_row resets to a RangeIndex for save/checkpoint replay consistency.
         assert "Bob" not in result["name"].values
+        assert result.index.equals(pd.RangeIndex(len(result)))
 
     def test_del_row_out_of_range(self, sample_df):
         with pytest.raises(TransformationError, match="out of range"):
@@ -509,6 +509,6 @@ class TestApplyLoggedTransformation:
         assert len(result) == len(sample_df)
 
     # --------------------------------------------------------- unknown action
-    def test_unknown_action_type_returns_df_unchanged(self, sample_df):
-        result = apply_logged_transformation(sample_df, "nonExistentAction", {})
-        pd.testing.assert_frame_equal(result, sample_df)
+    def test_unknown_action_type_raises(self, sample_df):
+        with pytest.raises(TransformationError, match="Unknown action type"):
+            apply_logged_transformation(sample_df, "nonExistentAction", {})

--- a/dataloom-frontend/package-lock.json
+++ b/dataloom-frontend/package-lock.json
@@ -9,12 +9,15 @@
       "version": "0.0.0",
       "dependencies": {
         "axios": "^1.7.2",
+        "jspdf": "^4.2.1",
+        "jspdf-autotable": "^5.0.7",
         "lucide-react": "^0.575.0",
         "prop-types": "^15.8.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-icons": "^5.2.1",
-        "react-router-dom": "^6.24.0"
+        "react-router-dom": "^6.24.0",
+        "xlsx": "^0.18.5"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.4.2",
@@ -316,7 +319,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
       "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1621,12 +1623,25 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "license": "MIT"
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/react": {
       "version": "18.3.28",
@@ -1648,6 +1663,13 @@
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
@@ -1884,6 +1906,15 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/agent-base": {
@@ -2219,6 +2250,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
@@ -2403,6 +2444,39 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/chai": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
@@ -2490,6 +2564,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2553,6 +2636,30 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2566,6 +2673,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/css.escape": {
@@ -2860,6 +2977,16 @@
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz",
+      "integrity": "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optional": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -3469,6 +3596,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-png": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
+      "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pako": "^2.0.3",
+        "iobuffer": "^5.3.2",
+        "pako": "^2.1.0"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -3478,6 +3616,12 @@
       "dependencies": {
         "reusify": "^1.0.4"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
@@ -3594,6 +3738,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/fraction.js": {
@@ -3961,6 +4114,20 @@
         "node": ">=18"
       }
     },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -4092,6 +4259,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/iobuffer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
+      "license": "MIT"
     },
     "node_modules/is-arguments": {
       "version": "1.2.0",
@@ -4692,6 +4865,32 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jspdf": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
+      "integrity": "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "fast-png": "^6.2.0",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.11",
+        "core-js": "^3.6.0",
+        "dompurify": "^3.3.1",
+        "html2canvas": "^1.0.0-rc.5"
+      }
+    },
+    "node_modules/jspdf-autotable": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/jspdf-autotable/-/jspdf-autotable-5.0.7.tgz",
+      "integrity": "sha512-2wr7H6liNDBYNwt25hMQwXkEWFOEopgKIvR1Eukuw6Zmprm/ZcnmLTQEjW7Xx3FCbD3v7pflLcnMAv/h1jFDQw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "jspdf": "^2 || ^3 || ^4"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -5317,6 +5516,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -5396,6 +5601,13 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -5778,6 +5990,16 @@
       ],
       "license": "MIT"
     },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -5921,6 +6143,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
@@ -5992,6 +6221,16 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
       }
     },
     "node_modules/rimraf": {
@@ -6359,12 +6598,34 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
     },
     "node_modules/std-env": {
       "version": "3.10.0",
@@ -6606,6 +6867,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -6670,6 +6941,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/text-table": {
@@ -7035,6 +7316,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
+      }
+    },
     "node_modules/vite": {
       "version": "5.4.21",
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
@@ -7367,6 +7658,24 @@
         "node": ">=8"
       }
     },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -7404,6 +7713,27 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/xml-name-validator": {

--- a/dataloom-frontend/package.json
+++ b/dataloom-frontend/package.json
@@ -13,12 +13,15 @@
   },
   "dependencies": {
     "axios": "^1.7.2",
+    "jspdf": "^4.2.1",
+    "jspdf-autotable": "^5.0.7",
     "lucide-react": "^0.575.0",
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^5.2.1",
-    "react-router-dom": "^6.24.0"
+    "react-router-dom": "^6.24.0",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.4.2",

--- a/dataloom-frontend/src/Components/DataScreen.jsx
+++ b/dataloom-frontend/src/Components/DataScreen.jsx
@@ -18,6 +18,9 @@ export default function DataScreen() {
 
   const handleTransform = (data) => {
     setTableData(data);
+    if (projectId) {
+      refreshProject(projectId);
+    }
   };
 
   return (

--- a/dataloom-frontend/src/Components/Homescreen.jsx
+++ b/dataloom-frontend/src/Components/Homescreen.jsx
@@ -21,7 +21,7 @@ const ProjectCard = ({ project, onClick, onDelete }) => {
           e.stopPropagation();
           onDelete(project.project_id);
         }}
-        className="absolute top-2 right-2 text-gray-400 hover:text-red-500 transition-colors duration-150 p-1 rounded-md hover:bg-red-50"
+        className="absolute top-2 right-2 text-gray-400 hover:text-red-500 transition-colors duration-150 p-1 rounded-lg hover:bg-red-50"
         aria-label="Delete project"
       >
         <svg
@@ -59,7 +59,7 @@ const NewProjectCard = ({ onClick }) => (
 const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024; // 10 MB
 
 const EmptyState = ({ onClick }) => (
-  <div className="flex flex-col items-center justify-center py-16 px-6 rounded-xl border-2 border-dashed border-gray-200 bg-gray-50 text-center">
+  <div className="flex flex-col items-center justify-center py-16 px-6 rounded-lg border-2 border-dashed border-gray-200 bg-gray-50 text-center">
     <div className="mb-4 flex items-center justify-center w-16 h-16 rounded-full bg-blue-50">
       <svg
         xmlns="http://www.w3.org/2000/svg"
@@ -107,6 +107,16 @@ const HomeScreen = () => {
   const isFormValid =
     projectName.trim().length > 0 && projectDescription.trim().length > 0 && fileUpload !== null;
 
+  const handleCloseModal = useCallback(() => {
+    setShowModal(false);
+    setProjectName("");
+    setProjectDescription("");
+    setFileUpload(null);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+  }, []);
+
   useEffect(() => {
     fetchRecentProjects();
   }, []);
@@ -132,16 +142,6 @@ const HomeScreen = () => {
   const handleNewProjectClick = () => {
     setShowModal(true);
   };
-
-  const handleCloseModal = useCallback(() => {
-    setShowModal(false);
-    setProjectName("");
-    setProjectDescription("");
-    setFileUpload(null);
-    if (fileInputRef.current) {
-      fileInputRef.current.value = "";
-    }
-  }, []);
 
   const handleSubmitModal = async (event) => {
     event.preventDefault();
@@ -299,7 +299,7 @@ const HomeScreen = () => {
             onClick={isSubmitting ? undefined : handleCloseModal}
             aria-hidden="true"
           ></div>
-          <div className="bg-white rounded-xl shadow-xl p-8 z-50 max-w-lg w-full mx-4">
+          <div className="bg-white rounded-lg shadow-xl p-8 z-50 max-w-lg w-full mx-4">
             <h2 id="modal-title" className="text-xl font-semibold text-gray-900 mb-6">
               New Project
             </h2>
@@ -359,14 +359,14 @@ const HomeScreen = () => {
             </div>
             <div className="flex flex-row justify-end gap-3 mt-6">
               <button
-                className="px-4 py-2 bg-white border border-gray-300 text-gray-700 hover:bg-gray-50 rounded-md text-sm font-medium transition-colors duration-150 disabled:opacity-50 disabled:cursor-not-allowed"
+                className="px-4 py-2 bg-white border border-gray-300 text-gray-700 hover:bg-gray-50 rounded-lg text-sm font-medium transition-colors duration-150 disabled:opacity-50 disabled:cursor-not-allowed"
                 onClick={handleCloseModal}
                 disabled={isSubmitting}
               >
                 Cancel
               </button>
               <button
-                className="px-4 py-2 bg-blue-500 hover:bg-blue-600 text-white rounded-md text-sm font-medium transition-colors duration-150 disabled:opacity-50 disabled:cursor-not-allowed"
+                className="px-4 py-2 bg-blue-500 hover:bg-blue-600 text-white rounded-lg text-sm font-medium transition-colors duration-150 disabled:opacity-50 disabled:cursor-not-allowed"
                 onClick={handleSubmitModal}
                 disabled={!isFormValid || isSubmitting}
               >

--- a/dataloom-frontend/src/Components/MenuNavbar.jsx
+++ b/dataloom-frontend/src/Components/MenuNavbar.jsx
@@ -47,6 +47,7 @@ const MenuNavbar = ({ projectId, onTransform }) => {
   const [logs, setLogs] = useState([]);
   const [checkpoints, setCheckpoints] = useState(null);
   const [isInputOpen, setIsInputOpen] = useState(false);
+  const [pendingSaveResolver, setPendingSaveResolver] = useState(null);
   const [confirmData, setConfirmData] = useState(null);
   const [toast, setToast] = useState(null);
 
@@ -76,10 +77,22 @@ const MenuNavbar = ({ projectId, onTransform }) => {
 
   const handleSave = () => {
     setIsInputOpen(true);
+    setPendingSaveResolver(null);
   };
+
+  const requestSaveMessage = () =>
+    new Promise((resolve) => {
+      setPendingSaveResolver(() => resolve);
+      setIsInputOpen(true);
+    });
 
   const handleSubmitCommit = async (message) => {
     setIsInputOpen(false);
+    if (pendingSaveResolver) {
+      pendingSaveResolver(message || null);
+      setPendingSaveResolver(null);
+      return;
+    }
     if (!message) return;
 
     try {
@@ -304,7 +317,7 @@ const MenuNavbar = ({ projectId, onTransform }) => {
                     <button
                       key={item.label}
                       onClick={item.onClick}
-                      className={`flex flex-col items-center gap-1 px-3 py-1.5 rounded-md ${
+                      className={`flex flex-col items-center gap-1 px-3 py-1.5 rounded-lg ${
                         isActive ? "bg-blue-50 text-blue-600" : "hover:bg-gray-100"
                       }`}
                     >
@@ -333,6 +346,8 @@ const MenuNavbar = ({ projectId, onTransform }) => {
             setActiveForm(null);
           }}
           projectId={projectId}
+          onTransform={onTransform}
+          onSave={requestSaveMessage}
         />
       )}
       {showSortForm && (
@@ -342,6 +357,8 @@ const MenuNavbar = ({ projectId, onTransform }) => {
             setActiveForm(null);
           }}
           projectId={projectId}
+          onTransform={onTransform}
+          onSave={requestSaveMessage}
         />
       )}
       {showDropDuplicateForm && (
@@ -361,6 +378,8 @@ const MenuNavbar = ({ projectId, onTransform }) => {
             setActiveForm(null);
           }}
           projectId={projectId}
+          onTransform={onTransform}
+          onSave={requestSaveMessage}
         />
       )}
       {showPivotTableForm && (
@@ -370,9 +389,21 @@ const MenuNavbar = ({ projectId, onTransform }) => {
             setActiveForm(null);
           }}
           projectId={projectId}
+          onTransform={onTransform}
+          onSave={requestSaveMessage}
         />
       )}
-      {showMeltForm && <MeltForm onClose={() => setShowMeltForm(false)} projectId={projectId} />}
+      {showMeltForm && (
+        <MeltForm
+          projectId={projectId}
+          onClose={() => {
+            setShowMeltForm(false);
+            setActiveForm(null);
+          }}
+          onTransform={onTransform}
+          onSave={requestSaveMessage}
+        />
+      )}
       {showCastDataTypeForm && (
         <CastDataTypeForm
           projectId={projectId}
@@ -427,7 +458,13 @@ const MenuNavbar = ({ projectId, onTransform }) => {
         isOpen={isInputOpen}
         message="Enter a commit message for this save:"
         onSubmit={handleSubmitCommit}
-        onCancel={() => setIsInputOpen(false)}
+        onCancel={() => {
+          setIsInputOpen(false);
+          if (pendingSaveResolver) {
+            pendingSaveResolver(null);
+            setPendingSaveResolver(null);
+          }
+        }}
       />
 
       <ConfirmDialog

--- a/dataloom-frontend/src/Components/Table.jsx
+++ b/dataloom-frontend/src/Components/Table.jsx
@@ -245,79 +245,101 @@ const Table = ({ projectId, data: externalData }) => {
   };
 
   return (
-    <div className="px-8 pt-3">
-      <div
-        className="overflow-x-scroll overflow-y-auto border border-gray-200 rounded-lg shadow-sm"
-        style={{ maxHeight: "calc(100vh - 140px)" }}
-      >
-        <table className="min-w-full bg-white">
-          <thead className="sticky top-0 bg-gray-50">
-            <tr>
-              {columns.map((column, columnIndex) => (
-                <th
-                  key={columnIndex}
-                  className="py-1.5 px-3 border-b border-gray-200 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
-                  onContextMenu={(e) => open(e, { type: "column", columnIndex })}
-                >
-                  <button className="w-full text-left text-gray-500 hover:text-gray-700 hover:bg-gray-100 py-0.5 px-1.5 rounded-md transition-colors duration-150">
-                    {column}
-                    {column !== "S.No." && <DtypeBadge dtype={dtypes[column]} />}
-                  </button>
-                </th>
-              ))}
-            </tr>
-          </thead>
+    <div className="px-8 pt-6 pb-8">
+      <div className="flex flex-col border border-gray-200 rounded-lg shadow-sm bg-white overflow-hidden">
+        {/* Header Bar */}
+        <div className="bg-gray-50 border-b border-gray-200 px-4 py-3">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+            <div className="flex flex-wrap items-center gap-2 text-sm">
+              <span className="font-semibold text-slate-800">Original dataset</span>
+              <span className="text-slate-300">/</span>
+              <span className="font-medium text-slate-700">{totalRows} rows</span>
+              <span className="text-slate-300">/</span>
+              <span className="font-medium text-slate-700">{ctxColumns.length} columns</span>
+              <span className="text-xs text-slate-500">
+                Primary workspace. All modifications are automatically tracked.
+              </span>
+            </div>
+          </div>
+        </div>
 
-          <tbody>
-            {data.map((row, rowIndex) => (
-              <tr
-                key={rowIndex}
-                className="border-b border-gray-100 hover:bg-gray-50 transition-colors duration-150"
-              >
-                {row.map((cell, cellIndex) => (
-                  <td
-                    key={cellIndex}
-                    className="py-1 px-3 text-xs text-gray-700"
-                    onContextMenu={(e) => open(e, { type: "row", rowIndex })}
+        {/* Table Container */}
+        <div
+          className="overflow-x-auto overflow-y-auto"
+          style={{ maxHeight: "calc(100vh - 240px)" }}
+        >
+          <table className="min-w-full bg-white divide-y divide-gray-200">
+            <thead className="sticky top-0 bg-gray-50 z-10">
+              <tr>
+                {columns.map((column, columnIndex) => (
+                  <th
+                    key={columnIndex}
+                    className={`py-3 border-b border-gray-200 text-sm font-semibold text-gray-600 uppercase tracking-tight whitespace-nowrap bg-gray-50 ${columnIndex === 0 ? "pl-4 pr-2 text-left" : "px-4 text-left"}`}
+                    onContextMenu={(e) => open(e, { type: "column", columnIndex })}
                   >
-                    {editingCell &&
-                    editingCell.rowIndex === rowIndex &&
-                    editingCell.cellIndex === cellIndex ? (
-                      <input
-                        type="text"
-                        value={editValue}
-                        onChange={(e) => setEditValue(e.target.value)}
-                        onBlur={() => handleEditCell(rowIndex, cellIndex, editValue)}
-                        className="w-full p-1 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none"
-                        onKeyDown={(e) => handleInputKeyDown(e, rowIndex, cellIndex)}
-                      />
-                    ) : (
-                      <div
-                        onClick={() => handleCellClick(rowIndex, cellIndex, cell)}
-                        className={
-                          cellIndex !== 0 ? "cursor-pointer hover:bg-gray-50 p-1 rounded" : ""
-                        }
-                      >
-                        {cell}
-                      </div>
-                    )}
-                  </td>
+                    <button
+                      className={`flex items-center gap-2 text-gray-600 hover:text-gray-900 hover:bg-gray-100 py-1 px-2 rounded-lg transition-colors duration-150 ${columnIndex === 0 ? "text-left" : ""}`}
+                    >
+                      {column}
+                      {column !== "S.No." && <DtypeBadge dtype={dtypes[column]} />}
+                    </button>
+                  </th>
                 ))}
               </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
+            </thead>
 
-      <div className="fixed bottom-0 left-0 right-0 bg-white shadow-lg border-t border-gray-200 z-10">
-        <TablePagination
-          totalRows={totalRows}
-          totalPages={totalPages}
-          page={page}
-          pageSize={pageSize}
-          onPageChange={handlePageChange}
-          onPageSizeChange={handlePageSizeChange}
-        />
+            <tbody className="divide-y divide-gray-100">
+              {data.map((row, rowIndex) => (
+                <tr key={rowIndex} className="hover:bg-slate-50 transition-colors duration-150">
+                  {row.map((cell, cellIndex) => (
+                    <td
+                      key={cellIndex}
+                      className={`py-2.5 text-sm text-gray-700 border-r border-gray-50 last:border-r-0 ${cellIndex === 0 ? "pl-4 pr-2 text-left" : "px-4 text-left"}`}
+                      onContextMenu={(e) => open(e, { type: "row", rowIndex })}
+                    >
+                      {editingCell &&
+                      editingCell.rowIndex === rowIndex &&
+                      editingCell.cellIndex === cellIndex ? (
+                        <input
+                          type="text"
+                          value={editValue}
+                          onChange={(e) => setEditValue(e.target.value)}
+                          onBlur={() => handleEditCell(rowIndex, cellIndex, editValue)}
+                          autoFocus
+                          className="w-full p-1.5 border border-blue-400 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none bg-blue-50/50 text-sm"
+                          onKeyDown={(e) => handleInputKeyDown(e, rowIndex, cellIndex)}
+                        />
+                      ) : (
+                        <div
+                          onClick={() => handleCellClick(rowIndex, cellIndex, cell)}
+                          className={
+                            cellIndex !== 0
+                              ? "cursor-pointer hover:bg-white hover:shadow-sm hover:ring-1 hover:ring-gray-200 p-1.5 rounded transition-all truncate"
+                              : "p-1.5 text-gray-400 font-mono text-xs text-left"
+                          }
+                        >
+                          {cell}
+                        </div>
+                      )}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        {/* Pagination Bar - Now part of the card */}
+        <div className="border-t border-gray-200 bg-white">
+          <TablePagination
+            totalRows={totalRows}
+            totalPages={totalPages}
+            page={page}
+            pageSize={pageSize}
+            onPageChange={handlePageChange}
+            onPageSizeChange={handlePageSizeChange}
+          />
+        </div>
       </div>
 
       <ContextMenu
@@ -393,7 +415,7 @@ export function TablePagination({
   onPageSizeChange,
 }) {
   const [pageSizeOpen, setPageSizeOpen] = useState(false);
-  const pageSizeOptions = [10, 25, 50, 100];
+  const pageSizeOptions = [10, 25, 50, 100, "All"];
 
   const handlePrevious = () => {
     if (page > 1) {
@@ -411,35 +433,40 @@ export function TablePagination({
     <div className="flex items-center justify-between px-8 py-3 bg-white">
       <div className="flex items-center gap-6 text-sm text-gray-600">
         <div className="flex items-center gap-2">
-          <span className="text-gray-500">Total Rows:</span>
-          <span className="text-gray-900">{totalRows}</span>
+          <span className="text-gray-500 font-medium">Total Rows:</span>
+          <span className="text-gray-900 font-semibold">{totalRows}</span>
         </div>
         <div className="flex items-center gap-2">
-          <span className="text-gray-500">Page:</span>
-          <span className="text-gray-900">
+          <span className="text-gray-500 font-medium">Page:</span>
+          <span className="text-gray-900 font-semibold">
             {page} of {totalPages}
           </span>
         </div>
         <div className="flex items-center gap-2 relative">
-          <span className="text-gray-500">Page Size:</span>
+          <span className="text-gray-500 font-medium">Page Size:</span>
           <div className="relative inline-block">
             <button
               onClick={() => setPageSizeOpen(!pageSizeOpen)}
-              className="border-2 border-gray-300 rounded-md px-4 py-1 text-sm min-w-[40px] text-center focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="border-2 border-gray-100 rounded-lg px-3 py-1 text-sm min-w-[60px] text-center font-medium hover:border-blue-400 hover:text-blue-600 transition-all focus:outline-none focus:ring-2 focus:ring-blue-100 bg-gray-50/50"
             >
-              {pageSize}
+              {pageSize === totalRows && totalRows > 0 ? "All" : pageSize}
             </button>
 
             {pageSizeOpen && (
-              <div className="absolute bottom-full mb-1 min-w-[60px] bg-white border-2 border-gray-300 rounded-lg shadow-lg z-10">
+              <div className="absolute bottom-full mb-2 min-w-[80px] bg-white border border-gray-200 rounded-lg shadow-xl z-20 py-1.5 overflow-hidden">
                 {pageSizeOptions.map((size) => (
                   <div
                     key={size}
                     onClick={() => {
-                      onPageSizeChange(size);
+                      const actualSize = size === "All" ? totalRows : size;
+                      onPageSizeChange(actualSize);
                       setPageSizeOpen(false);
                     }}
-                    className="px-4 py-2 text-sm hover:bg-blue-50 hover:text-blue-700 cursor-pointer rounded-md"
+                    className={`px-4 py-2 text-sm cursor-pointer transition-colors ${
+                      (size === "All" && pageSize === totalRows) || size === pageSize
+                        ? "bg-blue-50 text-blue-700 font-semibold"
+                        : "text-gray-600 hover:bg-slate-50 hover:text-blue-600"
+                    }`}
                   >
                     {size}
                   </div>
@@ -454,7 +481,7 @@ export function TablePagination({
         <button
           onClick={handlePrevious}
           disabled={page === 1}
-          className="p-1.5 border-2 border-gray-300 rounded-md hover:bg-blue-50 disabled:opacity-40 disabled:cursor-not-allowed transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500"
+          className="p-1.5 border-2 border-gray-300 rounded-lg hover:bg-blue-50 disabled:opacity-40 disabled:cursor-not-allowed transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500"
           aria-label="Previous page"
         >
           <ChevronLeft className="w-5 h-5 text-gray-700" />
@@ -462,7 +489,7 @@ export function TablePagination({
         <button
           onClick={handleNext}
           disabled={page === totalPages}
-          className="p-1.5 border-2 border-gray-300 rounded-md hover:bg-blue-50 disabled:opacity-40 disabled:cursor-not-allowed transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500"
+          className="p-1.5 border-2 border-gray-300 rounded-lg hover:bg-blue-50 disabled:opacity-40 disabled:cursor-not-allowed transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500"
           aria-label="Next page"
         >
           <ChevronRight className="w-5 h-5 text-gray-700" />

--- a/dataloom-frontend/src/Components/common/Button.jsx
+++ b/dataloom-frontend/src/Components/common/Button.jsx
@@ -16,7 +16,7 @@ const VARIANT_CLASSES = {
 export default function Button({ variant = "primary", children, className = "", ...rest }) {
   return (
     <button
-      className={`px-4 py-2 rounded-md font-medium transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2 ${VARIANT_CLASSES[variant] || VARIANT_CLASSES.primary} ${className}`}
+      className={`px-4 py-2 rounded-lg font-medium transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2 ${VARIANT_CLASSES[variant] || VARIANT_CLASSES.primary} ${className}`}
       {...rest}
     >
       {children}

--- a/dataloom-frontend/src/Components/common/DtypeBadge.jsx
+++ b/dataloom-frontend/src/Components/common/DtypeBadge.jsx
@@ -14,7 +14,7 @@ const DtypeBadge = ({ dtype }) => {
   const style = DTYPE_STYLES[dtype] || "bg-gray-100 text-gray-700";
 
   return (
-    <span className={`ml-1.5 inline-block px-1.5 py-0.5 text-[10px] font-medium rounded ${style}`}>
+    <span className={`ml-1.5 inline-block px-1.5 py-0.5 text-xs font-medium rounded ${style}`}>
       {dtype}
     </span>
   );

--- a/dataloom-frontend/src/Components/forms/AdvQueryFilterForm.jsx
+++ b/dataloom-frontend/src/Components/forms/AdvQueryFilterForm.jsx
@@ -1,20 +1,23 @@
 import { useState } from "react";
 import PropTypes from "prop-types";
+import { LuChevronDown, LuDownload, LuSave, LuCode } from "react-icons/lu";
 import TransformResultPreview from "./TransformResultPreview";
-import { transformProject } from "../../api";
+import { transformProject, saveProject } from "../../api";
 import { ADV_QUERY_FILTER } from "../../constants/operationTypes";
 import useError from "../../hooks/useError";
 import FormErrorAlert from "../common/FormErrorAlert";
+import { downloadCsv, downloadExcel, downloadJson, downloadPdf } from "../../utils/exportUtils";
 
-const AdvQueryFilterForm = ({ projectId, onClose }) => {
+const AdvQueryFilterForm = ({ projectId, onClose, onTransform, onSave }) => {
   const [query, setQuery] = useState("");
   const [result, setResult] = useState(null);
   const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [isExportMenuOpen, setIsExportMenuOpen] = useState(false);
   const { error, clearError, handleError } = useError();
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    console.log("Query:", query);
     setLoading(true);
     clearError();
     try {
@@ -23,49 +26,212 @@ const AdvQueryFilterForm = ({ projectId, onClose }) => {
         adv_query: { query },
       });
       setResult(response);
-      console.log("Query API response:", response);
     } catch (err) {
-      console.error("Error applying query:", err.message);
       handleError(err);
     } finally {
       setLoading(false);
     }
   };
 
+  const handleSaveQueried = async () => {
+    if (!result) return;
+
+    setSaving(true);
+    try {
+      const advQuery = { query };
+      const commitMessage = await onSave(advQuery);
+      if (!commitMessage) return;
+
+      await transformProject(projectId, {
+        operation_type: ADV_QUERY_FILTER,
+        adv_query: advQuery,
+        persist: true,
+      });
+
+      const savedProject = await saveProject(projectId, commitMessage);
+      onTransform(savedProject);
+      setResult(savedProject);
+    } catch (err) {
+      handleError(err);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleExportAs = (format) => {
+    if (!result) return;
+    const cols = result.columns || [];
+    const rows = result.rows || [];
+    const filename = `query-export.${format}`;
+
+    switch (format) {
+      case "csv":
+        downloadCsv(filename, cols, rows);
+        break;
+      case "excel":
+        downloadExcel(filename, cols, rows);
+        break;
+      case "pdf":
+        downloadPdf(filename, cols, rows, "Advanced Query Export");
+        break;
+      case "json":
+        downloadJson(filename, cols, rows);
+        break;
+      default:
+        break;
+    }
+    setIsExportMenuOpen(false);
+  };
+
   return (
-    <div className="p-4 border border-gray-200 rounded-lg bg-white">
-      <form onSubmit={handleSubmit}>
-        <h3 className="font-semibold text-gray-900 mb-2">Advanced Query</h3>
-        <div className="mb-2">
-          <label className="block text-sm font-medium text-gray-700">Query:</label>
-          <input
-            type="text"
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            className="border border-gray-300 rounded-md w-full px-3 py-2 bg-white text-gray-900 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none"
-            placeholder="e.g., col1 > 10 and col2 < 5"
-            required
-          />
-        </div>
-        <div className="flex justify-between">
-          <button
-            type="submit"
-            className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-md font-medium transition-colors duration-150"
-            disabled={loading}
-          >
-            Submit
-          </button>
+    <div className="border border-gray-200 rounded-lg bg-white shadow-sm mb-8 mx-8 overflow-hidden">
+      <div className="bg-gray-50 border-b border-gray-200 px-6 py-4">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-4">
+            <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-blue-50 text-blue-600 shadow-sm ring-1 ring-inset ring-blue-100">
+              <LuCode className="h-4 w-4" />
+            </div>
+            <div>
+              <h3 className="text-sm font-bold uppercase tracking-wider text-slate-800">
+                Advanced Query
+              </h3>
+              <p className="text-[11px] text-slate-500 font-medium mt-0.5">
+                Apply complex filters using logical expressions.
+              </p>
+            </div>
+          </div>
           <button
             type="button"
             onClick={onClose}
-            className="bg-white border border-gray-300 text-gray-700 hover:bg-gray-50 px-4 py-2 rounded-md font-medium transition-colors duration-150"
+            className="text-gray-400 hover:text-gray-600 p-1.5 hover:bg-gray-200/50 rounded-lg transition-all"
           >
-            Cancel
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
           </button>
         </div>
-      </form>
-      <FormErrorAlert message={error} />
-      {result && <TransformResultPreview columns={result.columns} rows={result.rows} />}
+      </div>
+
+      <div className="p-8">
+        <form onSubmit={handleSubmit} className="space-y-6">
+          <div className="space-y-1.5">
+            <label className="block text-xs font-bold text-slate-700 uppercase tracking-tight">
+              Expression:
+            </label>
+            <input
+              type="text"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              className="w-full bg-white border border-slate-200 rounded-lg px-4 py-2.5 text-sm text-slate-900 placeholder:text-slate-400 focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 focus:outline-none transition-all"
+              placeholder="e.g., col1 > 10 and col2 < 5"
+              required
+            />
+            <p className="text-[10px] text-slate-400 font-mono">
+              Syntax: column [operator] value [and/or] ...
+            </p>
+          </div>
+
+          <div className="flex justify-end gap-3 pt-4 border-t border-gray-50">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-6 py-2 text-sm font-bold text-slate-600 hover:text-slate-800 hover:bg-slate-50 rounded-lg transition-all"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="bg-blue-500 hover:bg-blue-600 text-white px-8 py-2 rounded-lg font-bold text-sm shadow-lg shadow-blue-100 transition-all active:scale-95 disabled:opacity-50"
+              disabled={loading}
+            >
+              {loading ? "Processing..." : "Run Query"}
+            </button>
+          </div>
+        </form>
+
+        {error && (
+          <div className="mt-6">
+            <FormErrorAlert message={error} />
+          </div>
+        )}
+
+        {result && (
+          <div className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm mt-8">
+            <div className="bg-gray-50 border-b border-gray-200 px-6 py-4">
+              <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+                <div className="space-y-1">
+                  <div className="flex items-center gap-2 text-sm font-bold text-gray-900">
+                    <span className="text-blue-600">Query Result</span>
+                    <span className="text-gray-300 font-normal">/</span>
+                    <span className="text-gray-600">{result.rows?.length || 0} rows found</span>
+                  </div>
+                  <p className="text-xs text-gray-500">Preview of the matching data rows.</p>
+                </div>
+
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={handleSaveQueried}
+                    disabled={saving}
+                    className="inline-flex items-center gap-2 rounded-lg border border-gray-200 bg-white px-5 py-2 text-sm font-bold text-gray-700 transition-all hover:bg-gray-50 hover:border-gray-300 active:bg-gray-100"
+                  >
+                    <LuSave className="h-4 w-4 text-blue-500" />
+                    {saving ? "Saving..." : "Save result"}
+                  </button>
+
+                  <div className="relative">
+                    <button
+                      type="button"
+                      onClick={() => setIsExportMenuOpen((open) => !open)}
+                      className="inline-flex items-center gap-2 rounded-lg bg-slate-900 px-5 py-2 text-sm font-bold text-white shadow-lg shadow-slate-100 transition-all hover:bg-slate-800 active:scale-95"
+                    >
+                      <LuDownload className="h-4 w-4" />
+                      Export
+                      <LuChevronDown
+                        className={`h-4 w-4 transition-transform duration-200 ${isExportMenuOpen ? "rotate-180" : ""}`}
+                      />
+                    </button>
+                    {isExportMenuOpen && (
+                      <div className="absolute right-0 top-full z-20 mt-2 w-56 overflow-hidden rounded-lg border border-gray-100 bg-white p-1.5 shadow-2xl ring-1 ring-gray-900/5">
+                        <div className="px-3 py-2 text-[10px] font-bold uppercase tracking-widest text-gray-400">
+                          Select Format
+                        </div>
+                        {[
+                          { label: "CSV", format: "csv", desc: "For spreadsheets & generic use" },
+                          { label: "Excel", format: "excel", desc: "Microsoft Excel Worksheet" },
+                          { label: "PDF", format: "pdf", desc: "Ready for printing & sharing" },
+                          { label: "JSON", format: "json", desc: "For developers & API use" },
+                        ].map((item) => (
+                          <button
+                            key={item.format}
+                            type="button"
+                            onClick={() => handleExportAs(item.format)}
+                            className="flex w-full flex-col gap-0.5 rounded-lg px-3 py-2.5 text-left transition-colors hover:bg-blue-50 group"
+                          >
+                            <span className="text-sm font-bold text-gray-700 group-hover:text-blue-700">
+                              {item.label}
+                            </span>
+                            <span className="text-[10px] text-gray-400">{item.desc}</span>
+                          </button>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div className="p-1">
+              <TransformResultPreview columns={result.columns} rows={result.rows} embedded />
+            </div>
+          </div>
+        )}
+      </div>
     </div>
   );
 };
@@ -73,6 +239,8 @@ const AdvQueryFilterForm = ({ projectId, onClose }) => {
 AdvQueryFilterForm.propTypes = {
   projectId: PropTypes.string.isRequired,
   onClose: PropTypes.func.isRequired,
+  onTransform: PropTypes.func.isRequired,
+  onSave: PropTypes.func.isRequired,
 };
 
 export default AdvQueryFilterForm;

--- a/dataloom-frontend/src/Components/forms/CastDataTypeForm.jsx
+++ b/dataloom-frontend/src/Components/forms/CastDataTypeForm.jsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import PropTypes from "prop-types";
+import { LuType } from "react-icons/lu";
 import { transformProject } from "../../api";
 import { CAST_DATA_TYPE } from "../../constants/operationTypes";
 import { useToast } from "../../context/ToastContext";
@@ -37,54 +38,93 @@ const CastDataTypeForm = ({ projectId, onClose, onTransform }) => {
   };
 
   return (
-    <div className="p-4 border border-gray-200 rounded-lg bg-white">
-      <form onSubmit={handleSubmit}>
-        <h3 className="font-semibold text-gray-900 mb-2">Cast Data Type</h3>
-
-        <div className="flex space-x-2 mb-4">
-          <div className="flex-1">
-            <label className="block text-sm font-medium text-gray-700">Column:</label>
-            <ColumnSelect
-              value={column}
-              onChange={(e) => setColumn(e.target.value)}
-              placeholder="Select column..."
-            />
+    <div className="border border-gray-200 rounded-lg bg-white shadow-sm mb-8 mx-8 overflow-hidden">
+      <div className="bg-gray-50 border-b border-gray-200 px-6 py-4">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-4">
+            <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-blue-50 text-blue-600 shadow-sm ring-1 ring-inset ring-blue-100">
+              <LuType className="h-4 w-4" />
+            </div>
+            <div>
+              <h3 className="text-sm font-bold uppercase tracking-wider text-slate-800">
+                Cast Data Type
+              </h3>
+              <p className="text-[11px] text-slate-500 font-medium mt-0.5">
+                Convert a column to a different data type.
+              </p>
+            </div>
           </div>
-
-          <div className="flex-1">
-            <label className="block text-sm font-medium text-gray-700">Target Type:</label>
-            <select
-              value={targetType}
-              onChange={(e) => setTargetType(e.target.value)}
-              className="border border-gray-300 rounded-md w-full px-3 py-2 bg-white text-gray-900 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none"
-            >
-              <option value="string">String</option>
-              <option value="integer">Integer</option>
-              <option value="float">Float</option>
-              <option value="boolean">Boolean</option>
-              <option value="datetime">DateTime</option>
-            </select>
-          </div>
-        </div>
-
-        <div className="flex justify-between">
-          <button
-            type="submit"
-            className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-md font-medium transition-colors duration-150"
-          >
-            Apply
-          </button>
-
           <button
             type="button"
             onClick={onClose}
-            className="bg-white border border-gray-300 text-gray-700 hover:bg-gray-50 px-4 py-2 rounded-md font-medium transition-colors duration-150"
+            className="text-gray-400 hover:text-gray-600 p-1.5 hover:bg-gray-200/50 rounded-lg transition-all"
           >
-            Cancel
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
           </button>
         </div>
-      </form>
-      <FormErrorAlert message={error} />
+      </div>
+
+      <div className="p-8">
+        <form onSubmit={handleSubmit} className="space-y-6">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <div className="space-y-1.5">
+              <label className="block text-xs font-bold text-slate-700 uppercase tracking-tight">
+                Column:
+              </label>
+              <ColumnSelect
+                value={column}
+                onChange={(e) => setColumn(e.target.value)}
+                placeholder="Select column..."
+              />
+            </div>
+
+            <div className="space-y-1.5">
+              <label className="block text-xs font-bold text-slate-700 uppercase tracking-tight">
+                Target Type:
+              </label>
+              <select
+                value={targetType}
+                onChange={(e) => setTargetType(e.target.value)}
+                className="w-full bg-white border border-slate-200 rounded-lg px-4 py-2.5 text-sm text-slate-900 focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 focus:outline-none transition-all appearance-none cursor-pointer"
+              >
+                <option value="string">String</option>
+                <option value="integer">Integer</option>
+                <option value="float">Float</option>
+                <option value="boolean">Boolean</option>
+                <option value="datetime">DateTime</option>
+              </select>
+            </div>
+          </div>
+
+          <div className="flex justify-end gap-3 pt-4 border-t border-gray-50">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-6 py-2 text-sm font-bold text-slate-600 hover:text-slate-800 hover:bg-slate-50 rounded-lg transition-all"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="bg-blue-500 hover:bg-blue-600 text-white px-8 py-2 rounded-lg font-bold text-sm shadow-lg shadow-blue-100 transition-all active:scale-95"
+            >
+              Apply Cast
+            </button>
+          </div>
+        </form>
+        {error && (
+          <div className="mt-6">
+            <FormErrorAlert message={error} />
+          </div>
+        )}
+      </div>
     </div>
   );
 };

--- a/dataloom-frontend/src/Components/forms/DropDuplicateForm.jsx
+++ b/dataloom-frontend/src/Components/forms/DropDuplicateForm.jsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import PropTypes from "prop-types";
+import { LuTrash2 } from "react-icons/lu";
 import { transformProject } from "../../api";
 import { DROP_DUPLICATE } from "../../constants/operationTypes";
 import useError from "../../hooks/useError";
@@ -33,50 +34,93 @@ const DropDuplicateForm = ({ projectId, onClose, onTransform }) => {
   };
 
   return (
-    <div className="p-4 border border-gray-200 rounded-lg bg-white">
-      <form onSubmit={handleSubmit}>
-        <h3 className="font-semibold text-gray-900 mb-2">Drop Duplicate</h3>
-        <div className="flex space-x-2 mb-4">
-          <div className="flex-1">
-            <label className="block text-sm font-medium text-gray-700">Columns:</label>
-            <input
-              type="text"
-              value={columns}
-              onChange={(e) => setColumns(e.target.value)}
-              className="border border-gray-300 rounded-md w-full px-3 py-2 bg-white text-gray-900 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none"
-              placeholder="e.g., col1,col2"
-              required
-            />
+    <div className="border border-gray-200 rounded-lg bg-white shadow-sm mb-8 mx-8 overflow-hidden">
+      <div className="bg-gray-50 border-b border-gray-200 px-6 py-4">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-4">
+            <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-blue-50 text-blue-600 shadow-sm ring-1 ring-inset ring-blue-100">
+              <LuTrash2 className="h-4 w-4" />
+            </div>
+            <div>
+              <h3 className="text-sm font-bold uppercase tracking-wider text-slate-800">
+                Drop Duplicate
+              </h3>
+              <p className="text-[11px] text-slate-500 font-medium mt-0.5">
+                Remove duplicate rows based on specific columns.
+              </p>
+            </div>
           </div>
-          <div className="flex-1">
-            <label className="block text-sm font-medium text-gray-700">Keep:</label>
-            <select
-              value={keep}
-              onChange={(e) => setKeep(e.target.value)}
-              className="border border-gray-300 rounded-md w-full px-3 py-2 bg-white text-gray-900 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none"
-            >
-              <option value="first">First</option>
-              <option value="last">Last</option>
-            </select>
-          </div>
-        </div>
-        <div className="flex justify-between">
-          <button
-            type="submit"
-            className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-md font-medium transition-colors duration-150"
-          >
-            Submit
-          </button>
           <button
             type="button"
             onClick={onClose}
-            className="bg-white border border-gray-300 text-gray-700 hover:bg-gray-50 px-4 py-2 rounded-md font-medium transition-colors duration-150"
+            className="text-gray-400 hover:text-gray-600 p-1.5 hover:bg-gray-200/50 rounded-lg transition-all"
           >
-            Cancel
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
           </button>
         </div>
-      </form>
-      <FormErrorAlert message={error} />
+      </div>
+
+      <div className="p-8">
+        <form onSubmit={handleSubmit} className="space-y-6">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <div className="space-y-1.5">
+              <label className="block text-xs font-bold text-slate-700 uppercase tracking-tight">
+                Columns:
+              </label>
+              <input
+                type="text"
+                value={columns}
+                onChange={(e) => setColumns(e.target.value)}
+                className="w-full bg-white border border-slate-200 rounded-lg px-4 py-2.5 text-sm text-slate-900 placeholder:text-slate-400 focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 focus:outline-none transition-all"
+                placeholder="e.g., col1,col2"
+                required
+              />
+              <p className="text-[10px] text-slate-400">Separate multiple columns with commas.</p>
+            </div>
+            <div className="space-y-1.5">
+              <label className="block text-xs font-bold text-slate-700 uppercase tracking-tight">
+                Keep:
+              </label>
+              <select
+                value={keep}
+                onChange={(e) => setKeep(e.target.value)}
+                className="w-full bg-white border border-slate-200 rounded-lg px-4 py-2.5 text-sm text-slate-900 focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 focus:outline-none transition-all appearance-none cursor-pointer"
+              >
+                <option value="first">First Instance</option>
+                <option value="last">Last Instance</option>
+              </select>
+            </div>
+          </div>
+
+          <div className="flex justify-end gap-3 pt-4 border-t border-gray-50">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-6 py-2 text-sm font-bold text-slate-600 hover:text-slate-800 hover:bg-slate-50 rounded-lg transition-all"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="bg-blue-500 hover:bg-blue-600 text-white px-8 py-2 rounded-lg font-bold text-sm shadow-lg shadow-blue-100 transition-all active:scale-95"
+            >
+              Drop Duplicates
+            </button>
+          </div>
+        </form>
+        {error && (
+          <div className="mt-6">
+            <FormErrorAlert message={error} />
+          </div>
+        )}
+      </div>
     </div>
   );
 };

--- a/dataloom-frontend/src/Components/forms/FilterForm.jsx
+++ b/dataloom-frontend/src/Components/forms/FilterForm.jsx
@@ -1,13 +1,15 @@
 import { useState } from "react";
 import PropTypes from "prop-types";
-import { transformProject } from "../../api";
+import { LuChevronDown, LuDownload, LuFilter, LuSave } from "react-icons/lu";
+import { saveProject, transformProject } from "../../api";
 import { FILTER } from "../../constants/operationTypes";
 import TransformResultPreview from "./TransformResultPreview";
 import useError from "../../hooks/useError";
 import FormErrorAlert from "../common/FormErrorAlert";
 import ColumnSelect from "../common/ColumnSelect";
+import { downloadCsv, downloadExcel, downloadJson, downloadPdf } from "../../utils/exportUtils";
 
-const FilterForm = ({ projectId, onClose }) => {
+const FilterForm = ({ projectId, onClose, onTransform, onSave }) => {
   const [filterParams, setFilterParams] = useState({
     column: "",
     condition: "=",
@@ -15,6 +17,8 @@ const FilterForm = ({ projectId, onClose }) => {
   });
   const [result, setResult] = useState(null);
   const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [isExportMenuOpen, setIsExportMenuOpen] = useState(false);
   const { error, clearError, handleError } = useError();
 
   const handleInputChange = (e) => {
@@ -33,6 +37,7 @@ const FilterForm = ({ projectId, onClose }) => {
       const response = await transformProject(projectId, {
         operation_type: FILTER,
         parameters: filterParams,
+        persist: false,
       });
       setResult(response);
       console.log("Filter API response:", response);
@@ -44,69 +49,228 @@ const FilterForm = ({ projectId, onClose }) => {
     }
   };
 
+  const handleExportFilteredAs = (format) => {
+    if (!result) return;
+
+    const columns = result.columns || [];
+    const rows = result.rows || [];
+
+    switch (format) {
+      case "csv":
+        downloadCsv("filtered-export.csv", columns, rows);
+        break;
+      case "excel":
+        downloadExcel("filtered-export.xlsx", columns, rows);
+        break;
+      case "pdf":
+        downloadPdf("filtered-export.pdf", columns, rows, "Filtered Dataset Export");
+        break;
+      case "json":
+        downloadJson("filtered-export.json", columns, rows);
+        break;
+      default:
+        break;
+    }
+
+    setIsExportMenuOpen(false);
+  };
+
+  const handleSaveFiltered = async () => {
+    if (!result) return;
+
+    setSaving(true);
+    clearError();
+    try {
+      const commitMessage = await onSave(filterParams);
+      if (!commitMessage) return;
+
+      await transformProject(projectId, {
+        operation_type: FILTER,
+        parameters: filterParams,
+        persist: true,
+      });
+
+      const savedProject = await saveProject(projectId, commitMessage);
+      onTransform(savedProject);
+      setResult(savedProject);
+    } catch (err) {
+      console.error("Error saving filtered result:", err.response?.data || err.message);
+      handleError(err);
+    } finally {
+      setSaving(false);
+    }
+  };
+
   return (
-    <div className="p-4 border border-gray-200 rounded-lg bg-white">
-      <form onSubmit={handleSubmit}>
-        <h3 className="font-semibold text-gray-900 mb-2">Filter Dataset</h3>
-        <div className="flex flex-wrap mb-4">
-          <div className="w-full sm:w-1/3 mb-2">
-            <label className="block mb-1 text-sm font-medium text-gray-700">Column:</label>
-            <ColumnSelect
-              name="column"
-              value={filterParams.column}
-              onChange={handleInputChange}
-              placeholder="Select column to filter..."
-            />
-          </div>
-          <div className="w-full sm:w-1/3 mb-2 pl-2">
-            <label className="block mb-1 text-sm font-medium text-gray-700">Condition:</label>
-            <select
-              name="condition"
-              value={filterParams.condition}
-              onChange={handleInputChange}
-              className="border border-gray-300 rounded-md px-3 py-2 w-full bg-white text-gray-900 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none"
-              required
+    <div className="space-y-6 px-8 pb-10">
+      <div className="overflow-hidden rounded-md border border-gray-200 bg-white shadow-sm">
+        <div className="bg-gray-50 border-b border-gray-200 px-6 py-4">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-4">
+              <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-blue-50 text-blue-600 shadow-sm ring-1 ring-inset ring-blue-100">
+                <LuFilter className="h-4 w-4" />
+              </div>
+              <div>
+                <h3 className="text-sm font-bold text-gray-900 uppercase tracking-wider">
+                  Filter Dataset
+                </h3>
+                <p className="text-[11px] text-gray-500 mt-0.5">
+                  Narrow down rows based on specific criteria.
+                </p>
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={onClose}
+              className="text-gray-400 hover:text-gray-600 p-1.5 hover:bg-gray-200/50 rounded-lg transition-all"
             >
-              <option value="=">=</option>
-              <option value="!=">!= (not equal)</option>
-              <option value=">">&gt;</option>
-              <option value="<">&lt;</option>
-              <option value=">=">&gt;=</option>
-              <option value="<=">&lt;=</option>
-              <option value="contains">contains</option>
-            </select>
-          </div>
-          <div className="w-full sm:w-1/3 mb-2 pl-2">
-            <label className="block mb-1 text-sm font-medium text-gray-700">Value:</label>
-            <input
-              type="text"
-              name="value"
-              value={filterParams.value}
-              onChange={handleInputChange}
-              className="border border-gray-300 rounded-md px-3 py-2 w-full bg-white text-gray-900 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none"
-              required
-            />
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+            </button>
           </div>
         </div>
-        <div className="flex justify-between">
-          <button
-            type="submit"
-            className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-md font-medium transition-colors duration-150"
-            disabled={loading}
-          >
-            Apply Filter
-          </button>
-          <button
-            type="button"
-            onClick={onClose}
-            className="bg-white border border-gray-300 text-gray-700 hover:bg-gray-50 px-4 py-2 rounded-md font-medium transition-colors duration-150"
-          >
-            Cancel
-          </button>
-        </div>
-      </form>
+
+        <form onSubmit={handleSubmit} className="p-6 bg-white">
+          <div className="grid gap-6 md:grid-cols-3">
+            <div className="space-y-2">
+              <label className="block text-sm font-semibold text-gray-700">Column</label>
+              <ColumnSelect
+                name="column"
+                value={filterParams.column}
+                onChange={handleInputChange}
+                placeholder="Select column..."
+                className="w-full rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-all cursor-pointer"
+              />
+            </div>
+            <div className="space-y-2">
+              <label className="block text-sm font-semibold text-gray-700">Condition</label>
+              <select
+                name="condition"
+                value={filterParams.condition}
+                onChange={handleInputChange}
+                className="w-full rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-all appearance-none cursor-pointer"
+                required
+              >
+                <option value="=">Equals (=)</option>
+                <option value="!=">Not Equals (!=)</option>
+                <option value=">">Greater Than (&gt;)</option>
+                <option value="<">Less Than (&lt;)</option>
+                <option value=">=">Greater or Equal (&gt;=)</option>
+                <option value="<=">Less or Equal (&lt;=)</option>
+                <option value="contains">Contains Text</option>
+              </select>
+            </div>
+            <div className="space-y-2">
+              <label className="block text-sm font-semibold text-gray-700">Value</label>
+              <input
+                type="text"
+                name="value"
+                value={filterParams.value}
+                onChange={handleInputChange}
+                placeholder="Search value..."
+                className="w-full rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 placeholder:text-gray-400 focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-all"
+                required
+              />
+            </div>
+          </div>
+          <div className="mt-8 flex items-center justify-end gap-3 border-t border-gray-100 pt-6">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-6 py-2.5 text-sm font-semibold text-gray-600 hover:text-gray-800 transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="flex items-center gap-2 bg-blue-500 hover:bg-blue-600 text-white px-10 py-2.5 rounded-lg font-bold text-sm shadow-lg shadow-blue-100 transition-all active:scale-95 disabled:opacity-50 disabled:pointer-events-none"
+              disabled={loading || !filterParams.column}
+            >
+              {loading ? "Applying..." : "Apply Filter"}
+            </button>
+          </div>
+        </form>
+      </div>
+
       <FormErrorAlert message={error} />
-      {result && <TransformResultPreview columns={result.columns} rows={result.rows} />}
+
+      {result && (
+        <div className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+          <div className="bg-gray-50 border-b border-gray-200 px-6 py-4">
+            <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+              <div className="space-y-1">
+                <div className="flex items-center gap-2 text-sm font-bold text-gray-900">
+                  <span className="text-blue-600">Filtered Result</span>
+                  <span className="text-gray-300 font-normal">/</span>
+                  <span className="text-gray-600">{result.rows?.length ?? 0} matches found</span>
+                </div>
+                <p className="text-xs text-gray-500">Preview of the matching data rows.</p>
+              </div>
+
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={handleSaveFiltered}
+                  disabled={saving}
+                  className="inline-flex items-center gap-2 rounded-lg border border-gray-200 bg-white px-5 py-2 text-sm font-bold text-gray-700 transition-all hover:bg-gray-50 hover:border-gray-300 active:bg-gray-100"
+                >
+                  <LuSave className="h-4 w-4 text-blue-500" />
+                  {saving ? "Saving..." : "Save result"}
+                </button>
+
+                <div className="relative">
+                  <button
+                    type="button"
+                    onClick={() => setIsExportMenuOpen((open) => !open)}
+                    className="inline-flex items-center gap-2 rounded-lg bg-slate-900 px-5 py-2 text-sm font-bold text-white shadow-lg shadow-slate-100 transition-all hover:bg-slate-800 active:scale-95"
+                  >
+                    <LuDownload className="h-4 w-4" />
+                    Export
+                    <LuChevronDown
+                      className={`h-4 w-4 transition-transform duration-200 ${isExportMenuOpen ? "rotate-180" : ""}`}
+                    />
+                  </button>
+                  {isExportMenuOpen && (
+                    <div className="absolute right-0 top-full z-20 mt-2 w-56 overflow-hidden rounded-lg border border-gray-100 bg-white p-1.5 shadow-2xl ring-1 ring-gray-900/5">
+                      <div className="px-3 py-2 text-[10px] font-bold uppercase tracking-widest text-gray-400">
+                        Select Format
+                      </div>
+                      {[
+                        { label: "CSV", format: "csv", desc: "For spreadsheets & generic use" },
+                        { label: "Excel", format: "excel", desc: "Microsoft Excel Worksheet" },
+                        { label: "PDF", format: "pdf", desc: "Ready for printing & sharing" },
+                        { label: "JSON", format: "json", desc: "For developers & API use" },
+                      ].map((item) => (
+                        <button
+                          key={item.format}
+                          type="button"
+                          onClick={() => handleExportFilteredAs(item.format)}
+                          className="flex w-full flex-col gap-0.5 rounded-lg px-3 py-2.5 text-left transition-colors hover:bg-blue-50 group"
+                        >
+                          <span className="text-sm font-bold text-gray-700 group-hover:text-blue-700">
+                            {item.label}
+                          </span>
+                          <span className="text-[10px] text-gray-400">{item.desc}</span>
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="p-1">
+            <TransformResultPreview columns={result.columns} rows={result.rows} embedded />
+          </div>
+        </div>
+      )}
     </div>
   );
 };
@@ -114,6 +278,8 @@ const FilterForm = ({ projectId, onClose }) => {
 FilterForm.propTypes = {
   projectId: PropTypes.string.isRequired,
   onClose: PropTypes.func.isRequired,
+  onTransform: PropTypes.func.isRequired,
+  onSave: PropTypes.func.isRequired,
 };
 
 export default FilterForm;

--- a/dataloom-frontend/src/Components/forms/GroupByForm.jsx
+++ b/dataloom-frontend/src/Components/forms/GroupByForm.jsx
@@ -1,19 +1,23 @@
 import { useState } from "react";
 import PropTypes from "prop-types";
-import { transformProject } from "../../api";
+import { LuChevronDown, LuDownload, LuSave, LuLayers } from "react-icons/lu";
+import { transformProject, saveProject } from "../../api";
 import { GROUPBY } from "../../constants/operationTypes";
 import TransformResultPreview from "./TransformResultPreview";
 import useError from "../../hooks/useError";
 import FormErrorAlert from "../common/FormErrorAlert";
 import { useProjectContext } from "../../context/ProjectContext";
+import { downloadCsv, downloadExcel, downloadJson, downloadPdf } from "../../utils/exportUtils";
 
-const GroupByForm = ({ projectId, onClose, onTransform }) => {
-  const { columns: availableColumns, updateData } = useProjectContext();
+const GroupByForm = ({ projectId, onClose, onTransform, onSave }) => {
+  const { columns: availableColumns } = useProjectContext();
   const [selectedColumns, setSelectedColumns] = useState([]);
   const [aggColumn, setAggColumn] = useState("");
   const [aggFunction, setAggFunction] = useState("sum");
   const [result, setResult] = useState(null);
   const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [isExportMenuOpen, setIsExportMenuOpen] = useState(false);
   const { error, clearError, handleError } = useError();
 
   const handleColumnToggle = (col) => {
@@ -39,8 +43,6 @@ const GroupByForm = ({ projectId, onClose, onTransform }) => {
         },
       });
       setResult(response);
-      if (onTransform) onTransform(response);
-      updateData(response.columns, response.rows, response.dtypes);
     } catch (err) {
       handleError(err);
     } finally {
@@ -48,84 +50,311 @@ const GroupByForm = ({ projectId, onClose, onTransform }) => {
     }
   };
 
+  const handleSaveGrouped = async () => {
+    if (!result) return;
+
+    setSaving(true);
+    try {
+      const groupbyParams = {
+        columns: selectedColumns,
+        agg_column: aggColumn,
+        agg_function: aggFunction,
+      };
+      const commitMessage = await onSave(groupbyParams);
+      if (!commitMessage) return;
+
+      await transformProject(projectId, {
+        operation_type: GROUPBY,
+        groupby_params: groupbyParams,
+        persist: true,
+      });
+
+      const savedProject = await saveProject(projectId, commitMessage);
+      onTransform(savedProject);
+      setResult(savedProject);
+    } catch (err) {
+      handleError(err);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleExportAs = (format) => {
+    if (!result) return;
+    const cols = result.columns || [];
+    const rows = result.rows || [];
+    const filename = `groupby-export.${format}`;
+
+    switch (format) {
+      case "csv":
+        downloadCsv(filename, cols, rows);
+        break;
+      case "excel":
+        downloadExcel(filename, cols, rows);
+        break;
+      case "pdf":
+        downloadPdf(filename, cols, rows, "GroupBy Aggregation Export");
+        break;
+      case "json":
+        downloadJson(filename, cols, rows);
+        break;
+      default:
+        break;
+    }
+    setIsExportMenuOpen(false);
+  };
+
   return (
-    <div className="p-4 border border-gray-200 rounded-lg bg-white">
-      <form onSubmit={handleSubmit}>
-        <h3 className="font-semibold text-gray-900 mb-2">GroupBy Aggregation</h3>
-        <div className="flex flex-wrap mb-4">
-          <div className="w-full sm:w-1/3 mb-2">
-            <label className="block mb-1 text-sm font-medium text-gray-700">
-              Group By Columns:
-            </label>
-            <div className="border border-gray-300 rounded-md p-2 max-h-32 overflow-y-auto bg-white">
+    <div className="border border-gray-200 rounded-lg bg-white shadow-sm mb-8 mx-8 overflow-hidden">
+      <div className="bg-gray-50 border-b border-gray-200 px-6 py-4">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-4">
+            <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-blue-50 text-blue-600 shadow-sm ring-1 ring-inset ring-blue-100">
+              <LuLayers className="h-4 w-4" />
+            </div>
+            <div>
+              <h3 className="text-sm font-bold uppercase tracking-wider text-slate-800">
+                GroupBy Aggregation
+              </h3>
+              <p className="text-[11px] text-slate-500 font-medium mt-0.5">
+                Collapse rows by grouping unique values and calculating statistics.
+              </p>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-600 p-1.5 hover:bg-gray-200/50 rounded-lg transition-all"
+          >
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      <form onSubmit={handleSubmit} className="p-6 space-y-8">
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+          {/* Column 1: Group By */}
+          <div className="space-y-3">
+            <div className="flex items-center justify-between">
+              <label className="flex items-center gap-2 text-sm font-semibold text-gray-700">
+                <span className="flex items-center justify-center w-5 h-5 rounded-full bg-blue-50 text-blue-600 text-[10px]">
+                  1
+                </span>
+                Group By Columns
+              </label>
+              <button
+                type="button"
+                onClick={() =>
+                  setSelectedColumns(
+                    selectedColumns.length === availableColumns.length ? [] : [...availableColumns],
+                  )
+                }
+                className="text-[10px] font-bold text-blue-600 hover:text-blue-700"
+              >
+                {selectedColumns.length === availableColumns.length ? "Deselect All" : "Select All"}
+              </button>
+            </div>
+            <div className="border border-gray-200 rounded-xl p-3 max-h-48 overflow-y-auto bg-gray-50/30 space-y-1">
               {availableColumns.map((col) => (
-                <label key={col} className="flex items-center gap-2 py-0.5 text-sm text-gray-700">
+                <label
+                  key={col}
+                  className={`flex items-center gap-3 px-3 py-2 rounded-lg text-sm cursor-pointer transition-all ${
+                    selectedColumns.includes(col)
+                      ? "bg-blue-50 text-blue-700 font-medium border border-blue-100"
+                      : "text-gray-600 hover:bg-white hover:shadow-sm border border-transparent"
+                  }`}
+                >
                   <input
                     type="checkbox"
                     checked={selectedColumns.includes(col)}
                     onChange={() => handleColumnToggle(col)}
-                    className="rounded border-gray-300"
+                    className="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
                   />
                   {col}
                 </label>
               ))}
             </div>
           </div>
-          <div className="w-full sm:w-1/3 mb-2 pl-2">
-            <label className="block mb-1 text-sm font-medium text-gray-700">
-              Aggregation Column:
+
+          {/* Column 2: Aggregation Column */}
+          <div className="space-y-3">
+            <label className="flex items-center gap-2 text-sm font-semibold text-gray-700">
+              <span className="flex items-center justify-center w-5 h-5 rounded-full bg-blue-50 text-blue-600 text-[10px]">
+                2
+              </span>
+              Value to Aggregate
             </label>
-            <select
-              value={aggColumn}
-              onChange={(e) => setAggColumn(e.target.value)}
-              className="border border-gray-300 rounded-md px-3 py-2 w-full bg-white text-gray-900 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none"
-              required
-            >
-              <option value="">Select column...</option>
-              {availableColumns
-                .filter((col) => !selectedColumns.includes(col))
-                .map((col) => (
-                  <option key={col} value={col}>
-                    {col}
-                  </option>
-                ))}
-            </select>
+            <div className="space-y-1">
+              <select
+                value={aggColumn}
+                onChange={(e) => setAggColumn(e.target.value)}
+                className="w-full bg-white border border-gray-200 rounded-xl px-4 py-3 text-sm text-gray-900 focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 focus:outline-none transition-all appearance-none cursor-pointer"
+                required
+              >
+                <option value="">Select column...</option>
+                {availableColumns
+                  .filter((col) => !selectedColumns.includes(col))
+                  .map((col) => (
+                    <option key={col} value={col}>
+                      {col}
+                    </option>
+                  ))}
+              </select>
+              <p className="text-[10px] text-gray-400 pl-1">
+                The numeric column you want to calculate.
+              </p>
+            </div>
           </div>
-          <div className="w-full sm:w-1/3 mb-2 pl-2">
-            <label className="block mb-1 text-sm font-medium text-gray-700">Function:</label>
-            <select
-              value={aggFunction}
-              onChange={(e) => setAggFunction(e.target.value)}
-              className="border border-gray-300 rounded-md px-3 py-2 w-full bg-white text-gray-900 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none"
-            >
-              <option value="sum">Sum</option>
-              <option value="mean">Mean</option>
-              <option value="count">Count</option>
-              <option value="min">Min</option>
-              <option value="max">Max</option>
-              <option value="median">Median</option>
-            </select>
+
+          {/* Column 3: Function */}
+          <div className="space-y-3">
+            <label className="flex items-center gap-2 text-sm font-semibold text-gray-700">
+              <span className="flex items-center justify-center w-5 h-5 rounded-full bg-blue-50 text-blue-600 text-[10px]">
+                3
+              </span>
+              Calculation Type
+            </label>
+            <div className="grid grid-cols-2 gap-2">
+              {["sum", "mean", "count", "min", "max", "median"].map((func) => (
+                <button
+                  key={func}
+                  type="button"
+                  onClick={() => setAggFunction(func)}
+                  className={`px-3 py-2 text-xs font-medium rounded-lg border transition-all capitalize ${
+                    aggFunction === func
+                      ? "bg-blue-500 text-white border-blue-500 shadow-md shadow-blue-100"
+                      : "bg-white text-gray-600 border-gray-200 hover:border-blue-300 hover:text-blue-500"
+                  }`}
+                >
+                  {func}
+                </button>
+              ))}
+            </div>
           </div>
         </div>
-        <div className="flex justify-between">
-          <button
-            type="submit"
-            className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-md font-medium transition-colors duration-150"
-            disabled={loading || selectedColumns.length === 0 || !aggColumn}
-          >
-            Apply GroupBy
-          </button>
+
+        <div className="pt-6 border-t border-gray-50 flex items-center justify-end gap-3">
           <button
             type="button"
             onClick={onClose}
-            className="bg-white border border-gray-300 text-gray-700 hover:bg-gray-50 px-4 py-2 rounded-md font-medium transition-colors duration-150"
+            className="px-6 py-2.5 text-sm font-semibold text-gray-600 hover:text-gray-800 transition-colors"
           >
             Cancel
+          </button>
+          <button
+            type="submit"
+            className="flex items-center gap-2 bg-blue-500 hover:bg-blue-600 text-white px-8 py-2.5 rounded-lg font-bold text-sm shadow-lg shadow-blue-100 transition-all active:scale-95 disabled:opacity-50 disabled:pointer-events-none"
+            disabled={loading || selectedColumns.length === 0 || !aggColumn}
+          >
+            {loading ? (
+              <>
+                <svg
+                  className="animate-spin h-4 w-4 text-white"
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                >
+                  <circle
+                    className="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    strokeWidth="4"
+                  ></circle>
+                  <path
+                    className="opacity-75"
+                    fill="currentColor"
+                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                  ></path>
+                </svg>
+                Processing...
+              </>
+            ) : (
+              "Apply GroupBy"
+            )}
           </button>
         </div>
       </form>
       <FormErrorAlert message={error} />
-      {result && <TransformResultPreview columns={result.columns} rows={result.rows} />}
+      {result && (
+        <div className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm mt-8">
+          <div className="bg-gray-50 border-b border-gray-200 px-6 py-4">
+            <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+              <div className="space-y-1">
+                <div className="flex items-center gap-2 text-sm font-bold text-gray-900">
+                  <span className="text-blue-600">Aggregation Result</span>
+                  <span className="text-gray-300 font-normal">/</span>
+                  <span className="text-gray-600">{result.rows?.length || 0} unique groups</span>
+                </div>
+                <p className="text-xs text-gray-500">Preview of the aggregated data.</p>
+              </div>
+
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={handleSaveGrouped}
+                  disabled={saving}
+                  className="inline-flex items-center gap-2 rounded-lg border border-gray-200 bg-white px-5 py-2 text-sm font-bold text-gray-700 transition-all hover:bg-gray-50 hover:border-gray-300 active:bg-gray-100"
+                >
+                  <LuSave className="h-4 w-4 text-blue-500" />
+                  {saving ? "Saving..." : "Save result"}
+                </button>
+
+                <div className="relative">
+                  <button
+                    type="button"
+                    onClick={() => setIsExportMenuOpen((open) => !open)}
+                    className="inline-flex items-center gap-2 rounded-lg bg-slate-900 px-5 py-2 text-sm font-bold text-white shadow-lg shadow-slate-100 transition-all hover:bg-slate-800 active:scale-95"
+                  >
+                    <LuDownload className="h-4 w-4" />
+                    Export
+                    <LuChevronDown
+                      className={`h-4 w-4 transition-transform duration-200 ${isExportMenuOpen ? "rotate-180" : ""}`}
+                    />
+                  </button>
+                  {isExportMenuOpen && (
+                    <div className="absolute right-0 top-full z-20 mt-2 w-56 overflow-hidden rounded-lg border border-gray-100 bg-white p-1.5 shadow-2xl ring-1 ring-gray-900/5">
+                      <div className="px-3 py-2 text-[10px] font-bold uppercase tracking-widest text-gray-400">
+                        Select Format
+                      </div>
+                      {[
+                        { label: "CSV", format: "csv", desc: "For spreadsheets & generic use" },
+                        { label: "Excel", format: "excel", desc: "Microsoft Excel Worksheet" },
+                        { label: "PDF", format: "pdf", desc: "Ready for printing & sharing" },
+                        { label: "JSON", format: "json", desc: "For developers & API use" },
+                      ].map((item) => (
+                        <button
+                          key={item.format}
+                          type="button"
+                          onClick={() => handleExportAs(item.format)}
+                          className="flex w-full flex-col gap-0.5 rounded-lg px-3 py-2.5 text-left transition-colors hover:bg-blue-50 group"
+                        >
+                          <span className="text-sm font-bold text-gray-700 group-hover:text-blue-700">
+                            {item.label}
+                          </span>
+                          <span className="text-[10px] text-gray-400">{item.desc}</span>
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="p-1">
+            <TransformResultPreview columns={result.columns} rows={result.rows} embedded />
+          </div>
+        </div>
+      )}
     </div>
   );
 };
@@ -133,7 +362,8 @@ const GroupByForm = ({ projectId, onClose, onTransform }) => {
 GroupByForm.propTypes = {
   projectId: PropTypes.string.isRequired,
   onClose: PropTypes.func.isRequired,
-  onTransform: PropTypes.func,
+  onTransform: PropTypes.func.isRequired,
+  onSave: PropTypes.func.isRequired,
 };
 
 export default GroupByForm;

--- a/dataloom-frontend/src/Components/forms/MeltForm.jsx
+++ b/dataloom-frontend/src/Components/forms/MeltForm.jsx
@@ -1,9 +1,11 @@
 import { useState, useEffect } from "react";
 import PropTypes from "prop-types";
+import { LuChevronDown, LuDownload, LuSave, LuColumns3 as LuColumns } from "react-icons/lu";
 import TransformResultPreview from "./TransformResultPreview";
-import { transformProject, getProjectDetails } from "../../api";
+import { transformProject, getProjectDetails, saveProject } from "../../api";
+import { downloadCsv, downloadExcel, downloadJson, downloadPdf } from "../../utils/exportUtils";
 
-const MeltForm = ({ projectId, onClose }) => {
+const MeltForm = ({ projectId, onClose, onTransform, onSave }) => {
   const [columns, setColumns] = useState([]);
   const [idVars, setIdVars] = useState([]);
   const [valueVars, setValueVars] = useState([]);
@@ -11,6 +13,8 @@ const MeltForm = ({ projectId, onClose }) => {
   const [valueName, setValueName] = useState("value");
   const [result, setResult] = useState(null);
   const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [isExportMenuOpen, setIsExportMenuOpen] = useState(false);
   const [error, setError] = useState(null);
 
   useEffect(() => {
@@ -68,6 +72,63 @@ const MeltForm = ({ projectId, onClose }) => {
       setLoading(false);
     }
   };
+  const handleSaveMelted = async () => {
+    if (!result) return;
+
+    setSaving(true);
+    setError(null);
+    try {
+      const meltParams = {
+        id_vars: idVars,
+        value_vars:
+          valueVars.length > 0 ? valueVars : columns.filter((col) => !idVars.includes(col)),
+        var_name: varName.trim() || "variable",
+        value_name: valueName.trim() || "value",
+      };
+
+      const commitMessage = await onSave(meltParams);
+      if (!commitMessage) return;
+
+      await transformProject(projectId, {
+        operation_type: "melt",
+        melt_params: meltParams,
+        persist: true,
+      });
+
+      const savedProject = await saveProject(projectId, commitMessage);
+      onTransform(savedProject);
+      setResult(savedProject);
+    } catch (err) {
+      setError(err.response?.data?.detail || err.message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleExportAs = (format) => {
+    if (!result) return;
+    const cols = result.columns || [];
+    const rows = result.rows || [];
+    const filename = `melted-export.${format}`;
+
+    switch (format) {
+      case "csv":
+        downloadCsv(filename, cols, rows);
+        break;
+      case "excel":
+        downloadExcel(filename, cols, rows);
+        break;
+      case "pdf":
+        downloadPdf(filename, cols, rows, "Melted Dataset Export");
+        break;
+      case "json":
+        downloadJson(filename, cols, rows);
+        break;
+      default:
+        break;
+    }
+    setIsExportMenuOpen(false);
+  };
 
   const handleIdVarsChange = (col) => {
     if (idVars.includes(col)) {
@@ -86,123 +147,242 @@ const MeltForm = ({ projectId, onClose }) => {
   };
 
   return (
-    <div className="p-4 border border-gray-200 rounded-lg bg-white shadow-sm overflow-hidden">
-      <form onSubmit={handleSubmit} className="space-y-4">
-        <h3 className="font-semibold text-gray-900 flex items-center gap-2">
-          Melt (Unpivot) Dataset
-        </h3>
-
-        {error && (
-          <div className="bg-red-50 text-red-600 p-2 rounded text-sm border border-red-100">
-            {typeof error === "string" ? error : JSON.stringify(error, null, 2)}
-          </div>
-        )}
-
-        <div className="grid grid-cols-2 gap-4">
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
-              ID Variables (Keep as columns):
-            </label>
-            <div className="border border-gray-300 rounded-md max-h-40 overflow-y-auto p-2 bg-gray-50">
-              {columns.map((col) => (
-                <label
-                  key={`id-${col}`}
-                  className="flex items-center gap-2 py-1 px-1 hover:bg-gray-200 rounded cursor-pointer text-sm"
-                >
-                  <input
-                    type="checkbox"
-                    checked={idVars.includes(col)}
-                    onChange={() => handleIdVarsChange(col)}
-                    className="rounded text-blue-600"
-                  />
-                  {col}
-                </label>
-              ))}
+    <div className="border border-gray-200 rounded-lg bg-white shadow-sm mb-8 mx-8 overflow-hidden">
+      <div className="bg-gray-50 border-b border-gray-200 px-6 py-4">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-4">
+            <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-blue-50 text-blue-600 shadow-sm ring-1 ring-inset ring-blue-100">
+              <LuColumns className="h-4 w-4" />
             </div>
-            <p className="text-[10px] text-gray-400 mt-1">Columns that remain as identifiers.</p>
-          </div>
-
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
-              Value Variables (to unpivot):
-            </label>
-            <div className="border border-gray-300 rounded-md max-h-40 overflow-y-auto p-2 bg-gray-50">
-              {columns.map((col) => (
-                <label
-                  key={`val-${col}`}
-                  className="flex items-center gap-2 py-1 px-1 hover:bg-gray-200 rounded cursor-pointer text-sm"
-                >
-                  <input
-                    type="checkbox"
-                    checked={valueVars.includes(col)}
-                    onChange={() => handleValueVarsChange(col)}
-                    className="rounded text-blue-600"
-                  />
-                  {col}
-                </label>
-              ))}
+            <div>
+              <h3 className="text-sm font-bold uppercase tracking-wider text-slate-800">
+                Melt (Unpivot)
+              </h3>
+              <p className="text-[11px] text-slate-500 font-medium mt-0.5">
+                Transform wide datasets into a long format.
+              </p>
             </div>
-            <p className="text-[10px] text-gray-400 mt-1">
-              Leave empty to unpivot all non-ID columns.
-            </p>
           </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-600 p-1.5 hover:bg-gray-200/50 rounded-lg transition-all"
+          >
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
         </div>
+      </div>
 
-        <div className="grid grid-cols-2 gap-4">
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Variable Name:</label>
-            <input
-              type="text"
-              value={varName}
-              onChange={(e) => setVarName(e.target.value)}
-              className="border border-gray-300 rounded-md w-full px-3 py-2 bg-white text-gray-900 focus:ring-2 focus:ring-blue-500 text-sm"
-              placeholder="default: variable"
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Value Name:</label>
-            <input
-              type="text"
-              value={valueName}
-              onChange={(e) => setValueName(e.target.value)}
-              className="border border-gray-300 rounded-md w-full px-3 py-2 bg-white text-gray-900 focus:ring-2 focus:ring-blue-500 text-sm"
-              placeholder="default: value"
-            />
-          </div>
-        </div>
+      <div className="p-8">
+        <form onSubmit={handleSubmit} className="space-y-6">
+          {error && (
+            <div className="bg-red-50 text-red-600 p-3 rounded-lg text-sm border border-red-100 mb-6">
+              {typeof error === "string" ? error : JSON.stringify(error, null, 2)}
+            </div>
+          )}
 
-        <div className="flex justify-between pt-2">
-          <div className="flex gap-2">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+            <div className="space-y-2">
+              <div className="flex items-center justify-between">
+                <label className="block text-xs font-bold text-slate-700 uppercase tracking-tight">
+                  ID Variables:
+                </label>
+                <button
+                  type="button"
+                  onClick={() => setIdVars(idVars.length === columns.length ? [] : [...columns])}
+                  className="text-[10px] font-bold text-blue-600 hover:text-blue-700"
+                >
+                  {idVars.length === columns.length ? "Deselect All" : "Select All"}
+                </button>
+              </div>
+              <div className="border border-slate-200 rounded-lg max-h-48 overflow-y-auto p-3 bg-slate-50/50 space-y-1">
+                {columns.map((col) => (
+                  <label
+                    key={`id-${col}`}
+                    className={`flex items-center gap-3 py-1.5 px-3 rounded-lg text-sm cursor-pointer transition-all ${
+                      idVars.includes(col)
+                        ? "bg-blue-50 text-blue-700 border border-blue-100 shadow-sm"
+                        : "hover:bg-white hover:shadow-sm border border-transparent"
+                    }`}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={idVars.includes(col)}
+                      onChange={() => handleIdVarsChange(col)}
+                      className="rounded text-blue-600 focus:ring-blue-500/20"
+                    />
+                    {col}
+                  </label>
+                ))}
+              </div>
+              <p className="text-[10px] text-slate-400">Identifiers that remain as columns.</p>
+            </div>
+
+            <div className="space-y-2">
+              <div className="flex items-center justify-between">
+                <label className="block text-xs font-bold text-slate-700 uppercase tracking-tight">
+                  Value Variables:
+                </label>
+                <button
+                  type="button"
+                  onClick={() =>
+                    setValueVars(valueVars.length === columns.length ? [] : [...columns])
+                  }
+                  className="text-[10px] font-bold text-blue-600 hover:text-blue-700"
+                >
+                  {valueVars.length === columns.length ? "Deselect All" : "Select All"}
+                </button>
+              </div>
+              <div className="border border-slate-200 rounded-lg max-h-48 overflow-y-auto p-3 bg-slate-50/50 space-y-1">
+                {columns.map((col) => (
+                  <label
+                    key={`val-${col}`}
+                    className={`flex items-center gap-3 py-1.5 px-3 rounded-lg text-sm cursor-pointer transition-all ${
+                      valueVars.includes(col)
+                        ? "bg-blue-50 text-blue-700 border border-blue-100 shadow-sm"
+                        : "hover:bg-white hover:shadow-sm border border-transparent"
+                    }`}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={valueVars.includes(col)}
+                      onChange={() => handleValueVarsChange(col)}
+                      className="rounded text-blue-600 focus:ring-blue-500/20"
+                    />
+                    {col}
+                  </label>
+                ))}
+              </div>
+              <p className="text-[10px] text-slate-400">Columns to unpivot. Leave empty for all.</p>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6 pt-4">
+            <div className="space-y-1.5">
+              <label className="block text-xs font-bold text-slate-700 uppercase tracking-tight">
+                Variable Name:
+              </label>
+              <input
+                type="text"
+                value={varName}
+                onChange={(e) => setVarName(e.target.value)}
+                className="w-full bg-white border border-slate-200 rounded-lg px-4 py-2.5 text-sm text-slate-900 focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 focus:outline-none transition-all"
+                placeholder="default: variable"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <label className="block text-xs font-bold text-slate-700 uppercase tracking-tight">
+                Value Name:
+              </label>
+              <input
+                type="text"
+                value={valueName}
+                onChange={(e) => setValueName(e.target.value)}
+                className="w-full bg-white border border-slate-200 rounded-lg px-4 py-2.5 text-sm text-slate-900 focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 focus:outline-none transition-all"
+                placeholder="default: value"
+              />
+            </div>
+          </div>
+
+          <div className="flex justify-end gap-3 pt-6 border-t border-gray-50">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-6 py-2 text-sm font-bold text-slate-600 hover:text-slate-800 hover:bg-slate-50 rounded-lg transition-all"
+            >
+              Cancel
+            </button>
             <button
               type="submit"
-              className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-md font-medium transition-colors duration-150 text-sm disabled:opacity-50"
+              className="bg-blue-500 hover:bg-blue-600 text-white px-8 py-2 rounded-lg font-bold text-sm shadow-lg shadow-blue-100 transition-all active:scale-95 disabled:opacity-50"
               disabled={loading}
             >
               {loading ? "Processing..." : "Apply Melt"}
             </button>
-            <button
-              type="button"
-              onClick={onClose}
-              className="bg-white border border-gray-300 text-gray-700 hover:bg-gray-50 px-4 py-2 rounded-md font-medium transition-colors duration-150 text-sm"
-            >
-              Cancel
-            </button>
           </div>
-        </div>
-      </form>
-      {result && (
-        <div className="mt-6 border-t border-gray-100 pt-5 space-y-3">
-          <div className="flex items-center justify-between">
-            <h4 className="text-xs font-bold text-gray-400 uppercase tracking-widest">
-              Transformation Result Preview
-            </h4>
-            <span className="text-[10px] text-gray-400 bg-gray-50 px-2 py-0.5 rounded border border-gray-100">
-              {result.row_count} rows generated
-            </span>
+        </form>
+
+        {result && (
+          <div className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+            <div className="bg-gray-50 border-b border-gray-200 px-6 py-4">
+              <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+                <div className="space-y-1">
+                  <div className="flex items-center gap-2 text-sm font-bold text-gray-900">
+                    <span className="text-blue-600">Melted Result</span>
+                    <span className="text-gray-300 font-normal">/</span>
+                    <span className="text-gray-600">
+                      {result.row_count || result.rows?.length || 0} rows generated
+                    </span>
+                  </div>
+                  <p className="text-xs text-gray-500">Preview of the reshaped data.</p>
+                </div>
+
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={handleSaveMelted}
+                    disabled={saving}
+                    className="inline-flex items-center gap-2 rounded-lg border border-gray-200 bg-white px-5 py-2 text-sm font-bold text-gray-700 transition-all hover:bg-gray-50 hover:border-gray-300 active:bg-gray-100"
+                  >
+                    <LuSave className="h-4 w-4 text-blue-500" />
+                    {saving ? "Saving..." : "Save result"}
+                  </button>
+
+                  <div className="relative">
+                    <button
+                      type="button"
+                      onClick={() => setIsExportMenuOpen((open) => !open)}
+                      className="inline-flex items-center gap-2 rounded-lg bg-slate-900 px-5 py-2 text-sm font-bold text-white shadow-lg shadow-slate-100 transition-all hover:bg-slate-800 active:scale-95"
+                    >
+                      <LuDownload className="h-4 w-4" />
+                      Export
+                      <LuChevronDown
+                        className={`h-4 w-4 transition-transform duration-200 ${isExportMenuOpen ? "rotate-180" : ""}`}
+                      />
+                    </button>
+                    {isExportMenuOpen && (
+                      <div className="absolute right-0 top-full z-20 mt-2 w-56 overflow-hidden rounded-lg border border-gray-100 bg-white p-1.5 shadow-2xl ring-1 ring-gray-900/5">
+                        <div className="px-3 py-2 text-[10px] font-bold uppercase tracking-widest text-gray-400">
+                          Select Format
+                        </div>
+                        {[
+                          { label: "CSV", format: "csv", desc: "For spreadsheets & generic use" },
+                          { label: "Excel", format: "excel", desc: "Microsoft Excel Worksheet" },
+                          { label: "PDF", format: "pdf", desc: "Ready for printing & sharing" },
+                          { label: "JSON", format: "json", desc: "For developers & API use" },
+                        ].map((item) => (
+                          <button
+                            key={item.format}
+                            type="button"
+                            onClick={() => handleExportAs(item.format)}
+                            className="flex w-full flex-col gap-0.5 rounded-lg px-3 py-2.5 text-left transition-colors hover:bg-blue-50 group"
+                          >
+                            <span className="text-sm font-bold text-gray-700 group-hover:text-blue-700">
+                              {item.label}
+                            </span>
+                            <span className="text-[10px] text-gray-400">{item.desc}</span>
+                          </button>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div className="p-1">
+              <TransformResultPreview columns={result.columns} rows={result.rows} embedded />
+            </div>
           </div>
-          <TransformResultPreview columns={result.columns} rows={result.rows} />
-        </div>
-      )}
+        )}
+      </div>
     </div>
   );
 };
@@ -210,6 +390,8 @@ const MeltForm = ({ projectId, onClose }) => {
 MeltForm.propTypes = {
   projectId: PropTypes.string.isRequired,
   onClose: PropTypes.func.isRequired,
+  onTransform: PropTypes.func.isRequired,
+  onSave: PropTypes.func.isRequired,
 };
 
 export default MeltForm;

--- a/dataloom-frontend/src/Components/forms/PivotTableForm.jsx
+++ b/dataloom-frontend/src/Components/forms/PivotTableForm.jsx
@@ -1,19 +1,23 @@
 import { useState } from "react";
 import PropTypes from "prop-types";
+import { LuChevronDown, LuDownload, LuSave, LuLayoutGrid } from "react-icons/lu";
 import TransformResultPreview from "./TransformResultPreview";
-import { transformProject } from "../../api";
+import { transformProject, saveProject } from "../../api";
 import { PIVOT_TABLES } from "../../constants/operationTypes";
 import useError from "../../hooks/useError";
 import FormErrorAlert from "../common/FormErrorAlert";
 import ColumnSelect from "../common/ColumnSelect";
+import { downloadCsv, downloadExcel, downloadJson, downloadPdf } from "../../utils/exportUtils";
 
-const PivotTableForm = ({ projectId, onClose }) => {
+const PivotTableForm = ({ projectId, onClose, onTransform, onSave }) => {
   const [index, setIndex] = useState("");
   const [column, setColumn] = useState("");
   const [value, setValue] = useState("");
   const [aggfun, setAggfun] = useState("sum");
   const [result, setResult] = useState(null);
   const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [isExportMenuOpen, setIsExportMenuOpen] = useState(false);
   const { error, clearError, handleError } = useError();
 
   const handleSubmit = async (e) => {
@@ -35,74 +39,241 @@ const PivotTableForm = ({ projectId, onClose }) => {
     }
   };
 
+  const handleSavePivoted = async () => {
+    if (!result) return;
+
+    setSaving(true);
+    try {
+      const pivotQuery = { index, column, value, aggfun };
+      const commitMessage = await onSave(pivotQuery);
+      if (!commitMessage) return;
+
+      await transformProject(projectId, {
+        operation_type: PIVOT_TABLES,
+        pivot_query: pivotQuery,
+        persist: true,
+      });
+
+      const savedProject = await saveProject(projectId, commitMessage);
+      onTransform(savedProject);
+      setResult(savedProject);
+    } catch (err) {
+      handleError(err);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleExportAs = (format) => {
+    if (!result) return;
+    const cols = result.columns || [];
+    const rows = result.rows || [];
+    const filename = `pivot-export.${format}`;
+
+    switch (format) {
+      case "csv":
+        downloadCsv(filename, cols, rows);
+        break;
+      case "excel":
+        downloadExcel(filename, cols, rows);
+        break;
+      case "pdf":
+        downloadPdf(filename, cols, rows, "Pivot Table Export");
+        break;
+      case "json":
+        downloadJson(filename, cols, rows);
+        break;
+      default:
+        break;
+    }
+    setIsExportMenuOpen(false);
+  };
+
   return (
-    <div className="p-4 border border-gray-200 rounded-lg bg-white">
-      <form onSubmit={handleSubmit}>
-        <h3 className="font-semibold text-gray-900 mb-2">Pivot Table</h3>
-        <div className="flex space-x-2 mb-4">
-          <div className="flex-1">
-            <label className="block text-sm font-medium text-gray-700">Index:</label>
+    <div className="border border-gray-200 rounded-lg bg-white shadow-sm mb-8 mx-8 overflow-hidden">
+      <div className="bg-gray-50 border-b border-gray-200 px-6 py-4">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-4">
+            <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-blue-50 text-blue-600 shadow-sm ring-1 ring-inset ring-blue-100">
+              <LuLayoutGrid className="h-4 w-4" />
+            </div>
+            <div>
+              <h3 className="text-sm font-bold uppercase tracking-wider text-slate-800">
+                Pivot Table
+              </h3>
+              <p className="text-[11px] text-slate-500 font-medium mt-0.5">
+                Create a cross-tabulation to summarize and analyze data relationships.
+              </p>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-600 p-1.5 hover:bg-gray-200/50 rounded-lg transition-all"
+          >
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      <form onSubmit={handleSubmit} className="p-6 space-y-6">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-6">
+          <div className="space-y-2">
+            <label className="block text-sm font-semibold text-gray-700">Index (Rows)</label>
             <input
               type="text"
               value={index}
               onChange={(e) => setIndex(e.target.value)}
-              className="border border-gray-300 rounded-md w-full px-3 py-2 bg-white text-gray-900 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none"
-              placeholder="e.g., col1,col2"
+              className="w-full bg-white border border-gray-200 rounded-xl px-4 py-3 text-sm text-gray-900 focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-all outline-none"
+              placeholder="e.g., col1, col2"
               required
             />
+            <p className="text-[10px] text-gray-400 pl-1">Columns to use as rows in the pivot.</p>
           </div>
-          <div className="flex-1">
-            <label className="block text-sm font-medium text-gray-700">Column:</label>
+
+          <div className="space-y-2">
+            <label className="block text-sm font-semibold text-gray-700">Column (Headers)</label>
             <ColumnSelect
               value={column}
               onChange={(e) => setColumn(e.target.value)}
               placeholder="Select column..."
+              className="w-full bg-white border border-gray-200 rounded-xl px-4 py-3 text-sm focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-all appearance-none cursor-pointer"
             />
+            <p className="text-[10px] text-gray-400 pl-1">Column to use as headers.</p>
           </div>
-        </div>
-        <div className="flex space-x-2 mb-4">
-          <div className="flex-1">
-            <label className="block text-sm font-medium text-gray-700">Value:</label>
+
+          <div className="space-y-2">
+            <label className="block text-sm font-semibold text-gray-700">Value (Cells)</label>
             <ColumnSelect
               value={value}
               onChange={(e) => setValue(e.target.value)}
               placeholder="Select column..."
+              className="w-full bg-white border border-gray-200 rounded-xl px-4 py-3 text-sm focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-all appearance-none cursor-pointer"
             />
+            <p className="text-[10px] text-gray-400 pl-1">Column to summarize.</p>
           </div>
-          <div className="flex-1">
-            <label className="block text-sm font-medium text-gray-700">Aggregation Function:</label>
-            <select
-              value={aggfun}
-              onChange={(e) => setAggfun(e.target.value)}
-              className="border border-gray-300 rounded-md w-full px-3 py-2 bg-white text-gray-900 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none"
-            >
-              <option value="sum">Sum</option>
-              <option value="mean">Mean</option>
-              <option value="count">Count</option>
-              <option value="min">Min</option>
-              <option value="max">Max</option>
-            </select>
+
+          <div className="space-y-2">
+            <label className="block text-sm font-semibold text-gray-700">
+              Aggregation Function
+            </label>
+            <div className="grid grid-cols-3 gap-2">
+              {["sum", "mean", "count", "min", "max"].map((fun) => (
+                <button
+                  key={fun}
+                  type="button"
+                  onClick={() => setAggfun(fun)}
+                  className={`px-3 py-2 text-xs font-medium rounded-lg border transition-all capitalize ${
+                    aggfun === fun
+                      ? "bg-blue-500 text-white border-blue-500 shadow-md shadow-blue-100"
+                      : "bg-white text-gray-600 border-gray-200 hover:border-blue-300 hover:text-blue-500"
+                  }`}
+                >
+                  {fun}
+                </button>
+              ))}
+            </div>
           </div>
         </div>
-        <div className="flex justify-between">
-          <button
-            type="submit"
-            className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-md font-medium transition-colors duration-150"
-            disabled={loading}
-          >
-            {loading ? "Loading..." : "Submit"}
-          </button>
+
+        <div className="pt-6 border-t border-gray-50 flex items-center justify-end gap-3">
           <button
             type="button"
             onClick={onClose}
-            className="bg-white border border-gray-300 text-gray-700 hover:bg-gray-50 px-4 py-2 rounded-md font-medium transition-colors duration-150"
+            className="px-6 py-2.5 text-sm font-semibold text-gray-600 hover:text-gray-800 transition-colors"
           >
             Cancel
+          </button>
+          <button
+            type="submit"
+            className="flex items-center gap-2 bg-blue-500 hover:bg-blue-600 text-white px-8 py-2.5 rounded-lg font-bold text-sm shadow-lg shadow-blue-100 transition-all active:scale-95 disabled:opacity-50 disabled:pointer-events-none"
+            disabled={loading || !index || !column || !value}
+          >
+            {loading ? "Generating..." : "Apply Pivot"}
           </button>
         </div>
       </form>
       <FormErrorAlert message={error} />
-      {result && <TransformResultPreview columns={result.columns} rows={result.rows} />}
+      {result && (
+        <div className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm mt-8">
+          <div className="bg-gray-50 border-b border-gray-200 px-6 py-4">
+            <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+              <div className="space-y-1">
+                <div className="flex items-center gap-2 text-sm font-bold text-gray-900">
+                  <span className="text-blue-600">Pivot Result</span>
+                  <span className="text-gray-300 font-normal">/</span>
+                  <span className="text-gray-600">
+                    {result.rows?.length || 0} summaries generated
+                  </span>
+                </div>
+                <p className="text-xs text-gray-500">Preview of the pivoted data.</p>
+              </div>
+
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={handleSavePivoted}
+                  disabled={saving}
+                  className="inline-flex items-center gap-2 rounded-lg border border-gray-200 bg-white px-5 py-2 text-sm font-bold text-gray-700 transition-all hover:bg-gray-50 hover:border-gray-300 active:bg-gray-100"
+                >
+                  <LuSave className="h-4 w-4 text-blue-500" />
+                  {saving ? "Saving..." : "Save result"}
+                </button>
+
+                <div className="relative">
+                  <button
+                    type="button"
+                    onClick={() => setIsExportMenuOpen((open) => !open)}
+                    className="inline-flex items-center gap-2 rounded-lg bg-slate-900 px-5 py-2 text-sm font-bold text-white shadow-lg shadow-slate-100 transition-all hover:bg-slate-800 active:scale-95"
+                  >
+                    <LuDownload className="h-4 w-4" />
+                    Export
+                    <LuChevronDown
+                      className={`h-4 w-4 transition-transform duration-200 ${isExportMenuOpen ? "rotate-180" : ""}`}
+                    />
+                  </button>
+                  {isExportMenuOpen && (
+                    <div className="absolute right-0 top-full z-20 mt-2 w-56 overflow-hidden rounded-lg border border-gray-100 bg-white p-1.5 shadow-2xl ring-1 ring-gray-900/5">
+                      <div className="px-3 py-2 text-[10px] font-bold uppercase tracking-widest text-gray-400">
+                        Select Format
+                      </div>
+                      {[
+                        { label: "CSV", format: "csv", desc: "For spreadsheets & generic use" },
+                        { label: "Excel", format: "excel", desc: "Microsoft Excel Worksheet" },
+                        { label: "PDF", format: "pdf", desc: "Ready for printing & sharing" },
+                        { label: "JSON", format: "json", desc: "For developers & API use" },
+                      ].map((item) => (
+                        <button
+                          key={item.format}
+                          type="button"
+                          onClick={() => handleExportAs(item.format)}
+                          className="flex w-full flex-col gap-0.5 rounded-lg px-3 py-2.5 text-left transition-colors hover:bg-blue-50 group"
+                        >
+                          <span className="text-sm font-bold text-gray-700 group-hover:text-blue-700">
+                            {item.label}
+                          </span>
+                          <span className="text-[10px] text-gray-400">{item.desc}</span>
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="p-1">
+            <TransformResultPreview columns={result.columns} rows={result.rows} embedded />
+          </div>
+        </div>
+      )}
     </div>
   );
 };
@@ -110,6 +281,8 @@ const PivotTableForm = ({ projectId, onClose }) => {
 PivotTableForm.propTypes = {
   projectId: PropTypes.string.isRequired,
   onClose: PropTypes.func.isRequired,
+  onTransform: PropTypes.func.isRequired,
+  onSave: PropTypes.func.isRequired,
 };
 
 export default PivotTableForm;

--- a/dataloom-frontend/src/Components/forms/SortForm.jsx
+++ b/dataloom-frontend/src/Components/forms/SortForm.jsx
@@ -1,86 +1,270 @@
 import { useState } from "react";
 import PropTypes from "prop-types";
-import { transformProject } from "../../api";
+import { LuChevronDown, LuDownload, LuSave, LuArrowDownUp } from "react-icons/lu";
+import { transformProject, saveProject } from "../../api";
 import { SORT } from "../../constants/operationTypes";
 import TransformResultPreview from "./TransformResultPreview";
 import useError from "../../hooks/useError";
 import FormErrorAlert from "../common/FormErrorAlert";
 import ColumnSelect from "../common/ColumnSelect";
+import { downloadCsv, downloadExcel, downloadJson, downloadPdf } from "../../utils/exportUtils";
 
-const SortForm = ({ projectId, onClose }) => {
+const SortForm = ({ projectId, onClose, onTransform, onSave }) => {
   const [column, setColumn] = useState("");
   const [ascending, setAscending] = useState(true);
   const [result, setResult] = useState(null);
   const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [isExportMenuOpen, setIsExportMenuOpen] = useState(false);
   const { error, clearError, handleError } = useError();
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    console.log("Submitting sort with parameters:", { column, ascending });
     setLoading(true);
     clearError();
     try {
       const response = await transformProject(projectId, {
         operation_type: SORT,
-        sort_params: {
-          column,
-          ascending,
-        },
+        sort_params: { column, ascending },
       });
       setResult(response);
-      console.log("Sort API response:", response);
     } catch (err) {
-      console.error("Error applying sort:", err.response?.data || err.message);
       handleError(err);
     } finally {
       setLoading(false);
     }
   };
 
+  const handleSaveSorted = async () => {
+    if (!result) return;
+
+    setSaving(true);
+    try {
+      const sortParams = { column, ascending };
+      const commitMessage = await onSave(sortParams);
+      if (!commitMessage) return;
+
+      await transformProject(projectId, {
+        operation_type: SORT,
+        sort_params: sortParams,
+        persist: true,
+      });
+
+      const savedProject = await saveProject(projectId, commitMessage);
+      onTransform(savedProject);
+      setResult(savedProject);
+    } catch (err) {
+      handleError(err);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleExportAs = (format) => {
+    if (!result) return;
+    const cols = result.columns || [];
+    const rows = result.rows || [];
+    const filename = `sorted-export.${format}`;
+
+    switch (format) {
+      case "csv":
+        downloadCsv(filename, cols, rows);
+        break;
+      case "excel":
+        downloadExcel(filename, cols, rows);
+        break;
+      case "pdf":
+        downloadPdf(filename, cols, rows, "Sorted Dataset Export");
+        break;
+      case "json":
+        downloadJson(filename, cols, rows);
+        break;
+      default:
+        break;
+    }
+    setIsExportMenuOpen(false);
+  };
+
   return (
-    <div className="p-4 border border-gray-200 rounded-lg bg-white">
-      <form onSubmit={handleSubmit}>
-        <h3 className="font-semibold text-gray-900 mb-2">Sort Dataset</h3>
-        <div className="flex flex-wrap mb-4">
-          <div className="w-full sm:w-1/2 mb-2">
-            <label className="block mb-1 text-sm font-medium text-gray-700">Column:</label>
-            <ColumnSelect
-              value={column}
-              onChange={(e) => setColumn(e.target.value)}
-              placeholder="Select column to sort by..."
-            />
+    <div className="border border-gray-200 rounded-lg bg-white shadow-sm mb-8 mx-8 overflow-hidden">
+      <div className="bg-gray-50 border-b border-gray-200 px-6 py-4">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-4">
+            <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-blue-50 text-blue-600 shadow-sm ring-1 ring-inset ring-blue-100">
+              <LuArrowDownUp className="h-4 w-4" />
+            </div>
+            <div>
+              <h3 className="text-sm font-bold uppercase tracking-wider text-slate-800">
+                Sort Dataset
+              </h3>
+              <p className="text-[11px] text-slate-500 font-medium mt-0.5">
+                Reorder your data based on a specific column&apos;s values.
+              </p>
+            </div>
           </div>
-          <div className="w-full sm:w-1/2 mb-2 pl-2">
-            <label className="block mb-1 text-sm font-medium text-gray-700">Order:</label>
-            <select
-              value={ascending}
-              onChange={(e) => setAscending(e.target.value === "true")}
-              className="border border-gray-300 rounded-md px-3 py-2 w-full bg-white text-gray-900 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none"
-            >
-              <option value="true">Ascending</option>
-              <option value="false">Descending</option>
-            </select>
-          </div>
-        </div>
-        <div className="flex justify-between">
-          <button
-            type="submit"
-            className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-md font-medium transition-colors duration-150"
-            disabled={loading}
-          >
-            Submit
-          </button>
           <button
             type="button"
             onClick={onClose}
-            className="bg-white border border-gray-300 text-gray-700 hover:bg-gray-50 px-4 py-2 rounded-md font-medium transition-colors duration-150"
+            className="text-gray-400 hover:text-gray-600 p-1.5 hover:bg-gray-200/50 rounded-lg transition-all"
+          >
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      <form onSubmit={handleSubmit} className="p-6 space-y-6">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+          <div className="space-y-3">
+            <label className="block text-sm font-semibold text-gray-700">Column to Sort</label>
+            <ColumnSelect
+              value={column}
+              onChange={(e) => setColumn(e.target.value)}
+              placeholder="Select column..."
+              className="w-full bg-white border border-gray-200 rounded-xl px-4 py-3 text-sm focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-all appearance-none cursor-pointer"
+            />
+          </div>
+
+          <div className="space-y-3">
+            <label className="block text-sm font-semibold text-gray-700">Sort Order</label>
+            <div className="flex p-1 bg-gray-50 rounded-xl border border-gray-100">
+              <button
+                type="button"
+                onClick={() => setAscending(true)}
+                className={`flex-1 flex items-center justify-center gap-2 py-2 text-sm font-medium rounded-lg transition-all ${
+                  ascending
+                    ? "bg-white text-blue-500 shadow-sm border border-gray-100"
+                    : "text-gray-500 hover:text-gray-700 hover:bg-white/50"
+                }`}
+              >
+                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M3 4h13M3 8h9m-9 4h6m4 0l4-4m0 0l4 4m-4-4v12"
+                  />
+                </svg>
+                Ascending
+              </button>
+              <button
+                type="button"
+                onClick={() => setAscending(false)}
+                className={`flex-1 flex items-center justify-center gap-2 py-2 text-sm font-medium rounded-lg transition-all ${
+                  !ascending
+                    ? "bg-white text-blue-500 shadow-sm border border-gray-100"
+                    : "text-gray-500 hover:text-gray-700 hover:bg-white/50"
+                }`}
+              >
+                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M3 4h13M3 8h9m-9 4h9m5-1l4 4m0 0l4-4m-4 4V4"
+                  />
+                </svg>
+                Descending
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <div className="pt-6 border-t border-gray-50 flex items-center justify-end gap-3">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-6 py-2.5 text-sm font-semibold text-gray-600 hover:text-gray-800 transition-colors"
           >
             Cancel
+          </button>
+          <button
+            type="submit"
+            className="flex items-center gap-2 bg-blue-500 hover:bg-blue-600 text-white px-8 py-2.5 rounded-lg font-bold text-sm shadow-lg shadow-blue-100 transition-all active:scale-95 disabled:opacity-50 disabled:pointer-events-none"
+            disabled={loading || !column}
+          >
+            {loading ? "Sorting..." : "Apply Sort"}
           </button>
         </div>
       </form>
       <FormErrorAlert message={error} />
-      {result && <TransformResultPreview columns={result.columns} rows={result.rows} />}
+      {result && (
+        <div className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm mt-8">
+          <div className="bg-gray-50 border-b border-gray-200 px-6 py-4">
+            <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+              <div className="space-y-1">
+                <div className="flex items-center gap-2 text-sm font-bold text-gray-900">
+                  <span className="text-blue-600">Sort Result</span>
+                  <span className="text-gray-300 font-normal">/</span>
+                  <span className="text-gray-600">{result.rows?.length || 0} rows reordered</span>
+                </div>
+                <p className="text-xs text-gray-500">Preview of the sorted data.</p>
+              </div>
+
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={handleSaveSorted}
+                  disabled={saving}
+                  className="inline-flex items-center gap-2 rounded-lg border border-gray-200 bg-white px-5 py-2 text-sm font-bold text-gray-700 transition-all hover:bg-gray-50 hover:border-gray-300 active:bg-gray-100"
+                >
+                  <LuSave className="h-4 w-4 text-blue-500" />
+                  {saving ? "Saving..." : "Save result"}
+                </button>
+
+                <div className="relative">
+                  <button
+                    type="button"
+                    onClick={() => setIsExportMenuOpen((open) => !open)}
+                    className="inline-flex items-center gap-2 rounded-lg bg-slate-900 px-5 py-2 text-sm font-bold text-white shadow-lg shadow-slate-100 transition-all hover:bg-slate-800 active:scale-95"
+                  >
+                    <LuDownload className="h-4 w-4" />
+                    Export
+                    <LuChevronDown
+                      className={`h-4 w-4 transition-transform duration-200 ${isExportMenuOpen ? "rotate-180" : ""}`}
+                    />
+                  </button>
+                  {isExportMenuOpen && (
+                    <div className="absolute right-0 top-full z-20 mt-2 w-56 overflow-hidden rounded-lg border border-gray-100 bg-white p-1.5 shadow-2xl ring-1 ring-gray-900/5">
+                      <div className="px-3 py-2 text-[10px] font-bold uppercase tracking-widest text-gray-400">
+                        Select Format
+                      </div>
+                      {[
+                        { label: "CSV", format: "csv", desc: "For spreadsheets & generic use" },
+                        { label: "Excel", format: "excel", desc: "Microsoft Excel Worksheet" },
+                        { label: "PDF", format: "pdf", desc: "Ready for printing & sharing" },
+                        { label: "JSON", format: "json", desc: "For developers & API use" },
+                      ].map((item) => (
+                        <button
+                          key={item.format}
+                          type="button"
+                          onClick={() => handleExportAs(item.format)}
+                          className="flex w-full flex-col gap-0.5 rounded-lg px-3 py-2.5 text-left transition-colors hover:bg-blue-50 group"
+                        >
+                          <span className="text-sm font-bold text-gray-700 group-hover:text-blue-700">
+                            {item.label}
+                          </span>
+                          <span className="text-[10px] text-gray-400">{item.desc}</span>
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="p-1">
+            <TransformResultPreview columns={result.columns} rows={result.rows} embedded />
+          </div>
+        </div>
+      )}
     </div>
   );
 };
@@ -88,6 +272,8 @@ const SortForm = ({ projectId, onClose }) => {
 SortForm.propTypes = {
   projectId: PropTypes.string.isRequired,
   onClose: PropTypes.func.isRequired,
+  onTransform: PropTypes.func.isRequired,
+  onSave: PropTypes.func.isRequired,
 };
 
 export default SortForm;

--- a/dataloom-frontend/src/Components/forms/TransformResultPreview.jsx
+++ b/dataloom-frontend/src/Components/forms/TransformResultPreview.jsx
@@ -1,6 +1,6 @@
 import PropTypes from "prop-types";
 
-const TransformResultPreview = ({ columns, rows }) => {
+const TransformResultPreview = ({ columns, rows, embedded = false }) => {
   if (!rows || rows.length === 0) {
     return <p className="text-gray-500 mt-4 text-xs font-medium">No data available</p>;
   }
@@ -11,9 +11,12 @@ const TransformResultPreview = ({ columns, rows }) => {
 
   const displayColumns = ["S.No.", ...columns];
   const displayRows = rows.map((row, index) => [index + 1, ...row]);
+  const containerClassName = embedded
+    ? "overflow-hidden border-t border-slate-200 bg-white mb-6"
+    : "mt-2 overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm mb-4";
 
   return (
-    <div className="mt-2 border border-gray-200 rounded-lg shadow-sm overflow-hidden bg-white">
+    <div className={containerClassName}>
       <div className="overflow-x-auto overflow-y-auto max-h-72">
         <table className="min-w-full bg-white border-collapse">
           <thead className="sticky top-0 bg-gray-50 z-10">
@@ -21,20 +24,12 @@ const TransformResultPreview = ({ columns, rows }) => {
               {displayColumns.map((col, index) => (
                 <th
                   key={index}
-                  className="py-1.5 px-3 border-b border-gray-200 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                  className={`py-2.5 border-b border-gray-200 text-sm font-semibold text-gray-600 uppercase tracking-tight whitespace-nowrap bg-gray-50 ${index === 0 ? "pl-4 pr-2 text-left" : "px-4 text-left"}`}
                 >
-                  {/* 
-                    TODO: Button is kept for visual consistency with the main application DataFrame.
-                    Wire up actual sort/filter handlers here in the future.
-                  */}
                   <button
                     type="button"
-                    className="w-full text-left text-gray-500 hover:text-gray-700 hover:bg-gray-100 py-0.5 px-1.5 rounded-md transition-colors duration-150"
+                    className={`flex items-center gap-2 text-gray-600 hover:text-gray-900 hover:bg-gray-100 py-1 px-2 rounded-md transition-colors duration-150 ${index === 0 ? "text-left" : ""}`}
                     title={`Sort by ${col}`}
-                    onClick={() => {
-                      // TODO: Implement column sort/filter behavior
-                      console.log(`Column header clicked: ${col}`);
-                    }}
                   >
                     {col}
                   </button>
@@ -42,15 +37,23 @@ const TransformResultPreview = ({ columns, rows }) => {
               ))}
             </tr>
           </thead>
-          <tbody className="bg-white">
+          <tbody className="bg-white divide-y divide-gray-100">
             {displayRows.map((row, rowIndex) => (
-              <tr
-                key={rowIndex}
-                className="border-b border-gray-100 hover:bg-gray-50 transition-colors duration-150"
-              >
+              <tr key={rowIndex} className="hover:bg-slate-50 transition-colors duration-150">
                 {row.map((cell, cellIndex) => (
-                  <td key={cellIndex} className="py-1 px-3 text-xs text-gray-700 whitespace-nowrap">
-                    {String(cell)}
+                  <td
+                    key={cellIndex}
+                    className={`py-2 text-sm text-gray-700 whitespace-nowrap ${cellIndex === 0 ? "pl-4 pr-2 text-left" : "px-4 text-left"}`}
+                  >
+                    <div
+                      className={
+                        cellIndex !== 0
+                          ? "p-1.5"
+                          : "p-1.5 text-gray-400 font-mono text-xs text-left"
+                      }
+                    >
+                      {String(cell)}
+                    </div>
                   </td>
                 ))}
               </tr>
@@ -64,6 +67,7 @@ const TransformResultPreview = ({ columns, rows }) => {
 
 TransformResultPreview.propTypes = {
   columns: PropTypes.arrayOf(PropTypes.string).isRequired,
+  embedded: PropTypes.bool,
   rows: PropTypes.arrayOf(
     PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool])),
   ).isRequired,

--- a/dataloom-frontend/src/Components/forms/TrimWhitespaceForm.jsx
+++ b/dataloom-frontend/src/Components/forms/TrimWhitespaceForm.jsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import PropTypes from "prop-types";
+import { LuScissors } from "react-icons/lu";
 import { transformProject } from "../../api";
 import { TRIM_WHITESPACE } from "../../constants/operationTypes";
 import { useProjectContext } from "../../context/ProjectContext";
@@ -36,46 +37,91 @@ const TrimWhitespaceForm = ({ projectId, onClose, onTransform }) => {
   };
 
   return (
-    <div className="p-4 border border-gray-200 rounded-lg bg-white">
-      <form onSubmit={handleSubmit}>
-        <h3 className="font-semibold text-gray-900 mb-2">Trim Whitespace</h3>
-
-        <div className="mb-4">
-          <label className="block text-sm font-medium text-gray-700">Column:</label>
-          <select
-            value={column}
-            onChange={(e) => setColumn(e.target.value)}
-            className="border border-gray-300 rounded-md w-full px-3 py-2 bg-white text-gray-900 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none"
-            required
-          >
-            <option value="">Select column...</option>
-            <option value="All string columns">All string columns</option>
-            {columns.map((col) => (
-              <option key={col} value={col}>
-                {col}
-              </option>
-            ))}
-          </select>
-        </div>
-
-        <div className="flex justify-between">
-          <button
-            type="submit"
-            disabled={loading}
-            className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-md font-medium transition-colors duration-150 disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            {loading ? "Applying..." : "Apply"}
-          </button>
-
+    <div className="border border-gray-200 rounded-lg bg-white shadow-sm mb-8 mx-8 overflow-hidden">
+      <div className="bg-gray-50 border-b border-gray-200 px-6 py-4">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-4">
+            <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-blue-50 text-blue-600 shadow-sm ring-1 ring-inset ring-blue-100">
+              <LuScissors className="h-4 w-4" />
+            </div>
+            <div>
+              <h3 className="text-sm font-bold uppercase tracking-wider text-slate-800">
+                Trim Whitespace
+              </h3>
+              <p className="text-[11px] text-slate-500 font-medium mt-0.5">
+                Remove leading and trailing spaces from text.
+              </p>
+            </div>
+          </div>
           <button
             type="button"
             onClick={onClose}
-            className="bg-white border border-gray-300 text-gray-700 hover:bg-gray-50 px-4 py-2 rounded-md font-medium transition-colors duration-150"
+            className="text-gray-400 hover:text-gray-600 p-1.5 hover:bg-gray-200/50 rounded-lg transition-all"
           >
-            Cancel
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
           </button>
         </div>
-      </form>
+      </div>
+
+      <div className="p-8">
+        <form onSubmit={handleSubmit} className="space-y-6">
+          <div className="max-w-md space-y-1.5">
+            <label className="block text-xs font-bold text-slate-700 uppercase tracking-tight">
+              Column:
+            </label>
+            <div className="relative">
+              <select
+                value={column}
+                onChange={(e) => setColumn(e.target.value)}
+                className="w-full bg-white border border-slate-200 rounded-lg px-4 py-2.5 text-sm text-slate-900 focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 focus:outline-none transition-all appearance-none cursor-pointer"
+                required
+              >
+                <option value="">Select column...</option>
+                <option value="All string columns">All string columns</option>
+                {columns.map((col) => (
+                  <option key={col} value={col}>
+                    {col}
+                  </option>
+                ))}
+              </select>
+              <div className="absolute inset-y-0 right-0 flex items-center px-2 pointer-events-none text-slate-400">
+                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M19 9l-7 7-7-7"
+                  />
+                </svg>
+              </div>
+            </div>
+          </div>
+
+          <div className="flex justify-end gap-3 pt-4 border-t border-gray-50">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-6 py-2 text-sm font-bold text-slate-600 hover:text-slate-800 hover:bg-slate-50 rounded-lg transition-all"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={loading}
+              className="bg-blue-500 hover:bg-blue-600 text-white px-8 py-2 rounded-lg font-bold text-sm shadow-lg shadow-blue-100 transition-all active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {loading ? "Trimming..." : "Apply Trim"}
+            </button>
+          </div>
+        </form>
+      </div>
     </div>
   );
 };

--- a/dataloom-frontend/src/utils/exportUtils.js
+++ b/dataloom-frontend/src/utils/exportUtils.js
@@ -1,0 +1,69 @@
+import * as XLSX from "xlsx";
+import { jsPDF } from "jspdf";
+import autoTable from "jspdf-autotable";
+
+const escapeCsvValue = (value) => {
+  const text = value === null || value === undefined ? "" : String(value);
+  return `"${text.replaceAll('"', '""')}"`;
+};
+
+const buildCsv = (columns, rows) => {
+  const header = columns.map(escapeCsvValue).join(",");
+  const body = rows.map((row) => row.map(escapeCsvValue).join(",")).join("\n");
+  return [header, body].filter(Boolean).join("\n");
+};
+
+export const downloadCsv = (filename, columns, rows) => {
+  const csv = buildCsv(columns, rows);
+  const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+};
+
+export const downloadJson = (filename, columns, rows) => {
+  const json = rows.map((row) =>
+    columns.reduce((acc, column, index) => {
+      acc[column] = row[index];
+      return acc;
+    }, {}),
+  );
+  const blob = new Blob([JSON.stringify(json, null, 2)], {
+    type: "application/json;charset=utf-8;",
+  });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+};
+
+export const downloadExcel = (filename, columns, rows) => {
+  const sheetData = [columns, ...rows];
+  const worksheet = XLSX.utils.aoa_to_sheet(sheetData);
+  const workbook = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(workbook, worksheet, "ExportData");
+  XLSX.writeFile(workbook, filename);
+};
+
+export const downloadPdf = (filename, columns, rows, title = "Dataset Export") => {
+  const doc = new jsPDF({ orientation: "landscape", unit: "pt", format: "a4" });
+  doc.setFontSize(14);
+  doc.text(title, 40, 35);
+  autoTable(doc, {
+    startY: 50,
+    head: [columns],
+    body: rows,
+    styles: { fontSize: 8, cellPadding: 4 },
+    headStyles: { fillColor: [37, 99, 235] },
+  });
+  doc.save(filename);
+};


### PR DESCRIPTION
## Summary

Redesigns all 9 transformation form UIs with a modern card-based layout, adds multi-format data export (CSV/JSON/Excel/PDF), and fixes filter transformation persistence for save/checkpoint replay.

## Changes

### Frontend (UI Redesign)
- **All 9 transformation forms** (GroupBy, Filter, Sort, Melt, Pivot, CastDataType, DropDuplicate, TrimWhitespace, AdvQueryFilter) redesigned with:
  - Card-based layout with icon headers, descriptions, and close buttons
  - Consistent typography, spacing, and color system
  - Inline result preview via `TransformResultPreview` component
  - Responsive form fields with custom-styled dropdowns
- **Table component** improved with better column header styling and row hover effects
- **MenuNavbar** updated with export menu integration
- **Homescreen** layout improvements

### Frontend (Export Utilities)
- New `exportUtils.js` module supporting:
  - **CSV** — proper escaping and UTF-8 encoding
  - **JSON** — formatted column-keyed output
  - **Excel** — via `xlsx` library
  - **PDF** — landscape A4 with auto-table via `jspdf` + `jspdf-autotable`

### Backend (Filter Persistence Fix)
- Added `persist` flag to `TransformationInput` schema (default `True`)
- Filter operation now respects `persist` flag instead of hardcoded `False`
- Added `filter` replay branch in `apply_logged_transformation` so saved/checkpointed filter transforms are replayed correctly

### Tests
- Added `TestSaveWithFilterReplay` integration test verifying end-to-end filter → save → reload
- Fixed `delete_row` index assertion to match RangeIndex reset behavior
- Fixed `unknown_action_type` test to expect `TransformationError` raise

## New Dependencies
- `jspdf` ^4.2.1
- `jspdf-autotable` ^5.0.7
- `xlsx` ^0.18.5
