### PR TITLE
fix(backend): coerce cell edit values to column dtype before assignment

### DIFF
--- a/dataloom-backend/app/services/transformation_service.py
+++ b/dataloom-backend/app/services/transformation_service.py
@@ -197,6 +197,60 @@ def change_cell_value(df: pd.DataFrame, row_index: int, col_index: int, value) -
 
     # col_index is 1-based from frontend (accounting for S.No. column)
     column_name = df.columns[col_index - 1]
+
+    # Cast value to match the column's existing dtype so pandas doesn't reject
+    # string values for numeric columns (the frontend always sends strings).
+    col_dtype = df[column_name].dtype
+    if value == "" or value is None:
+        # Clearing a cell stores Python None. Numeric columns are upcast to
+        # object so None can coexist with the remaining values (int64 has no
+        # null sentinel; we upcast float64 too for consistency with the int
+        # path, even though NaN would fit natively).
+        if pd.api.types.is_integer_dtype(col_dtype) or pd.api.types.is_float_dtype(col_dtype):
+            df[column_name] = df[column_name].astype(object)
+        value = None
+    else:
+        try:
+            if pd.api.types.is_integer_dtype(col_dtype):
+                # Try int() first so large integer strings like
+                # "9007199254740993" (above 2^53) keep full precision —
+                # int(float(...)) would round-trip them through a 64-bit
+                # float and lose bits. Fractional input ("31.7") falls
+                # through to int(float(...)) and silently truncates;
+                # truncation is kept deliberately so common typos like
+                # "31.0" still round-trip cleanly. Non-numeric strings
+                # ("hello") and out-of-range exponents ("1e500") raise and
+                # fall through to the object-fallback branch below.
+                try:
+                    value = int(str(value).strip())
+                except ValueError:
+                    value = int(float(value))
+            elif pd.api.types.is_float_dtype(col_dtype):
+                value = float(value)
+            elif pd.api.types.is_bool_dtype(col_dtype):
+                # Accepted tokens are a superset of cast_data_type()'s, so a
+                # value that cast-to-boolean would accept never gets rejected
+                # by a cell edit.
+                normalized = str(value).strip().lower()
+                if normalized in ("true", "1", "yes", "t", "y", "on"):
+                    value = True
+                elif normalized in ("false", "0", "no", "f", "n", "off"):
+                    value = False
+                else:
+                    raise TransformationError(
+                        f"Cannot interpret {value!r} as boolean for column "
+                        f"'{column_name}'. Expected one of: true/false, 1/0, "
+                        "yes/no, t/f, y/n, on/off."
+                    )
+        except (ValueError, TypeError, OverflowError):
+            # One uncoercible edit (e.g. "hello" in an int column, or an
+            # out-of-range exponent like "1e500") demotes the whole column
+            # to object dtype, preserving the user's input at the cost of
+            # the column's type invariant. Loud failure would be safer but
+            # the product choice is to keep the edit and let the UI surface
+            # the dtype change.
+            df[column_name] = df[column_name].astype(object)
+
     df.at[row_index, column_name] = value
     return df
 

--- a/dataloom-backend/tests/test_transformations.py
+++ b/dataloom-backend/tests/test_transformations.py
@@ -157,6 +157,83 @@ class TestChangeCellValue:
         result = change_cell_value(sample_df, 0, 1, "Alice Updated")
         assert result.iloc[0]["name"] == "Alice Updated"
 
+    # int column — frontend always sends strings
+    def test_int_cell_with_numeric_string_preserves_dtype(self, sample_df):
+        result = change_cell_value(sample_df, 0, 2, "31")
+        assert result.iloc[0]["age"] == 31
+        assert pd.api.types.is_integer_dtype(result["age"].dtype)
+
+    def test_int_cell_with_fractional_string_truncates(self, sample_df):
+        # Documented behavior: int columns silently truncate fractional input.
+        result = change_cell_value(sample_df, 0, 2, "31.7")
+        assert result.iloc[0]["age"] == 31
+        assert pd.api.types.is_integer_dtype(result["age"].dtype)
+
+    def test_int_cell_preserves_precision_for_large_integer_string(self, sample_df):
+        # 2^53 + 1 cannot be represented exactly as a float64, so a naive
+        # int(float(...)) would lose the trailing bit. int() handles it.
+        result = change_cell_value(sample_df, 0, 2, "9007199254740993")
+        assert result.iloc[0]["age"] == 9007199254740993
+        assert pd.api.types.is_integer_dtype(result["age"].dtype)
+
+    def test_int_cell_with_overflowing_exponent_upcasts_column(self, sample_df):
+        # int(float("1e500")) raises OverflowError (float is inf); should
+        # upcast to object instead of bubbling up as a 500.
+        result = change_cell_value(sample_df, 0, 2, "1e500")
+        assert result["age"].dtype == object
+        assert result.iloc[0]["age"] == "1e500"
+
+    def test_int_cell_with_non_numeric_string_upcasts_column(self, sample_df):
+        result = change_cell_value(sample_df, 0, 2, "hello")
+        assert result.iloc[0]["age"] == "hello"
+        assert result["age"].dtype == object
+
+    # float column
+    def test_float_cell_with_decimal_string(self):
+        df = pd.DataFrame({"name": ["A", "B"], "score": [1.0, 2.0]})
+        result = change_cell_value(df, 0, 2, "3.14")
+        assert result.iloc[0]["score"] == pytest.approx(3.14)
+        assert pd.api.types.is_float_dtype(result["score"].dtype)
+
+    # bool column — explicit truthy/falsy matrix, raise on unknown
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("true", True),
+            ("True", True),
+            ("1", True),
+            ("yes", True),
+            ("t", True),
+            ("y", True),
+            ("on", True),
+            ("false", False),
+            ("False", False),
+            ("0", False),
+            ("no", False),
+            ("f", False),
+            ("n", False),
+            ("off", False),
+        ],
+    )
+    def test_bool_cell_truthy_falsy_matrix(self, raw, expected):
+        df = pd.DataFrame({"name": ["A"], "active": [True]})
+        result = change_cell_value(df, 0, 2, raw)
+        # pandas stores booleans as np.bool_; compare by value, not identity.
+        assert bool(result.iloc[0]["active"]) == expected
+        assert pd.api.types.is_bool_dtype(result["active"].dtype)
+
+    def test_bool_cell_rejects_unknown_token(self):
+        df = pd.DataFrame({"name": ["A"], "active": [True]})
+        with pytest.raises(TransformationError, match="as boolean"):
+            change_cell_value(df, 0, 2, "foo")
+
+    # empty-string clears numeric cell and upcasts the column
+    def test_clear_numeric_cell_stores_none(self, sample_df):
+        result = change_cell_value(sample_df, 0, 2, "")
+        assert result.iloc[0]["age"] is None
+        # column was upcast to object so None can coexist with remaining ints
+        assert result["age"].dtype == object
+
 
 class TestFillEmpty:
     def test_fill_all_columns(self):


### PR DESCRIPTION
## Summary

Fixes #231 — editing an `int64` cell through `change_cell_value()` throws `TypeError: Invalid value '31' for dtype 'int64'`.

## Root Cause

The frontend always sends cell values as JSON strings (e.g. `"2099"`), but `df.at[row_index, column_name] = value` rejects assigning a string to a typed pandas column.

## Changes

**`dataloom-backend/app/services/transformation_service.py`** — `change_cell_value()`

- Inspect the target column's dtype before assignment
- Cast the incoming string value to `int`, `float`, or `bool` to match
- Handle empty/null values by upcasting the column to `object` so `None` can coexist
- If casting fails (e.g. writing `"hello"` into an int column), gracefully fall back to `object` dtype instead of raising a 400

## Testing

- **Lint**: `ruff check` and `ruff format` pass ✅  
- **Backend tests**: 161 passed, 2 pre-existing failures (unrelated to this PR) ✅  
- **Frontend tests**: 48/48 passed ✅  
- **Manual verification** via curl:
  - ✅ Editing an int cell with a numeric string (`"2099"`) — succeeds, value stored as int  
  - ✅ Editing an int cell with a non-numeric string (`"hello"`) — succeeds, column upcasts to object  
  - ✅ Clearing a numeric cell (empty string) — succeeds, stores None  
