### PR TITLE
Fix: resolve handleCloseModal initialization error on frontend

### DIFF
--- a/dataloom-frontend/src/Components/Homescreen.jsx
+++ b/dataloom-frontend/src/Components/Homescreen.jsx
@@ -107,6 +107,16 @@ const HomeScreen = () => {
   const isFormValid =
     projectName.trim().length > 0 && projectDescription.trim().length > 0 && fileUpload !== null;
 
+  const handleCloseModal = useCallback(() => {
+    setShowModal(false);
+    setProjectName("");
+    setProjectDescription("");
+    setFileUpload(null);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+  }, []);
+
   useEffect(() => {
     fetchRecentProjects();
   }, []);
@@ -132,16 +142,6 @@ const HomeScreen = () => {
   const handleNewProjectClick = () => {
     setShowModal(true);
   };
-
-  const handleCloseModal = useCallback(() => {
-    setShowModal(false);
-    setProjectName("");
-    setProjectDescription("");
-    setFileUpload(null);
-    if (fileInputRef.current) {
-      fileInputRef.current.value = "";
-    }
-  }, []);
 
   const handleSubmitModal = async (event) => {
     event.preventDefault();


### PR DESCRIPTION
## Description

Fixed a frontend runtime error where the application crashed with:

```text
Cannot access 'handleCloseModal' before initialization
```

The issue occurred while running the frontend after starting the backend server locally. The error was caused by referencing `handleCloseModal` before its initialization. Updated the component logic to ensure the function is declared before usage.

Fixes #271

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

Describe the tests you ran to verify your changes.

- [x] Existing tests pass
- [ ] New tests added
- [x] Manual testing

## Screenshots

**Before Change**
![Before Change](https://res.cloudinary.com/dwvegpato/image/upload/v1777730586/noyq6jidvv0u6xd2x16t.png)

**After Change**
![After Change](https://res.cloudinary.com/dwvegpato/image/upload/v1777730543/njwv0akmkrkkwy4vpz45.png)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally