### PR TITLE
fix: replace deprecated Pydantic v2 APIs in schemas and transformations

### DIFF
--- a/dataloom-backend/app/api/endpoints/transformations.py
+++ b/dataloom-backend/app/api/endpoints/transformations.py
@@ -174,7 +174,7 @@ async def transform_project(
 
     if should_save:
         save_csv_safe(result_df, project.file_path)
-        log_transformation(db, project_id, transformation_input.operation_type, transformation_input.dict())
+        log_transformation(db, project_id, transformation_input.operation_type, transformation_input.model_dump())
 
     resp = dataframe_to_response(result_df)
     return {

--- a/dataloom-backend/app/schemas.py
+++ b/dataloom-backend/app/schemas.py
@@ -5,7 +5,7 @@ import uuid
 from enum import StrEnum
 from typing import Any
 
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, ConfigDict, field_validator
 
 # --- Enums ---
 
@@ -336,5 +336,4 @@ class LastResponse(BaseModel):
     description: str | None
     last_modified: datetime.datetime
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)


### PR DESCRIPTION
- Replace class-based Config with ConfigDict in LastResponse (schemas.py)
- Add ConfigDict to pydantic imports (schemas.py)
- Replace .dict() with .model_dump() in transformations.py

Fixes #54

## Description

Replace deprecated Pydantic V2 APIs to resolve `PydanticDeprecatedSince20` warnings during tests.

Fixes #54 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

Ran `python -m pytest` — `PydanticDeprecatedSince20` deprecation warnings from these files are now resolved.

- [x] Existing tests pass
- [ ] New tests added
- [x] Manual testing

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [ ] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally
