### PR TITLE
Fix: validate commit message before closing modal and add required in…

### DIFF
--- a/dataloom-frontend/src/Components/MenuNavbar.jsx
+++ b/dataloom-frontend/src/Components/MenuNavbar.jsx
@@ -79,8 +79,12 @@ const MenuNavbar = ({ projectId, onTransform }) => {
   };
 
   const handleSubmitCommit = async (message) => {
+    if (!message || !message.trim()) {
+      setToast({ message: "Commit message is required.", type: "error" });
+      return;
+    }
+
     setIsInputOpen(false);
-    if (!message) return;
 
     try {
       await saveProject(projectId, message);
@@ -426,6 +430,7 @@ const MenuNavbar = ({ projectId, onTransform }) => {
       <InputDialog
         isOpen={isInputOpen}
         message="Enter a commit message for this save:"
+        required={true}
         onSubmit={handleSubmitCommit}
         onCancel={() => setIsInputOpen(false)}
       />

--- a/dataloom-frontend/src/Components/common/InputDialog.jsx
+++ b/dataloom-frontend/src/Components/common/InputDialog.jsx
@@ -2,7 +2,14 @@ import { useState, useEffect } from "react";
 import Modal from "./Modal";
 import Button from "./Button";
 
-export default function InputDialog({ isOpen, message, defaultValue = "", onSubmit, onCancel }) {
+export default function InputDialog({
+  isOpen,
+  message,
+  defaultValue = "",
+  onSubmit,
+  onCancel,
+  required = false,
+}) {
   const [value, setValue] = useState(defaultValue);
 
   useEffect(() => {
@@ -19,11 +26,14 @@ export default function InputDialog({ isOpen, message, defaultValue = "", onSubm
   return (
     <Modal isOpen={isOpen} onClose={onCancel} title="Input Required">
       <form onSubmit={handleSubmit}>
-        <p className="mb-3 text-gray-700">{message}</p>
+        <p className="mb-3 text-gray-700">
+          {message} {required && <span className="text-red-500">*</span>}
+        </p>
         <input
           type="text"
           value={value}
           onChange={(e) => setValue(e.target.value)}
+          placeholder={required ? "Required" : ""}
           className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 mb-4"
           autoFocus
         />


### PR DESCRIPTION
## Description
Fixes the commit message modal closing silently when submitted empty, with no validation error or feedback shown to the user. Also adds a required indicator (asterisk) to the input field so users know upfront the field cannot be left empty.

Fixes #283

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?
- [x] Existing 
- [ ] New tests added
- [x] Manual testing

Tested the following scenarios manually:
1. Clicked OK with empty field → toast error shown, modal stays open
2. Clicked OK with only spaces → toast error shown, modal stays open
3. Clicked OK with a valid message → project saves successfully

## Screen Recordings
**Before**

https://github.com/user-attachments/assets/e56dc137-08bb-4236-8966-39a8cec8e9e3

**After**

https://github.com/user-attachments/assets/eb0a00c8-b07d-4dea-9eca-8f0a3017b32f



## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally