### PR TITLE
fix: move handleCloseModal before useEffect to fix initialization error

### DIFF
--- a/dataloom-frontend/src/Components/Homescreen.jsx
+++ b/dataloom-frontend/src/Components/Homescreen.jsx
@@ -111,6 +111,16 @@ const HomeScreen = () => {
     fetchRecentProjects();
   }, []);
 
+  const handleCloseModal = useCallback(() => {
+    setShowModal(false);
+    setProjectName("");
+    setProjectDescription("");
+    setFileUpload(null);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+  }, []);
+
   useEffect(() => {
     if (!showModal) return;
     const handleKeyDown = (e) => {
@@ -132,16 +142,6 @@ const HomeScreen = () => {
   const handleNewProjectClick = () => {
     setShowModal(true);
   };
-
-  const handleCloseModal = useCallback(() => {
-    setShowModal(false);
-    setProjectName("");
-    setProjectDescription("");
-    setFileUpload(null);
-    if (fileInputRef.current) {
-      fileInputRef.current.value = "";
-    }
-  }, []);
 
   const handleSubmitModal = async (event) => {
     event.preventDefault();


### PR DESCRIPTION
## Description

Brief summary of the changes. Reference any related issues.
The `handleCloseModal` was referenced inside a `useEffect` (line 117) before it was defined (line 136), resulting in a "Cannot access 'handleCloseModal' before initialization" issue that crashed the entire app on load.

Fixes #271 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

Describe the tests you ran to verify your changes.

- [ ] Existing tests pass
- [ ] New tests added
- [x] Manual testing

## Screenshots (if applicable)
<img width="1470" height="956" alt="Screenshot 2026-05-02 at 11 40 53 PM" src="https://github.com/user-attachments/assets/5c8afd6c-bf75-457c-9909-d5e6a5efa77c" />
<img width="1372" height="892" alt="image" src="https://github.com/user-attachments/assets/bc9ebe70-6764-4a8f-89cc-969e5bc86c54" />


## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally
