### PR TITLE
fix: mobile toolbar overflow and toggle behaviour for active forms

### DIFF
--- a/dataloom-frontend/src/Components/MenuNavbar.jsx
+++ b/dataloom-frontend/src/Components/MenuNavbar.jsx
@@ -125,6 +125,23 @@ const MenuNavbar = ({ projectId, onTransform }) => {
   const [activeForm, setActiveForm] = useState(null);
 
   const handleMenuClick = (formType) => {
+    // If clicking the same form that's already open, close it
+    if (activeForm === formType) {
+      setActiveForm(null);
+      setShowFilterForm(false);
+      setShowSortForm(false);
+      setShowDropDuplicateForm(false);
+      setShowAdvQueryFilterForm(false);
+      setShowPivotTableForm(false);
+      setShowCastDataTypeForm(false);
+      setShowTrimWhitespaceForm(false);
+      setShowMeltForm(false);
+      setShowLogs(false);
+      setShowCheckpoints(false);
+      setShowGroupByForm(false);
+      return;
+    }
+
     setShowFilterForm(false);
     setShowSortForm(false);
     setShowDropDuplicateForm(false);
@@ -292,7 +309,7 @@ const MenuNavbar = ({ projectId, onTransform }) => {
         ))}
       </div>
 
-      <div className="flex items-stretch gap-3 px-8 py-2 min-h-[64px]">
+      <div className="flex items-stretch gap-3 px-8 py-2 min-h-[64px] overflow-x-auto">
         {tabs[activeTab].map((section, sectionIdx) => (
           <div key={section.group} className="flex items-stretch gap-3">
             {sectionIdx > 0 && <div className="w-px bg-gray-200 self-stretch" />}


### PR DESCRIPTION
## Description
Fixes two related UX issues in the MenuNavbar toolbar:

1. On mobile viewports, the **Data tab** toolbar items overflow horizontally 
off screen making several options unreachable. Fixed by adding 
`overflow-x-auto` to the toolbar container.

2. Clicking an already active toolbar option did not close the open 
form/panel. Fixed by adding a toggle check in `handleMenuClick` — if the 
clicked `formType` matches the current `activeForm`, all forms are closed 
and `activeForm` is reset.

Fixes #292

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

- [x] Existing tests pass
- [ ] New tests added
- [x] Manual testing
 
Tested the following scenarios manually:
1. Data tab toolbar at 375px width → all items reachable via horizontal scroll
2. Click Filter → form opens
3. Click Filter again → form closes
4. Click Filter → then click Sort → Filter closes, Sort opens
5. Click Logs → panel opens
6. Click Logs again → panel closes

## Screen Recordings
**Before**

https://github.com/user-attachments/assets/fe718d10-61b8-4866-96f4-d91ece8521c7

**After**

https://github.com/user-attachments/assets/ed9755b4-bef7-40d3-856e-6af538dd1b4b

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally