### PR TITLE
Fix: use correct column parameter name for Add Column and Delete Column operation

### DIFF
--- a/dataloom-frontend/src/Components/Table.jsx
+++ b/dataloom-frontend/src/Components/Table.jsx
@@ -104,7 +104,7 @@ const Table = ({ projectId, data: externalData }) => {
         try {
           const response = await transformProject(projectId, {
             operation_type: ADD_COLUMN,
-            col_params: { index, name: newColumnName },
+            add_col_params: { index, name: newColumnName },
           });
           updateTableData(response);
           refreshProject(projectId, 1, pageSize);
@@ -185,7 +185,7 @@ const Table = ({ projectId, data: externalData }) => {
     try {
       const response = await transformProject(projectId, {
         operation_type: DELETE_COLUMN,
-        del_col_params: { index: index - 1 }, // was col_params
+        del_col_params: { index: index - 1 },
       });
       updateTableData(response);
       refreshProject(projectId, 1, pageSize);


### PR DESCRIPTION
## Description
Fixes Add Column and Delete Column operations which were failing with a 400 error due to incorrect parameter names in the frontend request body.

- Add Column: frontend was sending `col_params` but backend expects `add_col_params`
- Delete Column: frontend was sending `col_params` but backend expects `del_col_params`

Fixes #301

## Type of Change
- [x] Bug fix

## How Has This Been Tested?
- [x] Manual testing

Tested the following scenarios manually:
1. Right-click column header → Add Column → enter name → column added successfully
2. Right-click column header → Delete Column → column deleted successfully
3. Existing operations (Add Row, Delete Row, Edit Cell) still work correctly

## Screen Recordings
**Before**

https://github.com/user-attachments/assets/62c7801f-da1f-4c26-91e4-582e6d3a2393





https://github.com/user-attachments/assets/90b677da-0e17-45b2-bfbb-4332b40c2952





**After**

https://github.com/user-attachments/assets/9136b2e4-ed1c-4938-82a0-ca4adfb2539a





https://github.com/user-attachments/assets/d67766a7-5a15-4a95-b57f-e997782a8b3b





## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally