### PR TITLE
Fix: handle camel case and partial updates in `setPaginationData` to prevent undefined pagination state

### DIFF
--- a/dataloom-frontend/src/Components/Table.jsx
+++ b/dataloom-frontend/src/Components/Table.jsx
@@ -240,7 +240,7 @@ const Table = ({ projectId, data: externalData }) => {
   };
 
   const handlePageSizeChange = (newSize) => {
-    setPaginationData({ page: 1, pageSize: newSize });
+    setPaginationData({ page: 1, page_size: newSize });
     refreshProject(projectId, 1, newSize);
   };
 

--- a/dataloom-frontend/src/context/ProjectContext.jsx
+++ b/dataloom-frontend/src/context/ProjectContext.jsx
@@ -71,10 +71,25 @@ export function ProjectProvider({ children }) {
   }, []);
 
   const setPaginationData = useCallback((paginationInfo) => {
-    setTotalRows(paginationInfo.total_rows);
-    setTotalPages(paginationInfo.total_pages);
-    setPage(paginationInfo.page);
-    setPageSize(paginationInfo.page_size);
+    if (paginationInfo.total_rows !== undefined) {
+      setTotalRows(paginationInfo.total_rows);
+    }
+
+    if (paginationInfo.total_pages !== undefined) {
+      setTotalPages(paginationInfo.total_pages);
+    }
+
+    if (paginationInfo.page !== undefined) {
+      setPage(paginationInfo.page);
+    }
+
+    if (paginationInfo.page_size !== undefined) {
+      setPageSize(paginationInfo.page_size);
+    }
+
+    if (paginationInfo.pageSize !== undefined) {
+      setPageSize(paginationInfo.pageSize);
+    }
   }, []);
 
   return (


### PR DESCRIPTION
## Description
Fixes a bug where changing the page size to a smaller value (e.g. 10 or 25) caused pagination to break with `totalRows`, `totalPages` and `pageSize` becoming `undefined`.

**Root cause**: `setPaginationData` expected snake_case keys (`page_size`) but `handlePageSizeChange` was sending camelCase (`pageSize`). Additionally, `handlePageChange` only sent `{ page: newPage }` causing other pagination fields to be overwritten with `undefined`.

**Fix**: updated `setPaginationData` to handle both camelCase and snake_case keys, and to only update fields that are explicitly provided (partial updates).

Fixes #307 

## Type of Change
- [x] Bug fix

## How Has This Been Tested?
- [x] Manual testing

Tested the following scenarios manually:
1. Change page size from 50 → 10 → renders correctly
2. Change page size from 50 → 25 → renders correctly
3. Change page size from 50 → 100 → renders correctly
4. Navigate to page 2 → pagination works correctly
5. Navigate back to page 1 → works correctly

## Screen Recordings
**Before**

https://github.com/user-attachments/assets/df5eb766-0423-4be4-9aac-b71a738e1794

**After**

https://github.com/user-attachments/assets/46202af9-534c-4e1c-a4b9-b8eb9df8026e



## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally