### PR TITLE
Column reorder vitest coverage

### DIFF
--- a/dataloom-frontend/src/Components/Table.jsx
+++ b/dataloom-frontend/src/Components/Table.jsx
@@ -1,6 +1,6 @@
 import ContextMenu from "./ContextMenu";
 import { useContextMenu } from "../hooks/useContextMenu";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { transformProject } from "../api";
 import { useProjectContext } from "../context/ProjectContext";
@@ -58,21 +58,21 @@ const Table = ({ projectId, data: externalData }) => {
   const [draggedColIndex, setDraggedColIndex] = useState(null);
   const [hoveredTargetIndex, setHoveredTargetIndex] = useState(null);
 
+  const safeOrder = useMemo(() => {
+    return columnOrder.length === ctxColumns.length ? columnOrder : ctxColumns.map((_, i) => i);
+  }, [columnOrder, ctxColumns]);
+
   useEffect(() => {
     if (ctxColumns.length > 0 && ctxRows.length > 0) {
-      const orderedColumns =
-        columnOrder.length === ctxColumns.length
-          ? columnOrder.map((i) => ctxColumns[i])
-          : ctxColumns;
-      setColumns(["S.No.", ...orderedColumns]);
+      setColumns(["S.No.", ...safeOrder.map((i) => ctxColumns[i])]);
       setData(
         ctxRows.map((row, index) => [
           (page - 1) * pageSize + index + 1,
-          ...(columnOrder.length === ctxColumns.length ? columnOrder.map((i) => row[i]) : row),
+          ...safeOrder.map((i) => row[i]),
         ]),
       );
     }
-  }, [ctxColumns, ctxRows, page, pageSize, columnOrder]);
+  }, [ctxColumns, ctxRows, page, pageSize, columnOrder, safeOrder]);
 
   useEffect(() => {
     if (externalData) {
@@ -342,11 +342,7 @@ const Table = ({ projectId, data: externalData }) => {
                           setHoveredTargetIndex(null);
                           return;
                         }
-                        const currentOrder =
-                          columnOrder.length === ctxColumns.length
-                            ? columnOrder
-                            : ctxColumns.map((_, index) => index);
-                        const newOrder = [...currentOrder];
+                        const newOrder = [...safeOrder];
                         const [moved] = newOrder.splice(source, 1);
                         newOrder.splice(target, 0, moved);
                         setColumnOrder(newOrder);

--- a/dataloom-frontend/src/test/ProjectContext.columnOrder.test.jsx
+++ b/dataloom-frontend/src/test/ProjectContext.columnOrder.test.jsx
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { ProjectProvider, useProjectContext } from "../context/ProjectContext";
+
+describe("ProjectContext — column order state", () => {
+  it("setColumnOrder updates order for current project only", () => {
+    const { result } = renderHook(() => useProjectContext(), {
+      wrapper: ProjectProvider,
+    });
+
+    act(() => {
+      result.current.setProjectInfo("project-1", "Project 1");
+    });
+
+    act(() => {
+      result.current.updateData(["City", "Amount", "Date"], [], {});
+    });
+
+    act(() => {
+      result.current.setColumnOrder([2, 0, 1]);
+    });
+
+    expect(result.current.columnOrder).toEqual([2, 0, 1]);
+  });
+
+  it("switching project initializes a fresh column order", () => {
+    const { result } = renderHook(() => useProjectContext(), {
+      wrapper: ProjectProvider,
+    });
+
+    act(() => {
+      result.current.setProjectInfo("project-1", "Project 1");
+    });
+
+    act(() => {
+      result.current.updateData(["City", "Amount", "Date"], [], {});
+    });
+
+    act(() => {
+      result.current.setColumnOrder([2, 0, 1]);
+    });
+
+    expect(result.current.columnOrder).toEqual([2, 0, 1]);
+
+    act(() => {
+      result.current.setProjectInfo("project-2", "Project 2");
+    });
+
+    act(() => {
+      result.current.updateData(["Name", "Score"], [], {});
+    });
+
+    expect(result.current.columnOrder).toEqual([0, 1]);
+  });
+
+  it("setColumnOrder does nothing when no projectId exists", () => {
+    const { result } = renderHook(() => useProjectContext(), {
+      wrapper: ProjectProvider,
+    });
+
+    act(() => {
+      result.current.setColumnOrder([2, 0, 1]);
+    });
+
+    expect(result.current.columnOrder).toEqual([]);
+  });
+});

--- a/dataloom-frontend/src/test/Table.columnOrder.test.jsx
+++ b/dataloom-frontend/src/test/Table.columnOrder.test.jsx
@@ -1,0 +1,137 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import Table from "../Components/Table";
+import { transformProject } from "../api";
+
+vi.mock("../api", () => ({
+  transformProject: vi.fn(() =>
+    Promise.resolve({
+      columns: ["City", "Amount", "Date"],
+      rows: [["New York", "100", "2024-01-01"]],
+      dtypes: {},
+    }),
+  ),
+}));
+
+const mockContext = {
+  columns: ["City", "Amount", "Date"],
+  rows: [
+    ["New York", "100", "2024-01-01"],
+    ["London", "200", "2024-01-02"],
+  ],
+  dtypes: {
+    City: "string",
+    Amount: "float",
+    Date: "date",
+  },
+  columnOrder: [0, 1, 2],
+  setColumnOrder: vi.fn(),
+  updateData: vi.fn(),
+  totalRows: 2,
+  totalPages: 1,
+  page: 1,
+  pageSize: 50,
+  setPaginationData: vi.fn(),
+  refreshProject: vi.fn(),
+};
+
+vi.mock("../context/ProjectContext", () => ({
+  useProjectContext: () => mockContext,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("Table — column reorder behavior", () => {
+  it("renders columns in default order", () => {
+    mockContext.columnOrder = [0, 1, 2];
+
+    render(<Table projectId="test-id" />);
+
+    const headers = screen.getAllByRole("columnheader");
+
+    expect(headers[1]).toHaveTextContent("City");
+    expect(headers[2]).toHaveTextContent("Amount");
+    expect(headers[3]).toHaveTextContent("Date");
+  });
+
+  it("renders columns in reordered sequence [2, 0, 1]", () => {
+    mockContext.columnOrder = [2, 0, 1];
+
+    render(<Table projectId="test-id" />);
+
+    const headers = screen.getAllByRole("columnheader");
+
+    expect(headers[1]).toHaveTextContent("Date");
+    expect(headers[2]).toHaveTextContent("City");
+    expect(headers[3]).toHaveTextContent("Amount");
+  });
+
+  it("falls back to default order when columnOrder length mismatches", () => {
+    mockContext.columnOrder = [0, 1];
+
+    render(<Table projectId="test-id" />);
+
+    const headers = screen.getAllByRole("columnheader");
+
+    expect(headers[1]).toHaveTextContent("City");
+    expect(headers[2]).toHaveTextContent("Amount");
+    expect(headers[3]).toHaveTextContent("Date");
+  });
+
+  it("calls setColumnOrder when columns are reordered via drag and drop", async () => {
+    mockContext.columnOrder = [0, 1, 2];
+
+    render(<Table projectId="test-id" />);
+
+    const buttons = screen.getAllByRole("button");
+
+    const cityHeader = buttons.find((h) => h.textContent.includes("City"));
+
+    const dateHeader = buttons.find((h) => h.textContent.includes("Date"));
+
+    const dataTransfer = {
+      effectAllowed: "",
+      dropEffect: "",
+      setData: vi.fn(),
+      getData: vi.fn(),
+    };
+
+    fireEvent.dragStart(cityHeader, { dataTransfer });
+    fireEvent.dragOver(dateHeader, { dataTransfer });
+    fireEvent.drop(dateHeader, { dataTransfer });
+
+    expect(mockContext.setColumnOrder).toHaveBeenCalledWith([1, 2, 0]);
+  });
+
+  it("uses backend column index when editing reordered columns", async () => {
+    const user = userEvent.setup();
+
+    mockContext.columnOrder = [2, 0, 1];
+
+    render(<Table projectId="test-id" />);
+
+    const cells = screen.getAllByText("New York");
+
+    await user.click(cells[0]);
+
+    const input = await screen.findByDisplayValue("New York");
+
+    await user.clear(input);
+    await user.type(input, "Paris{enter}");
+
+    await waitFor(() => {
+      expect(transformProject).toHaveBeenCalledWith(
+        "test-id",
+        expect.objectContaining({
+          change_cell_value: expect.objectContaining({
+            col_index: 1,
+          }),
+        }),
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Description
Adds Vitest test coverage for the column reorder feature introduced in #300, and extracts a repeated defensive guard into a `safeOrder` helper as suggested in the review.

Changes made:
- Added `src/test/Table.columnOrder.test.jsx` — 5 tests covering:
  - Column rendering in default order
  - Column rendering in reordered sequence
  - Fallback to default order when columnOrder length mismatches
  - `setColumnOrder` called correctly after drag and drop
  - Backend index translation used correctly when editing reordered cells
- Added `src/test/ProjectContext.columnOrder.test.jsx` — 3 tests covering:
  - `setColumnOrder` updates order for current project only
  - Switching project initializes a fresh column order
  - `setColumnOrder` does nothing when no projectId exists
- Extracted repeated `columnOrder.length === ctxColumns.length` guard into
  a `safeOrder` helper in `Table.jsx` (DRY refactor suggested in #300 review)

Follow-up to #300.

## Type of Change
- [x] New feature
- [x] Documentation update

## How Has This Been Tested?
- [x] Existing tests pass
- [x] New tests added

All 8 new tests pass. Existing test suite unaffected.

## Screenshots
<img width="819" height="261" alt="Screenshot 2026-05-23 at 10 09 58" src="https://github.com/user-attachments/assets/a27f211e-53b2-4bc9-81d2-ffc9dfa5330d" />


## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally