### PR TITLE
Fix: update undo endpoint to use `Depends(get_project_or_404)` for auth

### DIFF
--- a/dataloom-backend/app/api/endpoints/projects.py
+++ b/dataloom-backend/app/api/endpoints/projects.py
@@ -263,6 +263,7 @@ async def delete_project_endpoint(
 @router.post("/{project_id}/undo", response_model=schemas.ProjectResponse)
 async def undo_last_transformation(
     project_id: uuid.UUID,
+    project: models.Project = Depends(get_project_or_404),
     db: Session = Depends(database.get_db),
 ):
     """Undo the most recent transformation.
@@ -270,8 +271,6 @@ async def undo_last_transformation(
     Removes the last change log entry and rebuilds the working copy
     by replaying all remaining logs onto the original file.
     """
-    project = get_project_or_404(project_id, db)
-
     last_log = get_last_change_log(db, project_id)
     if not last_log:
         raise HTTPException(status_code=404, detail="No transformations to undo")


### PR DESCRIPTION
## Description
Fixes the undo endpoint which was broken after the auth feature was merged in #299.

The endpoint was calling `get_project_or_404(project_id, db)` directly — the old pattern before authentication was introduced. Updated to use `Depends(get_project_or_404)` consistent with every other endpoint in the codebase.

Fixes: undo endpoint returning "Network Error" after auth merge.

## Type of Change
- [x] Bug fix

## How Has This Been Tested?
- [x] Manual testing

Tested the following scenarios manually:
1. Apply Sort → click Undo → transformation reversed correctly
2. Apply Filter → click Undo → transformation reversed correctly
3. Apply GroupBy → click Undo → transformation reversed correctly
4. Click Undo with no transformations → "No transformations to undo" toast

## Screens Recordings
**Before**

https://github.com/user-attachments/assets/482a3176-5500-4fd2-8a30-6cfcc81071a2

**After**

https://github.com/user-attachments/assets/f7e0e48e-d97b-4f5c-aa21-7d79f7447d65



## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally