### PR TITLE
fix: increase table max height to prevent last row being hidden behind pagination bar

### DIFF
--- a/dataloom-frontend/src/Components/Table.jsx
+++ b/dataloom-frontend/src/Components/Table.jsx
@@ -298,7 +298,7 @@ const Table = ({ projectId, data: externalData }) => {
     <div className="px-8 pt-3">
       <div
         className="overflow-x-scroll overflow-y-auto border border-gray-200 rounded-lg shadow-sm"
-        style={{ maxHeight: "calc(100vh - 140px)" }}
+        style={{ maxHeight: "calc(100vh - 225px)" }}
       >
         <table data-testid="data-table" className="min-w-full bg-white">
           <thead className="sticky top-0 bg-gray-50">


### PR DESCRIPTION
## Description
Fixes the last row of the data table being hidden behind the fixed pagination bar at the bottom of the screen.

The table container's `maxHeight` was calculated without accounting for the height of the fixed pagination footer, causing the last row to be obscured and unreachable.

Fixes #314

## Type of Change
- [x] Bug fix

## How Has This Been Tested?
- [x] Manual testing

Tested the following scenarios manually:
1. Open a project with multiple rows → scroll to bottom → last row fully visible
2. Different page sizes (10, 25, 50, 100) → last row always visible

## Screenshots 
**Before**
<img width="1414" height="81" alt="Before" src="https://github.com/user-attachments/assets/4796b614-9eba-4a15-831b-931121665908" />

**After**
<img width="1413" height="131" alt="After" src="https://github.com/user-attachments/assets/f2ea2706-f081-47a6-934d-cf41f37a7e84" />


## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally