### PR TITLE
feat: implement multi-column sort with UI management

### DIFF
--- a/dataloom-backend/app/schemas.py
+++ b/dataloom-backend/app/schemas.py
@@ -75,11 +75,23 @@ class FilterParameters(BaseModel):
     value: str
 
 
-class SortParameters(BaseModel):
-    """Parameters for a column sort operation."""
+class SortCriterion(BaseModel):
+    """A single sort criterion (column + direction)."""
 
     column: str
     ascending: bool
+
+
+class SortParameters(BaseModel):
+    """Parameters for a column sort operation.
+
+    Supports both single-column (backward compatible) and multi-column sorting.
+    For multi-column sorting, use 'criteria' with a list of SortCriterion objects.
+    """
+
+    column: str | None = None
+    ascending: bool = True
+    criteria: list[SortCriterion] | None = None
 
 
 class AddOrDeleteRow(BaseModel):

--- a/dataloom-backend/app/services/transformation_service.py
+++ b/dataloom-backend/app/services/transformation_service.py
@@ -709,7 +709,11 @@ TRANSFORMATION_REGISTRY: dict[OperationType, TransformationSpec] = {
         params_field="sort_params",
         missing_error="Sort parameters required",
         persist=True,
-        build_args=lambda d: (d["sort_params"]["column"], d["sort_params"]["ascending"]),
+        build_args=lambda d: (
+            d["sort_params"].get("column"),
+            d["sort_params"].get("ascending", True),
+            d["sort_params"].get("criteria"),
+        ),
     ),
     OperationType.addRow: TransformationSpec(
         func="add_row",

--- a/dataloom-backend/app/services/transformation_service.py
+++ b/dataloom-backend/app/services/transformation_service.py
@@ -95,17 +95,46 @@ def apply_filter(df: pd.DataFrame, column: str, condition: str, value: str) -> p
     return ops[condition_str]()
 
 
-def apply_sort(df: pd.DataFrame, column: str, ascending: bool) -> pd.DataFrame:
-    """Sort DataFrame by a column.
+def apply_sort(
+    df: pd.DataFrame,
+    column: str | None = None,
+    ascending: bool = True,
+    criteria: list[dict] | None = None,
+) -> pd.DataFrame:
+    """Sort a DataFrame by one or more columns.
+
+    Supports both single-column (backward compatible) and multi-column sorting.
 
     Args:
         df: Source DataFrame.
-        column: Column name to sort by.
-        ascending: Sort direction.
+        column: Single column name (backward compatible).
+        ascending: Sort direction for single-column sort.
+        criteria: List of dicts with 'column' and 'ascending' keys for multi-column sort.
 
     Returns:
         Sorted DataFrame.
     """
+    if criteria is not None:
+        if len(criteria) == 0:
+            raise TransformationError("At least one sort criterion is required")
+
+        columns = []
+        ascending_list = []
+
+        for criterion in criteria:
+            col_name = criterion.get("column")
+            if not col_name:
+                raise TransformationError("Column name is required for each sort criterion")
+            if col_name not in df.columns:
+                raise TransformationError(f"Column '{col_name}' not found")
+            columns.append(col_name)
+            ascending_list.append(criterion.get("ascending", True))
+
+        return df.sort_values(by=columns, ascending=ascending_list)
+
+    # Single-column mode (backward compatible)
+    if column is None:
+        raise TransformationError("Column name is required for sorting")
     if column not in df.columns:
         raise TransformationError(f"Column '{column}' not found")
     return df.sort_values(by=column, ascending=ascending)

--- a/dataloom-backend/tests/test_transformations.py
+++ b/dataloom-backend/tests/test_transformations.py
@@ -89,6 +89,9 @@ class TestSort:
             {"column": "name", "ascending": False},
         ]
         result = apply_sort(sample_df, criteria=criteria)
+        # Verify actual row order — age ascending: Bob(25), Alice(30), Charlie(35)
+        assert list(result["age"]) == [25, 30, 35]
+        assert list(result["name"]) == ["Bob", "Alice", "Charlie"]
         assert list(result.columns) == list(sample_df.columns)
         assert len(result) == len(sample_df)
 

--- a/dataloom-backend/tests/test_transformations.py
+++ b/dataloom-backend/tests/test_transformations.py
@@ -82,6 +82,31 @@ class TestSort:
         with pytest.raises(TransformationError):
             apply_sort(sample_df, "nonexistent", True)
 
+    def test_multi_column_sort(self, sample_df):
+        """Multi-column sort should sort by multiple criteria in order."""
+        criteria = [
+            {"column": "age", "ascending": True},
+            {"column": "name", "ascending": False},
+        ]
+        result = apply_sort(sample_df, criteria=criteria)
+        assert list(result.columns) == list(sample_df.columns)
+        assert len(result) == len(sample_df)
+
+    def test_multi_column_sort_empty_criteria(self, sample_df):
+        """Empty criteria list should raise TransformationError."""
+        with pytest.raises(TransformationError, match="At least one sort criterion is required"):
+            apply_sort(sample_df, criteria=[])
+
+    def test_multi_column_sort_missing_column(self, sample_df):
+        """Missing column in criteria should raise TransformationError."""
+        with pytest.raises(TransformationError, match="Column name is required"):
+            apply_sort(sample_df, criteria=[{"column": "", "ascending": True}])
+
+    def test_multi_column_sort_invalid_column(self, sample_df):
+        """Invalid column name should raise TransformationError."""
+        with pytest.raises(TransformationError, match="not found"):
+            apply_sort(sample_df, criteria=[{"column": "nonexistent", "ascending": True}])
+
 
 class TestAddRow:
     def test_add_row_at_beginning(self, sample_df):

--- a/dataloom-frontend/src/Components/MenuNavbar.jsx
+++ b/dataloom-frontend/src/Components/MenuNavbar.jsx
@@ -65,7 +65,7 @@ const MenuNavbar = ({ projectId, onTransform }) => {
   const [confirmData, setConfirmData] = useState(null);
   const [toast, setToast] = useState(null);
 
-  const { updateData, columns } = useProjectContext();
+  const { updateData } = useProjectContext();
 
   const fetchLogs = useCallback(async () => {
     try {
@@ -424,7 +424,7 @@ const MenuNavbar = ({ projectId, onTransform }) => {
             setActiveForm(null);
           }}
           projectId={projectId}
-          columns={columns}
+          onTransform={onTransform}
         />
       )}
       {showDropDuplicateForm && (

--- a/dataloom-frontend/src/Components/MenuNavbar.jsx
+++ b/dataloom-frontend/src/Components/MenuNavbar.jsx
@@ -65,7 +65,7 @@ const MenuNavbar = ({ projectId, onTransform }) => {
   const [confirmData, setConfirmData] = useState(null);
   const [toast, setToast] = useState(null);
 
-  const { updateData } = useProjectContext();
+  const { updateData, columns } = useProjectContext();
 
   const fetchLogs = useCallback(async () => {
     try {
@@ -424,6 +424,7 @@ const MenuNavbar = ({ projectId, onTransform }) => {
             setActiveForm(null);
           }}
           projectId={projectId}
+          columns={columns}
         />
       )}
       {showDropDuplicateForm && (

--- a/dataloom-frontend/src/Components/forms/SortForm.jsx
+++ b/dataloom-frontend/src/Components/forms/SortForm.jsx
@@ -5,13 +5,14 @@ import { SORT } from "../../constants/operationTypes";
 import TransformResultPreview from "./TransformResultPreview";
 import useError from "../../hooks/useError";
 import FormErrorAlert from "../common/FormErrorAlert";
+import ColumnSelect from "../common/ColumnSelect";
 import { useProjectContext } from "../../context/ProjectContext";
 
 /**
  * SortForm component for multi-column sorting.
  * Allows users to add, remove, and reorder multiple sort criteria.
  */
-const SortForm = ({ projectId, columns = [], onClose, onTransform }) => {
+const SortForm = ({ projectId, onClose, onTransform }) => {
   const { updateData } = useProjectContext();
   const [criteria, setCriteria] = useState([{ id: 1, column: "", ascending: true }]);
   const [nextId, setNextId] = useState(2);
@@ -69,7 +70,6 @@ const SortForm = ({ projectId, columns = [], onClose, onTransform }) => {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    setError(null);
     const validationError = validateCriteria();
     if (validationError) {
       setError(validationError);
@@ -98,8 +98,6 @@ const SortForm = ({ projectId, columns = [], onClose, onTransform }) => {
     }
   };
 
-  const hasColumnList = Array.isArray(columns) && columns.length > 0;
-
   return (
     <div data-testid="sort-form" className="p-4 border border-gray-200 rounded-lg bg-white">
       <form onSubmit={handleSubmit}>
@@ -107,11 +105,6 @@ const SortForm = ({ projectId, columns = [], onClose, onTransform }) => {
         <p className="text-sm text-gray-600 mb-4">
           Add multiple sort criteria. Priority is determined by order (top = primary sort).
         </p>
-        {error && (
-          <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-md text-red-700 text-sm">
-            {error}
-          </div>
-        )}
         <div className="space-y-3 mb-4">
           {criteria.map((criterion, index) => (
             <div
@@ -120,31 +113,13 @@ const SortForm = ({ projectId, columns = [], onClose, onTransform }) => {
             >
               <span className="text-sm font-medium text-gray-500 w-6">{index + 1}.</span>
               <div className="flex-1">
-                {hasColumnList ? (
-                  <select
-                    data-testid="sort-column"
-                    value={criterion.column}
-                    onChange={(e) => updateCriterionColumn(criterion.id, e.target.value)}
-                    className="border border-gray-300 rounded-md px-3 py-2 w-full bg-white text-gray-900 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none text-sm"
-                    required
-                  >
-                    <option value="">Select column...</option>
-                    {columns.map((col) => (
-                      <option key={col} value={col}>
-                        {col}
-                      </option>
-                    ))}
-                  </select>
-                ) : (
-                  <input
-                    type="text"
-                    value={criterion.column}
-                    onChange={(e) => updateCriterionColumn(criterion.id, e.target.value)}
-                    placeholder="Column name"
-                    className="border border-gray-300 rounded-md px-3 py-2 w-full bg-white text-gray-900 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none text-sm"
-                    required
-                  />
-                )}
+                <ColumnSelect
+                  value={criterion.column}
+                  onChange={(e) => updateCriterionColumn(criterion.id, e.target.value)}
+                  placeholder="Select column..."
+                  required
+                  data-testid={index === 0 ? "sort-column" : undefined}
+                />
               </div>
               <select
                 value={criterion.ascending}
@@ -241,7 +216,6 @@ const SortForm = ({ projectId, columns = [], onClose, onTransform }) => {
 
 SortForm.propTypes = {
   projectId: PropTypes.string.isRequired,
-  columns: PropTypes.arrayOf(PropTypes.string),
   onClose: PropTypes.func.isRequired,
   onTransform: PropTypes.func,
 };

--- a/dataloom-frontend/src/Components/forms/SortForm.jsx
+++ b/dataloom-frontend/src/Components/forms/SortForm.jsx
@@ -1,77 +1,228 @@
-import { useState } from "react";
+import { useState, useCallback } from "react";
 import PropTypes from "prop-types";
 import { transformProject } from "../../api";
 import { SORT } from "../../constants/operationTypes";
 import TransformResultPreview from "./TransformResultPreview";
 import useError from "../../hooks/useError";
 import FormErrorAlert from "../common/FormErrorAlert";
-import ColumnSelect from "../common/ColumnSelect";
 import { useProjectContext } from "../../context/ProjectContext";
 
-const SortForm = ({ projectId, onClose, onTransform }) => {
-  const [column, setColumn] = useState("");
-  const [ascending, setAscending] = useState(true);
+/**
+ * SortForm component for multi-column sorting.
+ * Allows users to add, remove, and reorder multiple sort criteria.
+ */
+const SortForm = ({ projectId, columns = [], onClose, onTransform }) => {
+  const { updateData } = useProjectContext();
+  const [criteria, setCriteria] = useState([{ id: 1, column: "", ascending: true }]);
+  const [nextId, setNextId] = useState(2);
   const [result, setResult] = useState(null);
   const [loading, setLoading] = useState(false);
-  const { error, clearError, handleError } = useError();
-  const { updateData } = useProjectContext();
+  const { error, setError, clearError, handleError } = useError();
+
+  const addCriterion = useCallback(() => {
+    setCriteria((prev) => [...prev, { id: nextId, column: "", ascending: true }]);
+    setNextId((prev) => prev + 1);
+  }, [nextId]);
+
+  const removeCriterion = useCallback((id) => {
+    setCriteria((prev) => {
+      if (prev.length <= 1) {
+        return prev.map((c) => (c.id === id ? { ...c, column: "" } : c));
+      }
+      return prev.filter((c) => c.id !== id);
+    });
+  }, []);
+
+  const updateCriterionColumn = useCallback((id, column) => {
+    setCriteria((prev) => prev.map((c) => (c.id === id ? { ...c, column } : c)));
+  }, []);
+
+  const updateCriterionOrder = useCallback((id, ascending) => {
+    setCriteria((prev) => prev.map((c) => (c.id === id ? { ...c, ascending } : c)));
+  }, []);
+
+  const moveUp = useCallback((index) => {
+    if (index === 0) return;
+    setCriteria((prev) => {
+      const newCriteria = [...prev];
+      [newCriteria[index - 1], newCriteria[index]] = [newCriteria[index], newCriteria[index - 1]];
+      return newCriteria;
+    });
+  }, []);
+
+  const moveDown = useCallback((index) => {
+    setCriteria((prev) => {
+      if (index >= prev.length - 1) return prev;
+      const newCriteria = [...prev];
+      [newCriteria[index], newCriteria[index + 1]] = [newCriteria[index + 1], newCriteria[index]];
+      return newCriteria;
+    });
+  }, []);
+
+  const validateCriteria = useCallback(() => {
+    const emptyCriteria = criteria.filter((c) => !c.column || c.column.trim() === "");
+    if (emptyCriteria.length > 0) {
+      return "Please select a column for all sort criteria";
+    }
+    return null;
+  }, [criteria]);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
+    setError(null);
+    const validationError = validateCriteria();
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+    const criteriaList = criteria.map((c) => ({
+      column: c.column,
+      ascending: c.ascending,
+    }));
     setLoading(true);
     clearError();
     try {
       const response = await transformProject(projectId, {
         operation_type: SORT,
         sort_params: {
-          column,
-          ascending,
+          criteria: criteriaList,
         },
       });
       setResult(response);
       if (onTransform) onTransform(response);
-      updateData(response.columns, response.rows, response.dtypes);
+      updateData(response.columns, response.rows, { dtypes: response.dtypes });
     } catch (err) {
-      console.error("Error applying sort:", err.response?.data || err.message);
       handleError(err);
     } finally {
       setLoading(false);
     }
   };
 
+  const hasColumnList = Array.isArray(columns) && columns.length > 0;
+
   return (
     <div data-testid="sort-form" className="p-4 border border-gray-200 rounded-lg bg-white">
       <form onSubmit={handleSubmit}>
         <h3 className="font-semibold text-gray-900 mb-2">Sort Dataset</h3>
-        <div className="flex flex-wrap mb-4">
-          <div className="w-full sm:w-1/2 mb-2">
-            <label className="block mb-1 text-sm font-medium text-gray-700">Column:</label>
-            <ColumnSelect
-              data-testid="sort-column"
-              value={column}
-              onChange={(e) => setColumn(e.target.value)}
-              placeholder="Select column to sort by..."
-            />
+        <p className="text-sm text-gray-600 mb-4">
+          Add multiple sort criteria. Priority is determined by order (top = primary sort).
+        </p>
+        {error && (
+          <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-md text-red-700 text-sm">
+            {error}
           </div>
-          <div className="w-full sm:w-1/2 mb-2 pl-2">
-            <label className="block mb-1 text-sm font-medium text-gray-700">Order:</label>
-            <select
-              value={ascending}
-              onChange={(e) => setAscending(e.target.value === "true")}
-              className="border border-gray-300 rounded-md px-3 py-2 w-full bg-white text-gray-900 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none"
+        )}
+        <div className="space-y-3 mb-4">
+          {criteria.map((criterion, index) => (
+            <div
+              key={criterion.id}
+              className="flex items-center gap-2 p-3 bg-gray-50 rounded-md border border-gray-200"
             >
-              <option value="true">Ascending</option>
-              <option value="false">Descending</option>
-            </select>
-          </div>
+              <span className="text-sm font-medium text-gray-500 w-6">{index + 1}.</span>
+              <div className="flex-1">
+                {hasColumnList ? (
+                  <select
+                    data-testid="sort-column"
+                    value={criterion.column}
+                    onChange={(e) => updateCriterionColumn(criterion.id, e.target.value)}
+                    className="border border-gray-300 rounded-md px-3 py-2 w-full bg-white text-gray-900 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none text-sm"
+                    required
+                  >
+                    <option value="">Select column...</option>
+                    {columns.map((col) => (
+                      <option key={col} value={col}>
+                        {col}
+                      </option>
+                    ))}
+                  </select>
+                ) : (
+                  <input
+                    type="text"
+                    value={criterion.column}
+                    onChange={(e) => updateCriterionColumn(criterion.id, e.target.value)}
+                    placeholder="Column name"
+                    className="border border-gray-300 rounded-md px-3 py-2 w-full bg-white text-gray-900 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none text-sm"
+                    required
+                  />
+                )}
+              </div>
+              <select
+                value={criterion.ascending}
+                onChange={(e) => updateCriterionOrder(criterion.id, e.target.value === "true")}
+                className="border border-gray-300 rounded-md px-3 py-2 bg-white text-gray-900 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none text-sm w-32"
+              >
+                <option value="true">Ascending</option>
+                <option value="false">Descending</option>
+              </select>
+              <div className="flex gap-1">
+                <button
+                  type="button"
+                  onClick={() => moveUp(index)}
+                  disabled={index === 0}
+                  className="p-2 text-gray-500 hover:text-blue-600 hover:bg-blue-50 rounded disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                  title="Move up in priority"
+                >
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M5 15l7-7 7 7"
+                    />
+                  </svg>
+                </button>
+                <button
+                  type="button"
+                  onClick={() => moveDown(index)}
+                  disabled={index === criteria.length - 1}
+                  className="p-2 text-gray-500 hover:text-blue-600 hover:bg-blue-50 rounded disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                  title="Move down in priority"
+                >
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M19 9l-7 7-7-7"
+                    />
+                  </svg>
+                </button>
+                <button
+                  type="button"
+                  onClick={() => removeCriterion(criterion.id)}
+                  className="p-2 text-gray-500 hover:text-red-600 hover:bg-red-50 rounded transition-colors"
+                  title="Remove criterion"
+                >
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M6 18L18 6M6 6l12 12"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          ))}
         </div>
-        <div className="flex justify-between">
+        <button
+          type="button"
+          onClick={addCriterion}
+          className="mb-4 flex items-center gap-2 text-sm text-blue-600 hover:text-blue-700 hover:bg-blue-50 px-3 py-2 rounded-md transition-colors"
+        >
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+          </svg>
+          Add Sort Criterion
+        </button>
+        <div className="flex justify-between pt-4 border-t border-gray-200">
           <button
             type="submit"
-            className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-md font-medium transition-colors duration-150"
-            disabled={loading}
+            className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-md font-medium transition-colors duration-150 disabled:opacity-50 disabled:cursor-not-allowed"
+            disabled={loading || criteria.length === 0}
           >
-            Submit
+            {loading ? "Applying..." : "Apply Sort"}
           </button>
           <button
             type="button"
@@ -90,6 +241,7 @@ const SortForm = ({ projectId, onClose, onTransform }) => {
 
 SortForm.propTypes = {
   projectId: PropTypes.string.isRequired,
+  columns: PropTypes.arrayOf(PropTypes.string),
   onClose: PropTypes.func.isRequired,
   onTransform: PropTypes.func,
 };

--- a/e2e/transformations.spec.js
+++ b/e2e/transformations.spec.js
@@ -28,7 +28,7 @@ test.describe("Transformations", () => {
     const form = page.locator('[data-testid="sort-form"]');
     await form.waitFor({ state: "visible" });
     await form.locator('[data-testid="sort-column"]').selectOption("age");
-    await form.getByRole("button", { name: "Submit" }).click();
+    await form.getByRole("button", { name: /Apply Sort/i }).click();
 
     const preview = page.locator('[data-testid="transform-preview"]');
     await preview.waitFor({ state: "visible" });


### PR DESCRIPTION
## Description
Implements multi-column sorting for DataLoom. Users can now add multiple sort criteria, each with an independent column and direction (ascending/descending). Criteria can be reordered using up/down arrows to control sort priority.  The implementation is fully backward compatible, existing single-column sort behaviour is preserved.

Changes made:

**Backend:**
- Added `SortCriterion` model to `schemas.py`
- Updated `SortParameters` to support optional `criteria` list
- Updated `apply_sort()` in `transformation_service.py` to handle multi-column sorting
- Updated sort handler in `transformations.py` to pass criteria to service
- Added 4 new tests in `test_transformations.py` covering multi-column sort scenarios

**Frontend:**
- Rewrote `SortForm.jsx` with multi-criterion UI — add, remove, reorder criteria
- Added `columns` prop to `SortForm` for dropdown column selection
- Updated `MenuNavbar.jsx` to pass `columns` from context to `SortForm`

Closes #81

Note: This is a fresh rebased implementation based on the approach from closed PRs #123 and #204. All merge conflicts with main have been resolved.

## Type of Change
- [x] New feature

## How Has This Been Tested?
- [x] Existing tests pass
- [x] New tests added
- [x] Manual testing

Tested the following scenarios manually:
1. Sort by single column ascending → works correctly
2. Sort by single column descending → works correctly
3. Sort by multiple columns with mixed directions → works correctly
4. Move criteria up/down to change priority → reorders correctly
5. Remove a criterion → removed correctly, minimum 1 criterion enforced
6. Submit with empty column selected → validation message shown
7. Existing single-column sort backward compatible
8. All backend tests pass
9. All frontend tests pass

## Screen Recording

https://github.com/user-attachments/assets/0a11fd59-54fe-40c1-8aae-0c99afae6273



## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally