### PR TITLE
fix(backend): delete checkpointed projects reliably

### DIFF
--- a/dataloom-backend/app/api/endpoints/projects.py
+++ b/dataloom-backend/app/api/endpoints/projects.py
@@ -255,8 +255,28 @@ async def delete_project_endpoint(
     project: models.Project = Depends(get_project_or_404),
 ):
     """Delete a project and its associated files."""
-    delete_project_files(project.file_path)
-    delete_project(db, project)
+    project_id = project.project_id
+    project_name = project.name
+    file_path = project.file_path
+
+    logger.info("Delete project request: id=%s, name=%s, file_path=%s", project_id, project_name, file_path)
+
+    try:
+        delete_project(db, project)
+    except SQLAlchemyError as e:
+        logger.exception("Delete project database failure: id=%s, name=%s", project_id, project_name)
+        raise HTTPException(status_code=500, detail="Failed to delete project records.") from e
+
+    try:
+        delete_project_files(file_path)
+    except OSError:
+        logger.exception(
+            "Project database record deleted, but file cleanup failed: id=%s, name=%s, file_path=%s",
+            project_id,
+            project_name,
+            file_path,
+        )
+
     return {"success": True, "message": "Project deleted"}
 
 

--- a/dataloom-backend/app/services/project_service.py
+++ b/dataloom-backend/app/services/project_service.py
@@ -3,6 +3,7 @@
 import uuid
 from datetime import UTC, datetime
 
+from sqlalchemy.exc import SQLAlchemyError
 from sqlmodel import Session
 
 from app import models
@@ -74,15 +75,47 @@ def get_recent_projects(db: Session, owner_id: uuid.UUID, limit: int = 3) -> lis
 def delete_project(db: Session, project: models.Project) -> None:
     """Delete a project record from the database.
 
-    Cascade rules on the model handle deleting associated logs and checkpoints.
+    Associated logs are deleted before checkpoints because applied logs can
+    reference checkpoints directly.
 
     Args:
         db: Database session.
         project: The Project model instance to delete.
     """
-    db.delete(project)
-    db.commit()
-    logger.info("Deleted project: id=%s, name=%s", project.project_id, project.name)
+    project_id = project.project_id
+    project_name = project.name
+
+    try:
+        deleted_logs = (
+            db.query(models.ProjectChangeLog)
+            .filter(models.ProjectChangeLog.project_id == project_id)
+            .delete(synchronize_session=False)
+        )
+        deleted_checkpoints = (
+            db.query(models.Checkpoint)
+            .filter(models.Checkpoint.project_id == project_id)
+            .delete(synchronize_session=False)
+        )
+        deleted_projects = (
+            db.query(models.Project).filter(models.Project.project_id == project_id).delete(synchronize_session=False)
+        )
+        db.commit()
+    except SQLAlchemyError:
+        db.rollback()
+        logger.exception("Failed to delete project database records: id=%s, name=%s", project_id, project_name)
+        raise
+
+    if deleted_projects == 0:
+        logger.warning("Project delete matched no project row: id=%s, name=%s", project_id, project_name)
+
+    logger.info(
+        "Deleted project: id=%s, name=%s, projects=%d, logs=%d, checkpoints=%d",
+        project_id,
+        project_name,
+        deleted_projects,
+        deleted_logs,
+        deleted_checkpoints,
+    )
 
 
 def log_transformation(db: Session, project_id: uuid.UUID, operation_type: str, details: dict) -> None:

--- a/dataloom-backend/tests/test_save_revert.py
+++ b/dataloom-backend/tests/test_save_revert.py
@@ -44,6 +44,36 @@ class TestCheckpoint:
 
 
 class TestSaveEndpointRegressions:
+    def test_delete_checkpointed_project_removes_logs_and_checkpoints(self, client, db, test_user, tmp_path):
+        """Deleting a saved project should remove dependent logs before checkpoints."""
+        original_path = tmp_path / "checkpointed.csv"
+        copy_path = tmp_path / "checkpointed_copy.csv"
+        pd.DataFrame({"name": ["Alice"], "age": [30]}).to_csv(original_path, index=False)
+        shutil.copy2(original_path, copy_path)
+
+        project = create_project(
+            db,
+            name="Checkpointed Delete",
+            file_path=str(copy_path),
+            description="Delete regression",
+            owner_id=test_user.id,
+        )
+        log_transformation(
+            db,
+            project.project_id,
+            "renameCol",
+            {"rename_col_params": {"col_index": 1, "new_name": "years"}},
+        )
+        create_checkpoint(db, project.project_id, "saved")
+        project_id = project.project_id
+
+        response = client.delete(f"/projects/{project_id}")
+
+        assert response.status_code == 200
+        assert db.get(models.Project, project_id) is None
+        assert db.query(models.ProjectChangeLog).filter_by(project_id=project_id).count() == 0
+        assert db.query(models.Checkpoint).filter_by(project_id=project_id).count() == 0
+
     def test_second_save_preserves_previously_checkpointed_transforms(self, client, db, test_user, tmp_path):
         """A later save should keep earlier checkpointed transforms intact."""
         original_path = tmp_path / "sample.csv"


### PR DESCRIPTION
## Description
- Projects with checkpoints can be deleted successfully now.
- Added a new flow for project deletion where we first delete the logs, checkpoints and projects. Then we delete the project file.
- Also added some loggers.


Fixes https://github.com/c2siorg/dataloom/issues/322

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

Describe the tests you ran to verify your changes.

- [X] Existing tests pass
- [X] New tests added
- [X] Manual testing

## Checklist

- [X] My code follows the project's style guidelines
- [X] I have performed a self-review
- [X] I have added/updated documentation as needed
- [X] My changes generate no new warnings
- [X] Tests pass locally