### PR TITLE
feat: multi-format file upload (TSV, JSON, XLSX, Parquet)

### DIFF
--- a/dataloom-backend/app/api/endpoints/projects.py
+++ b/dataloom-backend/app/api/endpoints/projects.py
@@ -23,8 +23,9 @@ from app.services.project_service import (
     get_recent_projects,
 )
 from app.services.transformation_service import apply_logged_transformation
+from app.utils.file_formats import get_format
 from app.utils.logging import get_logger
-from app.utils.pandas_helpers import dataframe_to_response, read_csv_safe, save_csv_safe
+from app.utils.pandas_helpers import dataframe_to_response, read_table_safe, save_table_safe
 from app.utils.security import validate_upload_file
 
 logger = get_logger(__name__)
@@ -40,16 +41,25 @@ async def upload_project(
     db: Session = Depends(database.get_db),
     current_user: models.User = Depends(get_current_user),
 ):
-    """Upload a new CSV file for a project.
+    """Upload a new dataset file (CSV, TSV, JSON, XLSX, or Parquet) for a project.
 
-    Validates the file, stores it with a sanitized name, creates a working copy,
-    and returns the initial project data.
+    Validates the file, stores it with a sanitized name, creates a working copy
+    in the same native format, and returns the initial project data.
     """
     logger.info("Upload request: project=%s, file=%s", projectName, file.filename)
     await validate_upload_file(file)
 
     original_path, copy_path = store_upload(file)
-    df = read_csv_safe(original_path)
+    try:
+        df = read_table_safe(original_path)
+    except HTTPException as e:
+        # The just-uploaded file could not be parsed — that's a bad client file,
+        # not a server fault. Discard the orphaned files and report a clean 400.
+        delete_project_files(str(copy_path))
+        if e.status_code >= 500:
+            ext = Path(file.filename).suffix.lower()
+            raise HTTPException(status_code=400, detail=f"Could not parse the uploaded {ext} file.") from e
+        raise
 
     project = create_project(db, projectName, str(copy_path), projectDescription, current_user.id)
 
@@ -74,7 +84,7 @@ async def get_project_details(
     project: models.Project = Depends(get_project_or_404),
 ):
     """Fetch full project details including all rows and columns."""
-    df = read_csv_safe(project.file_path)
+    df = read_table_safe(project.file_path)
 
     total_rows = len(df)
     total_pages = (total_rows + pageSize - 1) // pageSize
@@ -140,7 +150,7 @@ async def save_project(
             detail=f"Project {project_id} working copy is misconfigured; please retry or contact support.",
         )
 
-    df = read_csv_safe(project.file_path)
+    df = read_table_safe(project.file_path)
 
     # Create checkpoint (marks logs as applied)
     checkpoint = create_checkpoint(db, project_id, commit_message)
@@ -174,7 +184,7 @@ async def revert_to_checkpoint(
     uploaded state.
     """
     original_path = get_original_path(project.file_path)
-    df = read_csv_safe(original_path)
+    df = read_table_safe(original_path)
 
     if checkpoint_id is not None:
         checkpoint = (
@@ -214,7 +224,7 @@ async def revert_to_checkpoint(
             df = apply_logged_transformation(df, log.action_type, log.action_details)
 
     # Write file first — if this fails, DB is unchanged and state remains consistent.
-    save_csv_safe(df, project.file_path)
+    save_table_safe(df, project.file_path)
     # Clear unapplied logs so a subsequent save cannot re-apply stale
     # transformations on top of the reverted file state.
     # Applies to all reverts (full and partial) to prevent stale log replay.
@@ -245,8 +255,13 @@ async def revert_to_checkpoint(
 
 @router.get("/{project_id}/export")
 async def export_project(project: models.Project = Depends(get_project_or_404)):
-    """Download the current working copy of a project as a CSV file."""
-    return FileResponse(project.file_path, media_type="text/csv", filename=f"{project.name}.csv")
+    """Download the current working copy of a project in its native format."""
+    fmt = get_format(project.file_path)
+    return FileResponse(
+        project.file_path,
+        media_type=fmt.media_type,
+        filename=f"{project.name}{fmt.extension}",
+    )
 
 
 @router.delete("/{project_id}")
@@ -298,7 +313,7 @@ async def undo_last_transformation(
     delete_change_log(db, last_log)
 
     original_path = get_original_path(project.file_path)
-    df = read_csv_safe(original_path)
+    df = read_table_safe(original_path)
 
     remaining_logs = (
         db.query(models.ProjectChangeLog)
@@ -310,7 +325,7 @@ async def undo_last_transformation(
     for log in remaining_logs:
         df = apply_logged_transformation(df, log.action_type, log.action_details)
 
-    save_csv_safe(df, project.file_path)
+    save_table_safe(df, project.file_path)
     db.commit()
 
     resp = dataframe_to_response(df)

--- a/dataloom-backend/app/api/endpoints/transformations.py
+++ b/dataloom-backend/app/api/endpoints/transformations.py
@@ -14,7 +14,7 @@ from app.api.dependencies import get_project_or_404
 from app.services import transformation_service as ts
 from app.services.project_service import log_transformation
 from app.utils.logging import get_logger
-from app.utils.pandas_helpers import dataframe_to_response, read_csv_safe, save_csv_safe
+from app.utils.pandas_helpers import dataframe_to_response, read_table_safe, save_table_safe
 
 logger = get_logger(__name__)
 
@@ -67,9 +67,9 @@ def _safe_http_exception_detail(error: HTTPException) -> str | None:
     if error.status_code >= 500:
         return "Internal server error"
 
-    # Utility-layer CSV 404s may embed absolute paths.
-    if error.status_code == 404 and "csv file not found" in lowered:
-        return "CSV file not found"
+    # Utility-layer file 404s may embed absolute paths.
+    if error.status_code == 404 and "file not found" in lowered:
+        return "File not found"
 
     if detail and (re.search(r"[A-Za-z]:\\[^\\\n]+", detail) or re.search(r"/(?:[^/\n]+/)+[^/\n]+", detail)):
         return "Resource not found" if error.status_code == 404 else "Internal server error"
@@ -117,19 +117,19 @@ async def transform_project(
     operation_type = getattr(transformation_input, "operation_type", "<unknown>")
 
     try:
-        df = read_csv_safe(project.file_path)
+        df = read_table_safe(project.file_path)
 
         result_df, should_save = _dispatch_transform(df, transformation_input)
 
         if should_save:
-            save_csv_safe(result_df, project.file_path)
+            save_table_safe(result_df, project.file_path)
             try:
                 log_transformation(db, project_id, operation_type, transformation_input.dict())
             except Exception:
                 # Compensate disk mutation if audit logging fails to avoid a
                 # partially persisted state (file changed without log entry).
                 try:
-                    save_csv_safe(df, project.file_path)
+                    save_table_safe(df, project.file_path)
                 except Exception:
                     logger.exception(
                         "Failed to restore project file after log_transformation failure for project_id=%s op=%s",

--- a/dataloom-backend/app/config.py
+++ b/dataloom-backend/app/config.py
@@ -28,7 +28,7 @@ class Settings(BaseSettings):
     database_url: str
     upload_dir: str = "uploads"
     max_upload_size_bytes: int = 10_485_760  # 10 MB
-    allowed_extensions: list[str] = [".csv"]
+    allowed_extensions: list[str] = [".csv", ".tsv", ".json", ".xlsx", ".parquet"]
     cors_origins: list[str] = ["http://localhost:3200"]
     debug: bool = False
     jwt_secret: str

--- a/dataloom-backend/app/services/file_service.py
+++ b/dataloom-backend/app/services/file_service.py
@@ -4,19 +4,27 @@ import shutil
 from pathlib import Path
 
 from app.config import get_settings
+from app.utils.file_formats import supported_extensions
 from app.utils.logging import get_logger
 from app.utils.security import resolve_upload_path, sanitize_filename
 
 logger = get_logger(__name__)
 
 
-def store_upload(file) -> tuple[Path, Path]:
-    """Store an uploaded file and create a working copy.
+def _copy_path_for(original_path: Path) -> Path:
+    """Derive the working-copy path for an original file, preserving its extension."""
+    return original_path.with_name(f"{original_path.stem}_copy{original_path.suffix}")
 
-    Validates the file extension (must be .csv) and enforces the configured
-    ``max_upload_size_bytes`` limit via chunked streaming before writing
-    anything to disk.  The file pointer is reset to 0 after validation so
-    ``shutil.copyfileobj`` writes a complete file.
+
+def store_upload(file) -> tuple[Path, Path]:
+    """Store an uploaded file and create a working copy in the same format.
+
+    Validates the file extension against the supported-format registry and
+    enforces the configured ``max_upload_size_bytes`` limit via chunked
+    streaming before writing anything to disk. The working copy keeps the
+    native extension, so revert/undo can re-read the original in its own format.
+    The file pointer is reset to 0 after validation so ``shutil.copyfileobj``
+    writes a complete file.
 
     Args:
         file: The FastAPI UploadFile object.
@@ -25,7 +33,7 @@ def store_upload(file) -> tuple[Path, Path]:
         Tuple of (original_path, copy_path).
 
     Raises:
-        ValueError: If the file is not a CSV or exceeds
+        ValueError: If the file format is unsupported or it exceeds
             ``settings.max_upload_size_bytes``.
     """
     settings = get_settings()
@@ -33,8 +41,8 @@ def store_upload(file) -> tuple[Path, Path]:
 
     # 1. Validate file extension
     ext = Path(file.filename).suffix.lower()
-    if ext != ".csv":
-        raise ValueError(f"Only CSV files are supported. Got: {ext}")
+    if ext not in supported_extensions():
+        raise ValueError(f"Unsupported file format '{ext}'. Supported: {supported_extensions()}")
 
     # 2. Validate file size via chunked streaming (avoids full memory read)
     _CHUNK = 65_536  # 64 KB
@@ -56,7 +64,7 @@ def store_upload(file) -> tuple[Path, Path]:
     with open(original_path, "wb+") as f:
         shutil.copyfileobj(file.file, f)
 
-    copy_path = Path(str(original_path).replace(".csv", "_copy.csv"))
+    copy_path = _copy_path_for(original_path)
     shutil.copy2(original_path, copy_path)
 
     logger.info("Stored upload: original=%s, copy=%s", original_path, copy_path)
@@ -66,20 +74,24 @@ def store_upload(file) -> tuple[Path, Path]:
 def get_original_path(copy_path: str) -> Path:
     """Derive the original file path from a working copy path.
 
+    Strips the ``_copy`` marker while preserving the native extension, so it
+    works for any supported format (``data_copy.xlsx`` -> ``data.xlsx``).
+
     Args:
-        copy_path: Path to the _copy.csv working file.
+        copy_path: Path to the ``_copy`` working file.
 
     Returns:
-        Path to the original CSV file.
+        Path to the original file.
     """
-    return Path(copy_path.replace("_copy.csv", ".csv"))
+    p = Path(copy_path)
+    return p.with_name(f"{p.stem.removesuffix('_copy')}{p.suffix}")
 
 
 def delete_project_files(copy_path: str) -> None:
     """Delete both the working copy and original file for a project.
 
     Args:
-        copy_path: Path to the _copy.csv working file.
+        copy_path: Path to the ``_copy`` working file.
     """
     original_path = get_original_path(copy_path)
 

--- a/dataloom-backend/app/utils/file_formats.py
+++ b/dataloom-backend/app/utils/file_formats.py
@@ -131,7 +131,16 @@ def _read_parquet(path: Path) -> pd.DataFrame:
 
 
 def _write_parquet(df: pd.DataFrame, path: Path) -> None:
-    df.to_parquet(path, index=False)
+    try:
+        df.to_parquet(path, index=False)
+    except (ValueError, TypeError):
+        # pyarrow rejects mixed-type object columns (e.g. a column holding both
+        # ints and strings after cell edits). Stringify object columns and retry
+        # so a parquet write/export never crashes on messy data.
+        coerced = df.copy()
+        obj_cols = coerced.select_dtypes(include="object").columns
+        coerced[obj_cols] = coerced[obj_cols].astype(str)
+        coerced.to_parquet(path, index=False)
 
 
 _FORMATS: dict[str, FileFormat] = {

--- a/dataloom-backend/app/utils/file_formats.py
+++ b/dataloom-backend/app/utils/file_formats.py
@@ -1,0 +1,175 @@
+"""File-format registry for multi-format dataset I/O.
+
+Each supported upload format is described by a :class:`FileFormat` entry that
+knows how to read it into a DataFrame, write a DataFrame back out, and what
+media type to serve it with. The rest of the application stays format-agnostic:
+transforms operate purely on DataFrames, and the working copy is kept in the
+same native format it was uploaded in.
+
+To add a new format, register one :class:`FileFormat` below — no changes are
+needed in the transform, save, or revert layers.
+"""
+
+import json
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+import pandas as pd
+
+
+@dataclass(frozen=True)
+class FileFormat:
+    """Describes how to read, write, and serve a single dataset file format.
+
+    Attributes:
+        extension: The lowercased file extension including the leading dot.
+        read: Callable that loads a path into a DataFrame.
+        write: Callable that writes a DataFrame to a path.
+        media_type: HTTP content type used when serving the file for download.
+    """
+
+    extension: str
+    read: Callable[[Path], pd.DataFrame]
+    write: Callable[[pd.DataFrame, Path], None]
+    media_type: str
+
+
+# --- CSV / TSV ------------------------------------------------------------
+
+
+def _read_csv(path: Path) -> pd.DataFrame:
+    return pd.read_csv(path)
+
+
+def _write_csv(df: pd.DataFrame, path: Path) -> None:
+    df.to_csv(path, index=False)
+
+
+def _read_tsv(path: Path) -> pd.DataFrame:
+    return pd.read_csv(path, sep="\t")
+
+
+def _write_tsv(df: pd.DataFrame, path: Path) -> None:
+    df.to_csv(path, sep="\t", index=False)
+
+
+# --- JSON (one level of nesting) ------------------------------------------
+
+
+def _scalarize(value):
+    """Coerce a JSON value into a cell value.
+
+    Arrays are stored as their JSON-string representation; scalars pass through
+    unchanged. Nested objects are handled by the caller, which flattens exactly
+    one level and rejects anything deeper.
+    """
+    if isinstance(value, list):
+        return json.dumps(value)
+    return value
+
+
+def _read_json(path: Path) -> pd.DataFrame:
+    """Read a JSON file into a DataFrame, flattening at most one level.
+
+    Accepts either a single object or an array of objects. A nested object is
+    flattened into ``parent.child`` columns; arrays become JSON strings. Nesting
+    deeper than one level is rejected so the failure surfaces at upload time.
+
+    Raises:
+        ValueError: If the JSON is not object-shaped or nests more than one level.
+    """
+    with open(path) as f:
+        data = json.load(f)
+
+    if isinstance(data, dict):
+        data = [data]
+    if not isinstance(data, list):
+        raise ValueError("JSON must be an object or an array of objects.")
+
+    records: list[dict] = []
+    for item in data:
+        if not isinstance(item, dict):
+            raise ValueError("Each JSON record must be an object.")
+        flat: dict = {}
+        for key, value in item.items():
+            if isinstance(value, dict):
+                for subkey, subvalue in value.items():
+                    if isinstance(subvalue, dict):
+                        raise ValueError(
+                            f"Nested object too deep at '{key}.{subkey}'; only one level of nesting is supported."
+                        )
+                    flat[f"{key}.{subkey}"] = _scalarize(subvalue)
+            else:
+                flat[key] = _scalarize(value)
+        records.append(flat)
+
+    return pd.DataFrame(records)
+
+
+def _write_json(df: pd.DataFrame, path: Path) -> None:
+    df.to_json(path, orient="records", indent=2)
+
+
+# --- XLSX -----------------------------------------------------------------
+
+
+def _read_xlsx(path: Path) -> pd.DataFrame:
+    # Default to the first sheet; multi-sheet selection can be added later.
+    return pd.read_excel(path)
+
+
+def _write_xlsx(df: pd.DataFrame, path: Path) -> None:
+    df.to_excel(path, index=False)
+
+
+# --- Parquet --------------------------------------------------------------
+
+
+def _read_parquet(path: Path) -> pd.DataFrame:
+    return pd.read_parquet(path)
+
+
+def _write_parquet(df: pd.DataFrame, path: Path) -> None:
+    df.to_parquet(path, index=False)
+
+
+_FORMATS: dict[str, FileFormat] = {
+    fmt.extension: fmt
+    for fmt in [
+        FileFormat(".csv", _read_csv, _write_csv, "text/csv"),
+        FileFormat(".tsv", _read_tsv, _write_tsv, "text/tab-separated-values"),
+        FileFormat(".json", _read_json, _write_json, "application/json"),
+        FileFormat(
+            ".xlsx",
+            _read_xlsx,
+            _write_xlsx,
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        ),
+        FileFormat(".parquet", _read_parquet, _write_parquet, "application/vnd.apache.parquet"),
+    ]
+}
+
+
+def supported_extensions() -> list[str]:
+    """Return the list of supported file extensions (with leading dots)."""
+    return list(_FORMATS.keys())
+
+
+def get_format(path) -> FileFormat:
+    """Look up the :class:`FileFormat` for a path by its extension.
+
+    Args:
+        path: A filesystem path or string whose suffix identifies the format.
+
+    Returns:
+        The matching FileFormat.
+
+    Raises:
+        ValueError: If the extension is not supported.
+    """
+    ext = Path(path).suffix.lower()
+    fmt = _FORMATS.get(ext)
+    if fmt is None:
+        raise ValueError(f"Unsupported file format '{ext}'. Supported: {supported_extensions()}")
+    return fmt

--- a/dataloom-backend/app/utils/pandas_helpers.py
+++ b/dataloom-backend/app/utils/pandas_helpers.py
@@ -1,4 +1,4 @@
-"""Pandas utility functions for safe CSV operations and response building."""
+"""Pandas utility functions for safe multi-format I/O and response building."""
 
 from pathlib import Path
 from typing import Any
@@ -6,41 +6,49 @@ from typing import Any
 import pandas as pd
 from fastapi import HTTPException
 
+from app.utils.file_formats import get_format
 
-def read_csv_safe(path: Path) -> pd.DataFrame:
-    """Read a CSV file safely with error handling.
+
+def read_table_safe(path: Path) -> pd.DataFrame:
+    """Read a dataset file safely, dispatching on its format, with error handling.
+
+    The format is resolved from the file extension via the format registry, so
+    CSV/TSV/JSON/XLSX/Parquet all flow through this single helper.
 
     Args:
-        path: Path to the CSV file.
+        path: Path to the dataset file.
 
     Returns:
-        DataFrame with the CSV contents.
+        DataFrame with the file contents.
 
     Raises:
-        HTTPException: If the file cannot be read.
+        HTTPException: 404 if the file is missing, 400 if the contents are
+            invalid for the format (e.g. JSON nested too deeply), 500 otherwise.
     """
     try:
-        return pd.read_csv(path)
+        return get_format(path).read(Path(path))
     except FileNotFoundError:
-        raise HTTPException(status_code=404, detail=f"CSV file not found: {path}") from None
+        raise HTTPException(status_code=404, detail=f"File not found: {path}") from None
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Error reading CSV: {str(e)}") from e
+        raise HTTPException(status_code=500, detail=f"Error reading file: {str(e)}") from e
 
 
-def save_csv_safe(df: pd.DataFrame, path: Path) -> None:
-    """Save a DataFrame to CSV safely.
+def save_table_safe(df: pd.DataFrame, path: Path) -> None:
+    """Save a DataFrame safely, dispatching on the destination file's format.
 
     Args:
         df: DataFrame to save.
-        path: Destination file path.
+        path: Destination file path; its extension selects the writer.
 
     Raises:
         HTTPException: If the file cannot be saved.
     """
     try:
-        df.to_csv(path, index=False)
+        get_format(path).write(df, Path(path))
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Error saving CSV: {str(e)}") from e
+        raise HTTPException(status_code=500, detail=f"Error saving file: {str(e)}") from e
 
 
 def _map_dtype(dtype) -> str:

--- a/dataloom-backend/pyproject.toml
+++ b/dataloom-backend/pyproject.toml
@@ -16,6 +16,8 @@ dependencies = [
     "uuid6>=2025.0.1",
     "pyjwt>=2.9",
     "pydantic[email]>=2.12.5",
+    "openpyxl>=3.1.5",
+    "pyarrow>=24.0.0",
 ]
 
 [tool.ruff]

--- a/dataloom-backend/tests/test_file_formats.py
+++ b/dataloom-backend/tests/test_file_formats.py
@@ -1,0 +1,121 @@
+"""Tests for the multi-format file registry and format-aware I/O helpers."""
+
+import json
+
+import pandas as pd
+import pytest
+from fastapi import HTTPException
+
+from app.utils.file_formats import get_format, supported_extensions
+from app.utils.pandas_helpers import read_table_safe, save_table_safe
+
+
+class TestRegistry:
+    def test_supported_extensions(self):
+        assert set(supported_extensions()) == {".csv", ".tsv", ".json", ".xlsx", ".parquet"}
+
+    def test_get_format_is_case_insensitive(self):
+        assert get_format("DATA.CSV").extension == ".csv"
+
+    def test_get_format_unsupported_raises(self):
+        with pytest.raises(ValueError, match="Unsupported file format '.txt'"):
+            get_format("notes.txt")
+
+
+class TestRoundTrip:
+    """Each format must survive a write → read round-trip via the helpers."""
+
+    @pytest.mark.parametrize("ext", [".csv", ".tsv", ".xlsx", ".parquet"])
+    def test_tabular_round_trip(self, ext, tmp_path):
+        df = pd.DataFrame({"name": ["Alice", "Bob"], "age": [30, 25]})
+        path = tmp_path / f"data{ext}"
+
+        save_table_safe(df, path)
+        result = read_table_safe(path)
+
+        pd.testing.assert_frame_equal(result.reset_index(drop=True), df)
+
+    def test_tsv_splits_on_tab_from_fixture(self, tmp_path):
+        """Read a hand-authored TSV to prove it splits on tabs, not commas.
+
+        A write→read round-trip can't catch this: if both sides wrongly used a
+        comma they'd still agree. Reading content we typed by hand can't be
+        fooled — and the comma inside a value confirms it isn't a delimiter.
+        """
+        path = tmp_path / "data.tsv"
+        path.write_text("name\tnote\nAlice\tlives in NYC, USA\n")
+
+        df = read_table_safe(path)
+
+        assert df.columns.tolist() == ["name", "note"]
+        assert df.iloc[0]["note"] == "lives in NYC, USA"
+
+    def test_parquet_preserves_dtypes(self, tmp_path):
+        """Parquet is binary and should keep integer dtype (unlike CSV)."""
+        df = pd.DataFrame({"age": [30, 25]})
+        path = tmp_path / "data.parquet"
+
+        save_table_safe(df, path)
+        result = read_table_safe(path)
+
+        assert result["age"].dtype == df["age"].dtype
+
+
+class TestJson:
+    def test_flat_records(self, tmp_path):
+        path = tmp_path / "data.json"
+        path.write_text(json.dumps([{"name": "Alice", "age": 30}, {"name": "Bob", "age": 25}]))
+
+        df = read_table_safe(path)
+
+        assert df.columns.tolist() == ["name", "age"]
+        assert df.iloc[0]["name"] == "Alice"
+
+    def test_single_object_is_treated_as_one_record(self, tmp_path):
+        path = tmp_path / "data.json"
+        path.write_text(json.dumps({"name": "Alice", "age": 30}))
+
+        df = read_table_safe(path)
+
+        assert len(df) == 1
+
+    def test_one_level_nesting_is_flattened(self, tmp_path):
+        path = tmp_path / "data.json"
+        path.write_text(json.dumps([{"name": "Alice", "address": {"city": "NYC", "zip": "10001"}}]))
+
+        df = read_table_safe(path)
+
+        assert "address.city" in df.columns
+        assert df.iloc[0]["address.city"] == "NYC"
+
+    def test_arrays_become_json_strings(self, tmp_path):
+        path = tmp_path / "data.json"
+        path.write_text(json.dumps([{"name": "Alice", "tags": ["a", "b"]}]))
+
+        df = read_table_safe(path)
+
+        assert df.iloc[0]["tags"] == '["a", "b"]'
+
+    def test_deep_nesting_rejected_as_400(self, tmp_path):
+        path = tmp_path / "data.json"
+        path.write_text(json.dumps([{"name": "Alice", "address": {"geo": {"lat": 1, "lng": 2}}}]))
+
+        with pytest.raises(HTTPException) as exc:
+            read_table_safe(path)
+        assert exc.value.status_code == 400
+        assert "only one level of nesting" in exc.value.detail
+
+    def test_non_object_records_rejected_as_400(self, tmp_path):
+        path = tmp_path / "data.json"
+        path.write_text(json.dumps([1, 2, 3]))
+
+        with pytest.raises(HTTPException) as exc:
+            read_table_safe(path)
+        assert exc.value.status_code == 400
+
+
+class TestHelperErrors:
+    def test_missing_file_is_404(self, tmp_path):
+        with pytest.raises(HTTPException) as exc:
+            read_table_safe(tmp_path / "nope.csv")
+        assert exc.value.status_code == 404

--- a/dataloom-backend/tests/test_file_formats.py
+++ b/dataloom-backend/tests/test_file_formats.py
@@ -50,6 +50,21 @@ class TestRoundTrip:
         assert df.columns.tolist() == ["name", "note"]
         assert df.iloc[0]["note"] == "lives in NYC, USA"
 
+    def test_parquet_write_survives_mixed_type_column(self, tmp_path):
+        """A mixed-type object column must not crash the parquet writer.
+
+        pyarrow rejects columns holding e.g. both ints and strings; the writer
+        falls back to stringifying object columns so export never 500s.
+        """
+        df = pd.DataFrame({"id": [1, 2, 3], "val": [10, "oops", 3.5]})
+        path = tmp_path / "mixed.parquet"
+
+        save_table_safe(df, path)  # must not raise
+        result = read_table_safe(path)
+
+        assert result["val"].tolist() == ["10", "oops", "3.5"]
+        assert result["id"].tolist() == [1, 2, 3]
+
     def test_parquet_preserves_dtypes(self, tmp_path):
         """Parquet is binary and should keep integer dtype (unlike CSV)."""
         df = pd.DataFrame({"age": [30, 25]})

--- a/dataloom-backend/tests/test_file_service.py
+++ b/dataloom-backend/tests/test_file_service.py
@@ -1,12 +1,13 @@
 """Unit tests for file_service.store_upload() validations."""
 
 from io import BytesIO
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
 from app.config import get_settings
-from app.services.file_service import store_upload
+from app.services.file_service import _copy_path_for, get_original_path, store_upload
 
 
 class MockUploadFile:
@@ -52,23 +53,39 @@ class TestStoreUploadExtension:
             # Should not raise
             store_upload(file)
 
-    def test_non_csv_raises_value_error(self):
-        """A non-.csv file must raise ValueError before touching the disk."""
-        file = MockUploadFile("report.xlsx")
-        with pytest.raises(ValueError, match="Only CSV files are supported. Got: .xlsx"):
+    @pytest.mark.parametrize("filename", ["data.tsv", "data.json", "report.xlsx", "data.parquet"])
+    def test_supported_formats_are_accepted(self, filename, tmp_path):
+        """Every registered non-CSV format must pass extension validation."""
+        file = MockUploadFile(filename)
+        original = tmp_path / filename
+
+        with (
+            patch("app.services.file_service.sanitize_filename", return_value=filename),
+            patch("app.services.file_service.resolve_upload_path", return_value=original),
+            patch("shutil.copy2"),
+        ):
+            result_original, result_copy = store_upload(file)
+
+        ext = original.suffix
+        assert str(result_copy).endswith(f"_copy{ext}")
+
+    def test_unsupported_format_raises_value_error(self):
+        """A file in an unregistered format must raise ValueError before touching disk."""
+        file = MockUploadFile("notes.txt")
+        with pytest.raises(ValueError, match="Unsupported file format '.txt'"):
             store_upload(file)
 
     def test_exe_file_raises_value_error(self):
         """An .exe file must raise ValueError."""
         file = MockUploadFile("malware.exe")
-        with pytest.raises(ValueError, match="Only CSV files are supported. Got: .exe"):
+        with pytest.raises(ValueError, match="Unsupported file format '.exe'"):
             store_upload(file)
 
     def test_no_extension_raises_value_error(self):
         """A filename with no extension must raise ValueError."""
         file = MockUploadFile("nodotfile")
-        # Path("nodotfile").suffix == "" → treated as non-.csv
-        with pytest.raises(ValueError, match="Only CSV files are supported. Got:"):
+        # Path("nodotfile").suffix == "" → unsupported format
+        with pytest.raises(ValueError, match="Unsupported file format"):
             store_upload(file)
 
     def test_error_message_includes_actual_extension(self):
@@ -76,6 +93,32 @@ class TestStoreUploadExtension:
         file = MockUploadFile("archive.zip")
         with pytest.raises(ValueError, match=r"\.zip"):
             store_upload(file)
+
+
+# ---------------------------------------------------------------------------
+# TestCopyOriginalPaths — the naming logic the multi-format refactor depends on
+# ---------------------------------------------------------------------------
+
+
+class TestCopyOriginalPaths:
+    """Working copy must keep the native extension, and the original must be
+    recoverable from it for any supported format. This is the exact bug the
+    refactor fixed (the old code hardcoded .csv)."""
+
+    @pytest.mark.parametrize("ext", [".csv", ".tsv", ".json", ".xlsx", ".parquet"])
+    def test_copy_path_preserves_extension(self, ext):
+        original = Path(f"/uploads/abc123_data{ext}")
+        assert _copy_path_for(original) == Path(f"/uploads/abc123_data_copy{ext}")
+
+    @pytest.mark.parametrize("ext", [".csv", ".tsv", ".json", ".xlsx", ".parquet"])
+    def test_original_recovered_from_copy(self, ext):
+        copy = f"/uploads/abc123_data_copy{ext}"
+        assert get_original_path(copy) == Path(f"/uploads/abc123_data{ext}")
+
+    @pytest.mark.parametrize("ext", [".csv", ".tsv", ".json", ".xlsx", ".parquet"])
+    def test_round_trip_is_stable(self, ext):
+        original = Path(f"/uploads/x_report{ext}")
+        assert get_original_path(str(_copy_path_for(original))) == original
 
 
 # ---------------------------------------------------------------------------

--- a/dataloom-backend/tests/test_multiformat_upload.py
+++ b/dataloom-backend/tests/test_multiformat_upload.py
@@ -1,0 +1,138 @@
+"""End-to-end tests for multi-format upload, lifecycle, and export.
+
+These drive the real API with TestClient (upload -> store -> read -> DB ->
+response), proving the whole pipeline works for each supported format, not just
+the format registry in isolation.
+"""
+
+from io import BytesIO
+
+import pandas as pd
+import pytest
+
+SAMPLE = pd.DataFrame(
+    {
+        "name": ["Alice", "Bob", "Charlie"],
+        "age": [30, 25, 35],
+        "city": ["New York", "Los Angeles", "Chicago"],
+    }
+)
+
+
+def _encode(df: pd.DataFrame, ext: str) -> bytes:
+    """Serialize a DataFrame to the on-disk bytes for the given format."""
+    if ext == ".csv":
+        return df.to_csv(index=False).encode()
+    if ext == ".tsv":
+        return df.to_csv(sep="\t", index=False).encode()
+    if ext == ".json":
+        return df.to_json(orient="records").encode()
+    if ext == ".xlsx":
+        buf = BytesIO()
+        df.to_excel(buf, index=False)
+        return buf.getvalue()
+    if ext == ".parquet":
+        buf = BytesIO()
+        df.to_parquet(buf, index=False)
+        return buf.getvalue()
+    raise ValueError(ext)
+
+
+def _upload(client, content: bytes, filename: str):
+    return client.post(
+        "/projects/upload",
+        files={"file": (filename, content, "application/octet-stream")},
+        data={"projectName": "Multiformat", "projectDescription": "format test"},
+    )
+
+
+# --- Happy path: every format uploads and parses correctly ----------------
+
+
+class TestUploadEachFormat:
+    @pytest.mark.parametrize("ext", [".csv", ".tsv", ".json", ".xlsx", ".parquet"])
+    def test_upload_returns_correct_shape(self, client, ext):
+        response = _upload(client, _encode(SAMPLE, ext), f"data{ext}")
+
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["columns"] == ["name", "age", "city"]
+        assert body["total_rows"] == 3
+        assert body["rows"][0][0] == "Alice"
+
+
+# --- Full lifecycle through the API for a non-CSV format ------------------
+
+
+class TestXlsxLifecycle:
+    """Upload -> transform -> revert on .xlsx exercises the native-extension
+    working-copy logic (the riskiest part of the refactor) end to end."""
+
+    def test_transform_then_revert(self, client):
+        project_id = _upload(client, _encode(SAMPLE, ".xlsx"), "data.xlsx").json()["project_id"]
+
+        filtered = client.post(
+            f"/projects/{project_id}/transform",
+            json={
+                "operation_type": "filter",
+                "parameters": {"column": "name", "condition": "=", "value": "Alice"},
+            },
+        )
+        assert filtered.status_code == 200, filtered.text
+        assert filtered.json()["row_count"] == 1
+
+        reverted = client.post(f"/projects/{project_id}/revert")
+        assert reverted.status_code == 200, reverted.text
+        assert reverted.json()["total_rows"] == 3
+
+
+# --- Export returns the native format -------------------------------------
+
+
+class TestExportNativeFormat:
+    def test_export_xlsx_round_trips(self, client):
+        project_id = _upload(client, _encode(SAMPLE, ".xlsx"), "data.xlsx").json()["project_id"]
+
+        response = client.get(f"/projects/{project_id}/export")
+
+        assert response.status_code == 200
+        assert "spreadsheetml" in response.headers["content-type"]
+        assert response.headers["content-disposition"].endswith('.xlsx"')
+        # The downloaded bytes must re-open as a valid spreadsheet.
+        result = pd.read_excel(BytesIO(response.content))
+        assert result["name"].tolist() == ["Alice", "Bob", "Charlie"]
+
+
+# --- Broken / malformed inputs fail gracefully (no 500 crash) -------------
+
+
+class TestBrokenInputs:
+    def test_malformed_json_is_400(self, client):
+        response = _upload(client, b"{not valid json", "broken.json")
+        assert response.status_code == 400
+
+    def test_deeply_nested_json_is_400(self, client):
+        content = b'[{"name": "Alice", "address": {"geo": {"lat": 1}}}]'
+        response = _upload(client, content, "nested.json")
+        assert response.status_code == 400
+        assert "nesting" in response.json()["detail"].lower()
+
+    def test_corrupt_xlsx_is_400_not_500(self, client):
+        # Random bytes with an .xlsx extension is not a real spreadsheet.
+        response = _upload(client, b"this is not a real xlsx file", "corrupt.xlsx")
+        assert response.status_code == 400
+        assert response.json()["detail"]  # non-empty, client-facing message
+
+    def test_corrupt_parquet_is_400_not_500(self, client):
+        # Garbage bytes with a .parquet extension must fail gracefully, not 500.
+        response = _upload(client, b"this is not a real parquet file", "corrupt.parquet")
+        assert response.status_code == 400
+        assert response.json()["detail"]  # non-empty, client-facing message
+
+    def test_empty_file_is_400(self, client):
+        response = _upload(client, b"", "empty.csv")
+        assert response.status_code == 400
+
+    def test_unsupported_extension_is_rejected(self, client):
+        response = _upload(client, b"hello", "notes.txt")
+        assert response.status_code == 400

--- a/dataloom-backend/tests/test_save_revert.py
+++ b/dataloom-backend/tests/test_save_revert.py
@@ -11,7 +11,7 @@ from app.services.project_service import (
     log_transformation,
 )
 from app.services.transformation_service import add_column, rename_column
-from app.utils.pandas_helpers import read_csv_safe, save_csv_safe
+from app.utils.pandas_helpers import read_table_safe, save_table_safe
 
 
 class TestCheckpoint:
@@ -92,8 +92,8 @@ class TestSaveEndpointRegressions:
             db, "Cumulative Save", str(copy_path), "Regression for repeated saves", owner_id=test_user.id
         )
 
-        renamed_df = rename_column(read_csv_safe(project.file_path), 1, "years")
-        save_csv_safe(renamed_df, project.file_path)
+        renamed_df = rename_column(read_table_safe(project.file_path), 1, "years")
+        save_table_safe(renamed_df, project.file_path)
         log_transformation(
             db,
             project.project_id,
@@ -109,8 +109,8 @@ class TestSaveEndpointRegressions:
         first_save = first_save_response.json()
         assert first_save["columns"] == ["name", "years", "city"]
 
-        extended_df = add_column(read_csv_safe(project.file_path), 3, "country")
-        save_csv_safe(extended_df, project.file_path)
+        extended_df = add_column(read_table_safe(project.file_path), 3, "country")
+        save_table_safe(extended_df, project.file_path)
         log_transformation(
             db,
             project.project_id,
@@ -125,4 +125,4 @@ class TestSaveEndpointRegressions:
         assert second_save_response.status_code == 200
         second_save = second_save_response.json()
         assert second_save["columns"] == ["name", "years", "city", "country"]
-        assert read_csv_safe(project.file_path).columns.tolist() == ["name", "years", "city", "country"]
+        assert read_table_safe(project.file_path).columns.tolist() == ["name", "years", "city", "country"]

--- a/dataloom-backend/tests/test_transform_http_semantics.py
+++ b/dataloom-backend/tests/test_transform_http_semantics.py
@@ -3,7 +3,7 @@
 import pytest
 from fastapi import HTTPException
 
-from app.utils.pandas_helpers import read_csv_safe
+from app.utils.pandas_helpers import read_table_safe
 
 
 @pytest.fixture
@@ -47,13 +47,13 @@ def test_transform_maps_transformation_error_to_400(client, project_id):
     assert "not found" in response.json()["detail"].lower()
 
 
-def test_transform_redacts_csv_not_found_path_detail(client, project_id, monkeypatch):
+def test_transform_redacts_file_not_found_path_detail(client, project_id, monkeypatch):
     from app.api.endpoints import transformations as transformations_endpoint
 
     def boom(*args, **kwargs):
-        raise HTTPException(status_code=404, detail="CSV file not found: /tmp/private/uploads/project.csv")
+        raise HTTPException(status_code=404, detail="File not found: /tmp/private/uploads/project.csv")
 
-    monkeypatch.setattr(transformations_endpoint, "read_csv_safe", boom)
+    monkeypatch.setattr(transformations_endpoint, "read_table_safe", boom)
 
     response = client.post(
         f"/projects/{project_id}/transform",
@@ -64,7 +64,7 @@ def test_transform_redacts_csv_not_found_path_detail(client, project_id, monkeyp
     )
 
     assert response.status_code == 404
-    assert response.json()["detail"] == "CSV file not found"
+    assert response.json()["detail"] == "File not found"
 
 
 def test_transform_redacts_internal_http_exception_detail(client, project_id, monkeypatch):
@@ -76,7 +76,7 @@ def test_transform_redacts_internal_http_exception_detail(client, project_id, mo
             detail="Error reading CSV: [Errno 13] Permission denied: /tmp/private/uploads/project.csv",
         )
 
-    monkeypatch.setattr(transformations_endpoint, "read_csv_safe", boom)
+    monkeypatch.setattr(transformations_endpoint, "read_table_safe", boom)
 
     response = client.post(
         f"/projects/{project_id}/transform",
@@ -160,7 +160,7 @@ def test_transform_returns_500_on_unexpected_exception_during_persistence(client
         raise RuntimeError("disk error")
 
     # This path runs only for mutating operations (should_save=True).
-    monkeypatch.setattr(transformations_endpoint, "save_csv_safe", boom)
+    monkeypatch.setattr(transformations_endpoint, "save_table_safe", boom)
 
     response = client.post(
         f"/projects/{project_id}/transform",
@@ -172,13 +172,13 @@ def test_transform_returns_500_on_unexpected_exception_during_persistence(client
 
     assert response.status_code == 500
     assert response.json()["detail"] == "Internal server error"
-    assert calls, "save_csv_safe was never called; persistence path may not have been exercised"
+    assert calls, "save_table_safe was never called; persistence path may not have been exercised"
 
 
 def test_transform_reverts_file_if_log_transformation_fails(client, project, monkeypatch):
     project_id = project["project_id"]
     file_path = project["file_path"]
-    original_df = read_csv_safe(file_path)
+    original_df = read_table_safe(file_path)
 
     from app.api.endpoints import transformations as transformations_endpoint
 
@@ -198,5 +198,5 @@ def test_transform_reverts_file_if_log_transformation_fails(client, project, mon
     assert response.status_code == 500
     assert response.json()["detail"] == "Internal server error"
 
-    restored_df = read_csv_safe(file_path)
+    restored_df = read_table_safe(file_path)
     assert restored_df.equals(original_df)

--- a/dataloom-backend/tests/test_upload.py
+++ b/dataloom-backend/tests/test_upload.py
@@ -45,13 +45,14 @@ class MockUploadFileNoSize:
 
 class TestValidateUploadFile:
     @pytest.mark.asyncio
-    async def test_csv_accepted(self):
-        file = MockUploadFile("data.csv")
+    @pytest.mark.parametrize("filename", ["data.csv", "data.tsv", "data.json", "data.xlsx", "data.parquet"])
+    async def test_supported_formats_accepted(self, filename):
+        file = MockUploadFile(filename)
         await validate_upload_file(file)
 
     @pytest.mark.asyncio
-    async def test_non_csv_rejected(self):
-        file = MockUploadFile("data.xlsx")
+    async def test_unsupported_format_rejected(self):
+        file = MockUploadFile("data.txt")
         with pytest.raises(HTTPException, match="not allowed"):
             await validate_upload_file(file)
 

--- a/dataloom-backend/uv.lock
+++ b/dataloom-backend/uv.lock
@@ -168,8 +168,10 @@ dependencies = [
     { name = "alembic" },
     { name = "bcrypt" },
     { name = "fastapi" },
+    { name = "openpyxl" },
     { name = "pandas" },
     { name = "psycopg2-binary" },
+    { name = "pyarrow" },
     { name = "pydantic", extra = ["email"] },
     { name = "pydantic-settings" },
     { name = "pyjwt" },
@@ -194,8 +196,10 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.14" },
     { name = "bcrypt", specifier = ">=5.0.0" },
     { name = "fastapi", specifier = ">=0.115" },
+    { name = "openpyxl", specifier = ">=3.1.5" },
     { name = "pandas", specifier = ">=2.1" },
     { name = "psycopg2-binary", specifier = ">=2.9" },
+    { name = "pyarrow", specifier = ">=24.0.0" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.12.5" },
     { name = "pydantic-settings", specifier = ">=2.0" },
     { name = "pyjwt", specifier = ">=2.9" },
@@ -247,6 +251,15 @@ wheels = [
 ]
 
 [[package]]
+name = "et-xmlfile"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54", size = 17234, upload-time = "2024-10-25T17:25:40.039Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa", size = 18059, upload-time = "2024-10-25T17:25:39.051Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.129.2"
 source = { registry = "https://pypi.org/simple" }
@@ -280,7 +293,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/ab/1608e5a7578e62113506740b88066bf09888322a311cff602105e619bd87/greenlet-3.3.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:ac8d61d4343b799d1e526db579833d72f23759c71e07181c2d2944e429eb09cd", size = 280358, upload-time = "2026-02-20T20:17:43.971Z" },
     { url = "https://files.pythonhosted.org/packages/a5/23/0eae412a4ade4e6623ff7626e38998cb9b11e9ff1ebacaa021e4e108ec15/greenlet-3.3.2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ceec72030dae6ac0c8ed7591b96b70410a8be370b6a477b1dbc072856ad02bd", size = 601217, upload-time = "2026-02-20T20:47:31.462Z" },
     { url = "https://files.pythonhosted.org/packages/f8/16/5b1678a9c07098ecb9ab2dd159fafaf12e963293e61ee8d10ecb55273e5e/greenlet-3.3.2-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a2a5be83a45ce6188c045bcc44b0ee037d6a518978de9a5d97438548b953a1ac", size = 611792, upload-time = "2026-02-20T20:55:58.423Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/c5/cc09412a29e43406eba18d61c70baa936e299bc27e074e2be3806ed29098/greenlet-3.3.2-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ae9e21c84035c490506c17002f5c8ab25f980205c3e61ddb3a2a2a2e6c411fcb", size = 626250, upload-time = "2026-02-20T21:02:46.596Z" },
     { url = "https://files.pythonhosted.org/packages/50/1f/5155f55bd71cabd03765a4aac9ac446be129895271f73872c36ebd4b04b6/greenlet-3.3.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43e99d1749147ac21dde49b99c9abffcbc1e2d55c67501465ef0930d6e78e070", size = 613875, upload-time = "2026-02-20T20:21:01.102Z" },
     { url = "https://files.pythonhosted.org/packages/fc/dd/845f249c3fcd69e32df80cdab059b4be8b766ef5830a3d0aa9d6cad55beb/greenlet-3.3.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4c956a19350e2c37f2c48b336a3afb4bff120b36076d9d7fb68cb44e05d95b79", size = 1571467, upload-time = "2026-02-20T20:49:33.495Z" },
     { url = "https://files.pythonhosted.org/packages/2a/50/2649fe21fcc2b56659a452868e695634722a6655ba245d9f77f5656010bf/greenlet-3.3.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6c6f8ba97d17a1e7d664151284cb3315fc5f8353e75221ed4324f84eb162b395", size = 1640001, upload-time = "2026-02-20T20:21:09.154Z" },
@@ -289,7 +301,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/48/f8b875fa7dea7dd9b33245e37f065af59df6a25af2f9561efa8d822fde51/greenlet-3.3.2-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:aa6ac98bdfd716a749b84d4034486863fd81c3abde9aa3cf8eff9127981a4ae4", size = 279120, upload-time = "2026-02-20T20:19:01.9Z" },
     { url = "https://files.pythonhosted.org/packages/49/8d/9771d03e7a8b1ee456511961e1b97a6d77ae1dea4a34a5b98eee706689d3/greenlet-3.3.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab0c7e7901a00bc0a7284907273dc165b32e0d109a6713babd04471327ff7986", size = 603238, upload-time = "2026-02-20T20:47:32.873Z" },
     { url = "https://files.pythonhosted.org/packages/59/0e/4223c2bbb63cd5c97f28ffb2a8aee71bdfb30b323c35d409450f51b91e3e/greenlet-3.3.2-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d248d8c23c67d2291ffd47af766e2a3aa9fa1c6703155c099feb11f526c63a92", size = 614219, upload-time = "2026-02-20T20:55:59.817Z" },
-    { url = "https://files.pythonhosted.org/packages/94/2b/4d012a69759ac9d77210b8bfb128bc621125f5b20fc398bce3940d036b1c/greenlet-3.3.2-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ccd21bb86944ca9be6d967cf7691e658e43417782bce90b5d2faeda0ff78a7dd", size = 628268, upload-time = "2026-02-20T21:02:48.024Z" },
     { url = "https://files.pythonhosted.org/packages/7a/34/259b28ea7a2a0c904b11cd36c79b8cef8019b26ee5dbe24e73b469dea347/greenlet-3.3.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6997d360a4e6a4e936c0f9625b1c20416b8a0ea18a8e19cabbefc712e7397ab", size = 616774, upload-time = "2026-02-20T20:21:02.454Z" },
     { url = "https://files.pythonhosted.org/packages/0a/03/996c2d1689d486a6e199cb0f1cf9e4aa940c500e01bdf201299d7d61fa69/greenlet-3.3.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:64970c33a50551c7c50491671265d8954046cb6e8e2999aacdd60e439b70418a", size = 1571277, upload-time = "2026-02-20T20:49:34.795Z" },
     { url = "https://files.pythonhosted.org/packages/d9/c4/2570fc07f34a39f2caf0bf9f24b0a1a0a47bc2e8e465b2c2424821389dfc/greenlet-3.3.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1a9172f5bf6bd88e6ba5a84e0a68afeac9dc7b6b412b245dd64f52d83c81e55b", size = 1640455, upload-time = "2026-02-20T20:21:10.261Z" },
@@ -298,7 +309,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/ae/8bffcbd373b57a5992cd077cbe8858fff39110480a9d50697091faea6f39/greenlet-3.3.2-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:8d1658d7291f9859beed69a776c10822a0a799bc4bfe1bd4272bb60e62507dab", size = 279650, upload-time = "2026-02-20T20:18:00.783Z" },
     { url = "https://files.pythonhosted.org/packages/d1/c0/45f93f348fa49abf32ac8439938726c480bd96b2a3c6f4d949ec0124b69f/greenlet-3.3.2-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18cb1b7337bca281915b3c5d5ae19f4e76d35e1df80f4ad3c1a7be91fadf1082", size = 650295, upload-time = "2026-02-20T20:47:34.036Z" },
     { url = "https://files.pythonhosted.org/packages/b3/de/dd7589b3f2b8372069ab3e4763ea5329940fc7ad9dcd3e272a37516d7c9b/greenlet-3.3.2-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c2e47408e8ce1c6f1ceea0dffcdf6ebb85cc09e55c7af407c99f1112016e45e9", size = 662163, upload-time = "2026-02-20T20:56:01.295Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/ac/85804f74f1ccea31ba518dcc8ee6f14c79f73fe36fa1beba38930806df09/greenlet-3.3.2-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e3cb43ce200f59483eb82949bf1835a99cf43d7571e900d7c8d5c62cdf25d2f9", size = 675371, upload-time = "2026-02-20T21:02:49.664Z" },
     { url = "https://files.pythonhosted.org/packages/d2/d8/09bfa816572a4d83bccd6750df1926f79158b1c36c5f73786e26dbe4ee38/greenlet-3.3.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:63d10328839d1973e5ba35e98cccbca71b232b14051fd957b6f8b6e8e80d0506", size = 664160, upload-time = "2026-02-20T20:21:04.015Z" },
     { url = "https://files.pythonhosted.org/packages/48/cf/56832f0c8255d27f6c35d41b5ec91168d74ec721d85f01a12131eec6b93c/greenlet-3.3.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8e4ab3cfb02993c8cc248ea73d7dae6cec0253e9afa311c9b37e603ca9fad2ce", size = 1619181, upload-time = "2026-02-20T20:49:36.052Z" },
     { url = "https://files.pythonhosted.org/packages/0a/23/b90b60a4aabb4cec0796e55f25ffbfb579a907c3898cd2905c8918acaa16/greenlet-3.3.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:94ad81f0fd3c0c0681a018a976e5c2bd2ca2d9d94895f23e7bb1af4e8af4e2d5", size = 1687713, upload-time = "2026-02-20T20:21:11.684Z" },
@@ -307,7 +317,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/98/6d/8f2ef704e614bcf58ed43cfb8d87afa1c285e98194ab2cfad351bf04f81e/greenlet-3.3.2-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:e26e72bec7ab387ac80caa7496e0f908ff954f31065b0ffc1f8ecb1338b11b54", size = 286617, upload-time = "2026-02-20T20:19:29.856Z" },
     { url = "https://files.pythonhosted.org/packages/5e/0d/93894161d307c6ea237a43988f27eba0947b360b99ac5239ad3fe09f0b47/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b466dff7a4ffda6ca975979bab80bdadde979e29fc947ac3be4451428d8b0e4", size = 655189, upload-time = "2026-02-20T20:47:35.742Z" },
     { url = "https://files.pythonhosted.org/packages/f5/2c/d2d506ebd8abcb57386ec4f7ba20f4030cbe56eae541bc6fd6ef399c0b41/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b8bddc5b73c9720bea487b3bffdb1840fe4e3656fba3bd40aa1489e9f37877ff", size = 658225, upload-time = "2026-02-20T20:56:02.527Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/67/8197b7e7e602150938049d8e7f30de1660cfb87e4c8ee349b42b67bdb2e1/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:59b3e2c40f6706b05a9cd299c836c6aa2378cabe25d021acd80f13abf81181cf", size = 666581, upload-time = "2026-02-20T21:02:51.526Z" },
     { url = "https://files.pythonhosted.org/packages/8e/30/3a09155fbf728673a1dea713572d2d31159f824a37c22da82127056c44e4/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b26b0f4428b871a751968285a1ac9648944cea09807177ac639b030bddebcea4", size = 657907, upload-time = "2026-02-20T20:21:05.259Z" },
     { url = "https://files.pythonhosted.org/packages/f3/fd/d05a4b7acd0154ed758797f0a43b4c0962a843bedfe980115e842c5b2d08/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1fb39a11ee2e4d94be9a76671482be9398560955c9e568550de0224e41104727", size = 1618857, upload-time = "2026-02-20T20:49:37.309Z" },
     { url = "https://files.pythonhosted.org/packages/6f/e1/50ee92a5db521de8f35075b5eff060dd43d39ebd46c2181a2042f7070385/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:20154044d9085151bc309e7689d6f7ba10027f8f5a8c0676ad398b951913d89e", size = 1680010, upload-time = "2026-02-20T20:21:13.427Z" },
@@ -553,6 +562,18 @@ wheels = [
 ]
 
 [[package]]
+name = "openpyxl"
+version = "3.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "et-xmlfile" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/f9/88d94a75de065ea32619465d2f77b29a0469500e99012523b91cc4141cd1/openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050", size = 186464, upload-time = "2024-06-28T14:03:44.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/da/977ded879c29cbd04de313843e76868e6e13408a94ed6b987245dc7c8506/openpyxl-3.1.5-py2.py3-none-any.whl", hash = "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2", size = 250910, upload-time = "2024-06-28T14:03:41.161Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -686,6 +707,49 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/97/77/21b0ea2e1a73aa5fa9222b2a6b8ba325c43c3a8d54272839c991f2345656/psycopg2_binary-2.9.11-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:32770a4d666fbdafab017086655bcddab791d7cb260a16679cc5a7338b64343b", size = 3044737, upload-time = "2025-10-30T02:55:35.69Z" },
     { url = "https://files.pythonhosted.org/packages/67/69/f36abe5f118c1dca6d3726ceae164b9356985805480731ac6712a63f24f0/psycopg2_binary-2.9.11-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c3cb3a676873d7506825221045bd70e0427c905b9c8ee8d6acd70cfcbd6e576d", size = 3347643, upload-time = "2025-10-10T11:13:53.499Z" },
     { url = "https://files.pythonhosted.org/packages/e1/36/9c0c326fe3a4227953dfb29f5d0c8ae3b8eb8c1cd2967aa569f50cb3c61f/psycopg2_binary-2.9.11-cp314-cp314-win_amd64.whl", hash = "sha256:4012c9c954dfaccd28f94e84ab9f94e12df76b4afb22331b1f0d3154893a6316", size = 2803913, upload-time = "2025-10-10T11:13:57.058Z" },
+]
+
+[[package]]
+name = "pyarrow"
+version = "24.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/13/13e1069b351bdc3881266e11147ffccf687505dbb0ea74036237f5d454a5/pyarrow-24.0.0.tar.gz", hash = "sha256:85fe721a14dd823aca09127acbb06c3ca723efbd436c004f16bca601b04dcc83", size = 1180261, upload-time = "2026-04-21T10:51:25.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/a9/9686d9f07837f91f775e8932659192e02c74f9d8920524b480b85212cc68/pyarrow-24.0.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:6233c9ed9ab9d1db47de57d9753256d9dcffbf42db341576099f0fd9f6bf4810", size = 34981559, upload-time = "2026-04-21T10:47:22.17Z" },
+    { url = "https://files.pythonhosted.org/packages/80/b6/0ddf0e9b6ead3474ab087ae598c76b031fc45532bf6a63f3a553440fb258/pyarrow-24.0.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:f7616236ec1bc2b15bfdec22a71ab38851c86f8f05ff64f379e1278cf20c634a", size = 36663654, upload-time = "2026-04-21T10:47:28.315Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/3b/926382efe8ce27ba729071d3566ade6dfb86bdf112f366000196b2f5780a/pyarrow-24.0.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:1617043b99bd33e5318ae18eb2919af09c71322ef1ca46566cdafc6e6712fb66", size = 45679394, upload-time = "2026-04-21T10:47:34.821Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/7a/829f7d9dfd37c207206081d6dad474d81dde29952401f07f2ba507814818/pyarrow-24.0.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:6165461f55ef6314f026de6638d661188e3455d3ec49834556a0ebbdbace18bb", size = 48863122, upload-time = "2026-04-21T10:47:42.056Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/e8/f88ce625fe8babaae64e8db2d417c7653adb3019b08aae85c5ed787dc816/pyarrow-24.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3b13dedfe76a0ad2d1d859b0811b53827a4e9d93a0bcb05cf59333ab4980cc7e", size = 49376032, upload-time = "2026-04-21T10:47:48.967Z" },
+    { url = "https://files.pythonhosted.org/packages/36/7a/82c363caa145fff88fb475da50d3bf52bb024f61917be5424c3392eaf878/pyarrow-24.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:25ea65d868eb04015cd18e6df2fbe98f07e5bda2abefabcb88fce39a947716f6", size = 51929490, upload-time = "2026-04-21T10:47:55.981Z" },
+    { url = "https://files.pythonhosted.org/packages/66/1c/e3e72c8014ad2743ca64a701652c733cc5cbcee15c0463a32a8c55518d9e/pyarrow-24.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:295f0a7f2e242dabd513737cf076007dc5b2d59237e3eca37b05c0c6446f3826", size = 27355660, upload-time = "2026-04-21T10:48:01.718Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/d3/a1abf004482026ddc17f4503db227787fa3cfe41ec5091ff20e4fea55e57/pyarrow-24.0.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:02b001b3ed4723caa44f6cd1af2d5c86aa2cf9971dacc2ffa55b21237713dfba", size = 34976759, upload-time = "2026-04-21T10:48:07.258Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/4a/34f0a36d28a2dd32225301b79daad44e243dc1a2bb77d43b60749be255c4/pyarrow-24.0.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:04920d6a71aabd08a0417709efce97d45ea8e6fb733d9ca9ecffb13c67839f68", size = 36658471, upload-time = "2026-04-21T10:48:13.347Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/78/543b94712ae8bb1a6023bcc1acf1a740fbff8286747c289cd9468fced2a5/pyarrow-24.0.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:a964266397740257f16f7bb2e4f08a0c81454004beab8ff59dd531b73610e9f2", size = 45675981, upload-time = "2026-04-21T10:48:20.201Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9f/8fb7c222b100d314137fa40ec050de56cd8c6d957d1cfff685ce72f15b17/pyarrow-24.0.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:6f066b179d68c413374294bc1735f68475457c933258df594443bb9d88ddc2a0", size = 48859172, upload-time = "2026-04-21T10:48:27.541Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/d3/1ea72538e6c8b3b475ed78d1049a2c518e655761ea50fe1171fc855fcab7/pyarrow-24.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1183baeb14c5f587b1ec52831e665718ce632caab84b7cd6b85fd44f96114495", size = 49385733, upload-time = "2026-04-21T10:48:34.7Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/be/c3d8b06a1ba35f2260f8e1f771abbee7d5e345c0937aab90675706b1690a/pyarrow-24.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:806f24b4085453c197a5078218d1ee08783ebbba271badd153d1ae22a3ee804f", size = 51934335, upload-time = "2026-04-21T10:48:42.099Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/62/89e07a1e7329d2cde3e3c6994ba0839a24977a2beda8be6005ea3d860b99/pyarrow-24.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:e4505fc6583f7b05ab854934896bcac8253b04ac1171a77dfb73efef92076d91", size = 27271748, upload-time = "2026-04-21T10:49:42.532Z" },
+    { url = "https://files.pythonhosted.org/packages/17/1a/cff3a59f80b5b1658549d46611b67163f65e0664431c076ad728bf9d5af4/pyarrow-24.0.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:1a4e45017efbf115032e4475ee876d525e0e36c742214fbe405332480ecd6275", size = 35238554, upload-time = "2026-04-21T10:48:48.526Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/99/cce0f42a327bfef2c420fb6078a3eb834826e5d6697bf3009fe11d2ad051/pyarrow-24.0.0-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:7986f1fa71cee060ad00758bcc79d3a93bab8559bf978fab9e53472a2e25a17b", size = 36782301, upload-time = "2026-04-21T10:48:55.181Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/66/8e560d5ff6793ca29aca213c53eec0dd482dd46cb93b2819e5aab52e4252/pyarrow-24.0.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:d3e0b61e8efb24ed38898e5cdc5fffa9124be480008d401a1f8071500494ae42", size = 45721929, upload-time = "2026-04-21T10:49:03.676Z" },
+    { url = "https://files.pythonhosted.org/packages/27/0c/a26e25505d030716e078d9f16eb74973cbf0b33b672884e9f9da1c83b871/pyarrow-24.0.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:55a3bc1e3df3b5567b7d27ef551b2283f0c68a5e86f1cd56abc569da4f31335b", size = 48825365, upload-time = "2026-04-21T10:49:11.714Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/eb/771f9ecb0c65e73fe9dccdd1717901b9594f08c4515d000c7c62df573811/pyarrow-24.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:641f795b361874ac9da5294f8f443dfdbee355cf2bd9e3b8d97aaac2306b9b37", size = 49451819, upload-time = "2026-04-21T10:49:21.474Z" },
+    { url = "https://files.pythonhosted.org/packages/48/da/61ae89a88732f5a785646f3ec6125dbb640fa98a540eb2b9889caa561403/pyarrow-24.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8adc8e6ce5fccf5dc707046ae4914fd537def529709cc0d285d37a7f9cd442ca", size = 51909252, upload-time = "2026-04-21T10:49:31.164Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1a/8dd5cafab7b66573fa91c03d06d213356ad4edd71813aa75e08ce2b3a844/pyarrow-24.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:9b18371ad2f44044b81a8d23bc2d8a9b6a6226dca775e8e16cfee640473d6c5d", size = 27388127, upload-time = "2026-04-21T10:49:37.334Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/80/d022a34ff05d2cbedd8ccf841fc1f532ecfa9eb5ed1711b56d0e0ea71fc9/pyarrow-24.0.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:1cc9057f0319e26333b357e17f3c2c022f1a83739b48a88b25bfd5fa2dc18838", size = 35007997, upload-time = "2026-04-21T10:49:48.796Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/ff/f01485fda6f4e5d441afb8dd5e7681e4db18826c1e271852f5d3957d6a80/pyarrow-24.0.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:e6f1278ee4785b6db21229374a1c9e54ec7c549de5d1efc9630b6207de7e170b", size = 36678720, upload-time = "2026-04-21T10:49:55.858Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/c2/2d2d5fea814237923f71b36495211f20b43a1576f9a4d6da7e751a64ec6f/pyarrow-24.0.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:adbbedc55506cbdabb830890444fb856bfb0060c46c6f8026c6c2f2cf86ae795", size = 45741852, upload-time = "2026-04-21T10:50:04.624Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/3a/28ba9c1c1ebdbb5f1b94dfebb46f207e52e6a554b7fe4132540fde29a3a0/pyarrow-24.0.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:ae8a1145af31d903fa9bb166824d7abe9b4681a000b0159c9fb99c11bc11ad26", size = 48889852, upload-time = "2026-04-21T10:50:12.293Z" },
+    { url = "https://files.pythonhosted.org/packages/df/51/4a389acfd31dca009f8fb82d7f510bb4130f2b3a8e18cf00194d0687d8ac/pyarrow-24.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d7027eba1df3b2069e2e8d80f644fa0918b68c46432af3d088ddd390d063ecde", size = 49445207, upload-time = "2026-04-21T10:50:20.677Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4b/0bab2b23d2ae901b1b9a03c0efd4b2d070256f8ce3fc43f6e58c167b2081/pyarrow-24.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e56a1ffe9bf7b727432b89104cc0849c21582949dd7bdcb34f17b2001a351a76", size = 51954117, upload-time = "2026-04-21T10:50:29.14Z" },
+    { url = "https://files.pythonhosted.org/packages/29/88/f4e9145da0417b3d2c12035a8492b35ff4a3dbc653e614fcfb51d9dedb38/pyarrow-24.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:38be1808cdd068605b787e6ca9119b27eb275a0234e50212c3492331680c3b1e", size = 28001155, upload-time = "2026-04-21T10:51:22.337Z" },
+    { url = "https://files.pythonhosted.org/packages/79/4f/46a49a63f43526da895b1a45bbb51d5baf8e4d77159f8528fc3e5490007f/pyarrow-24.0.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:418e48ce50a45a6a6c73c454677203a9c75c966cb1e92ca3370959185f197a05", size = 35250387, upload-time = "2026-04-21T10:50:35.552Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/da/d5e0cd5ef00796922404806d5f00325cdadc3441ce2c13fe7115f2df9a64/pyarrow-24.0.0-cp314-cp314t-macosx_12_0_x86_64.whl", hash = "sha256:2f16197705a230a78270cdd4ea8a1d57e86b2fdcbc34a1f6aebc72e65c986f9a", size = 36797102, upload-time = "2026-04-21T10:50:42.417Z" },
+    { url = "https://files.pythonhosted.org/packages/34/c7/5904145b0a593a05236c882933d439b5720f0a145381179063722fbfc123/pyarrow-24.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:fb24ac194bfc5e86839d7dcd52092ee31e5fe6733fe11f5e3b06ef0812b20072", size = 45745118, upload-time = "2026-04-21T10:50:49.324Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d3/cca42fe166d1c6e4d5b80e530b7949104d10e17508a90ae202dac205ce2a/pyarrow-24.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:9700ebd9a51f5895ce75ff4ac4b3c47a7d4b42bc618be8e713e5d56bacf5f931", size = 48844765, upload-time = "2026-04-21T10:50:55.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/49/942c3b79878ba928324d1e17c274ed84581db8c0a749b24bcf4cbdf15bd3/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d8ddd2768da81d3ee08cfea9b597f4abb4e8e1dc8ae7e204b608d23a0d3ab699", size = 49471890, upload-time = "2026-04-21T10:51:02.439Z" },
+    { url = "https://files.pythonhosted.org/packages/76/97/ff71431000a75d84135a1ace5ca4ba11726a231a8007bbb320a4c54075d5/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:61a3d7eaa97a14768b542f3d284dc6400dd2470d9f080708b13cd46b6ae18136", size = 51932250, upload-time = "2026-04-21T10:51:10.576Z" },
+    { url = "https://files.pythonhosted.org/packages/51/be/6f79d55816d5c22557cf27533543d5d70dfe692adfbee4b99f2760674f38/pyarrow-24.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:c91d00057f23b8d353039520dc3a6c09d8608164c692e9f59a175a42b2ae0c19", size = 28131282, upload-time = "2026-04-21T10:51:16.815Z" },
 ]
 
 [[package]]

--- a/dataloom-frontend/src/Components/Homescreen.jsx
+++ b/dataloom-frontend/src/Components/Homescreen.jsx
@@ -4,7 +4,7 @@ import { uploadProject, getRecentProjects, deleteProject } from "../api";
 import { useToast } from "../context/ToastContext";
 import ConfirmDialog from "./common/ConfirmDialog";
 import { UploadCloud, FileText, X, Pencil } from "lucide-react";
-import { formatFileSize } from "../utils/fileUtils";
+import { ACCEPTED_EXTENSIONS, formatFileSize, validateFile } from "../utils/fileUtils";
 
 const ProjectCard = ({ project, onClick, onDelete }) => {
   const modified = new Date(project.last_modified).toLocaleDateString(undefined, {
@@ -61,8 +61,6 @@ const NewProjectCard = ({ onClick }) => (
   </button>
 );
 
-const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024; // 10 MB
-const ACCEPTED_EXTENSIONS = [".csv", ".tsv", ".json", ".xlsx", ".parquet"];
 const ACCEPT_ATTR = ACCEPTED_EXTENSIONS.join(",");
 
 const EmptyState = ({ onClick }) => (
@@ -198,23 +196,9 @@ const HomeScreen = () => {
 
     if (!file) return;
 
-    const isSupported = ACCEPTED_EXTENSIONS.some((ext) => file.name.toLowerCase().endsWith(ext));
-
-    if (!isSupported) {
-      showToast(`Unsupported file type. Allowed: ${ACCEPTED_EXTENSIONS.join(", ")}`, "error");
-
-      if (fileInputRef.current) {
-        fileInputRef.current.value = "";
-      }
-
-      setFileUpload(null);
-      return;
-    }
-
-    if (file.size > MAX_FILE_SIZE_BYTES) {
-      const sizeMB = (file.size / (1024 * 1024)).toFixed(1);
-
-      showToast(`File too large (${sizeMB} MB). Maximum allowed size is 10 MB.`, "warning");
+    const validation = validateFile(file);
+    if (!validation.valid) {
+      showToast(validation.error, "warning");
 
       if (fileInputRef.current) {
         fileInputRef.current.value = "";

--- a/dataloom-frontend/src/Components/Homescreen.jsx
+++ b/dataloom-frontend/src/Components/Homescreen.jsx
@@ -62,28 +62,8 @@ const NewProjectCard = ({ onClick }) => (
 );
 
 const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024; // 10 MB
-
-const validateFile = (file) => {
-  if (!file) {
-    return { valid: false, error: "Please select a file to upload" };
-  }
-
-  const isCSV = file.type === "text/csv" || file.name.toLowerCase().endsWith(".csv");
-  if (!isCSV) {
-    return { valid: false, error: "Please upload a CSV file." };
-  }
-
-  if (file.size === 0) {
-    return { valid: false, error: "File is empty (0 bytes)." };
-  }
-
-  if (file.size > MAX_FILE_SIZE_BYTES) {
-    const sizeMB = (file.size / (1024 * 1024)).toFixed(1);
-    return { valid: false, error: `File too large (${sizeMB} MB). Maximum allowed size is 10 MB.` };
-  }
-
-  return { valid: true };
-};
+const ACCEPTED_EXTENSIONS = [".csv", ".tsv", ".json", ".xlsx", ".parquet"];
+const ACCEPT_ATTR = ACCEPTED_EXTENSIONS.join(",");
 
 const EmptyState = ({ onClick }) => (
   <div className="flex flex-col items-center justify-center py-16 px-6 rounded-xl border-2 border-dashed border-gray-200 bg-gray-50 text-center">
@@ -107,7 +87,7 @@ const EmptyState = ({ onClick }) => (
     </div>
     <h3 className="text-lg font-semibold text-gray-800 mb-1">No projects yet</h3>
     <p className="text-sm text-gray-500 mb-6 max-w-xs">
-      Upload a CSV file to get started. Your recent projects will appear here.
+      Upload a dataset to get started. Your recent projects will appear here.
     </p>
     <button
       type="button"
@@ -218,9 +198,23 @@ const HomeScreen = () => {
 
     if (!file) return;
 
-    const validation = validateFile(file);
-    if (!validation.valid) {
-      showToast(validation.error, "error");
+    const isSupported = ACCEPTED_EXTENSIONS.some((ext) => file.name.toLowerCase().endsWith(ext));
+
+    if (!isSupported) {
+      showToast(`Unsupported file type. Allowed: ${ACCEPTED_EXTENSIONS.join(", ")}`, "error");
+
+      if (fileInputRef.current) {
+        fileInputRef.current.value = "";
+      }
+
+      setFileUpload(null);
+      return;
+    }
+
+    if (file.size > MAX_FILE_SIZE_BYTES) {
+      const sizeMB = (file.size / (1024 * 1024)).toFixed(1);
+
+      showToast(`File too large (${sizeMB} MB). Maximum allowed size is 10 MB.`, "warning");
 
       if (fileInputRef.current) {
         fileInputRef.current.value = "";
@@ -393,7 +387,8 @@ const HomeScreen = () => {
               </div>
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-2">
-                  Upload Dataset <span className="text-gray-400 font-normal">(CSV)</span>
+                  Upload Dataset{" "}
+                  <span className="text-gray-400 font-normal">(CSV, TSV, JSON, XLSX, Parquet)</span>
                   <span className="text-red-500">*</span>
                 </label>
 
@@ -409,7 +404,7 @@ const HomeScreen = () => {
                       data-testid="file-input"
                       type="file"
                       ref={fileInputRef}
-                      accept=".csv"
+                      accept={ACCEPT_ATTR}
                       className="hidden"
                       onChange={handleFileUpload}
                       required
@@ -423,7 +418,7 @@ const HomeScreen = () => {
 
                       <div>
                         <p className="text-sm font-semibold text-gray-800">
-                          Drag & drop your CSV file here
+                          Drag & drop your dataset here
                         </p>
 
                         <p className="text-sm text-gray-500 mt-1">
@@ -448,7 +443,8 @@ const HomeScreen = () => {
                           </p>
 
                           <p className="text-xs text-gray-500 mt-1">
-                            {formatFileSize(fileUpload.size)} • CSV File
+                            {formatFileSize(fileUpload.size)} •{" "}
+                            {fileUpload.name.split(".").pop().toUpperCase()} File
                           </p>
                         </div>
                       </div>
@@ -477,7 +473,7 @@ const HomeScreen = () => {
                       type="file"
                       data-testid="file-input"
                       ref={fileInputRef}
-                      accept=".csv"
+                      accept={ACCEPT_ATTR}
                       className="hidden"
                       onChange={handleFileUpload}
                     />

--- a/dataloom-frontend/src/Components/MenuNavbar.jsx
+++ b/dataloom-frontend/src/Components/MenuNavbar.jsx
@@ -132,11 +132,11 @@ const MenuNavbar = ({ projectId, onTransform }) => {
 
   const handleExport = async () => {
     try {
-      const blob = await exportProject(projectId);
+      const { blob, filename } = await exportProject(projectId);
       const url = URL.createObjectURL(blob);
       const a = document.createElement("a");
       a.href = url;
-      a.download = "export.csv";
+      a.download = filename || "export.csv";
       document.body.appendChild(a);
       a.click();
       a.remove();

--- a/dataloom-frontend/src/api/projects.js
+++ b/dataloom-frontend/src/api/projects.js
@@ -68,15 +68,18 @@ export const revertToCheckpoint = async (projectId, checkpointId) => {
 };
 
 /**
- * Export the current working copy of a project as a CSV download.
+ * Export the current working copy of a project in its native format.
  * @param {string} projectId - The project ID.
- * @returns {Promise<Blob>} The CSV file as a Blob.
+ * @returns {Promise<{blob: Blob, filename: string|null}>} The file blob and the
+ *   server-provided download filename (parsed from Content-Disposition).
  */
 export const exportProject = async (projectId) => {
   const response = await client.get(`/projects/${projectId}/export`, {
     responseType: "blob",
   });
-  return response.data;
+  const disposition = response.headers["content-disposition"] || "";
+  const match = disposition.match(/filename="?([^"]+)"?/);
+  return { blob: response.data, filename: match ? match[1] : null };
 };
 
 /**

--- a/dataloom-frontend/src/utils/fileUtils.js
+++ b/dataloom-frontend/src/utils/fileUtils.js
@@ -1,3 +1,6 @@
+export const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024; // 10 MB
+export const ACCEPTED_EXTENSIONS = [".csv", ".tsv", ".json", ".xlsx", ".parquet"];
+
 export function formatFileSize(bytes) {
   if (bytes < 1024) {
     return `${bytes} B`;
@@ -8,4 +11,30 @@ export function formatFileSize(bytes) {
   }
 
   return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+}
+
+export function validateFile(file) {
+  if (!file) {
+    return { valid: false, error: "Please select a file to upload." };
+  }
+
+  const isSupported = ACCEPTED_EXTENSIONS.some((ext) => file.name.toLowerCase().endsWith(ext));
+
+  if (!isSupported) {
+    return {
+      valid: false,
+      error: `Unsupported file type. Allowed: ${ACCEPTED_EXTENSIONS.join(", ")}`,
+    };
+  }
+
+  if (file.size > MAX_FILE_SIZE_BYTES) {
+    const sizeMB = (file.size / (1024 * 1024)).toFixed(1);
+
+    return {
+      valid: false,
+      error: `File too large (${sizeMB} MB). Maximum allowed size is 10 MB.`,
+    };
+  }
+
+  return { valid: true };
 }


### PR DESCRIPTION
## Description
Adds upload support for TSV, JSON, XLSX, and Parquet alongside CSV.

## What changed
- **Format registry** (`app/utils/file_formats.py`): one entry per format with read/write/media-type, so the rest of the app stays format-agnostic and new formats are a single registry line.
- **Format-aware I/O**: `read_csv_safe`/`save_csv_safe` become `read_table_safe`/`save_table_safe`, dispatching on extension. Transform functions are untouched (they stay pure DataFrame ops).
- **Working copy keeps the native format** (`_copy.xlsx`, etc.). `get_original_path` derives the original deterministically from the copy name — no disk probing, no `.csv` assumption.
- **JSON**: flattens one level (`parent.child`), arrays become JSON strings, deeper nesting is rejected with a 400 at upload.
- **Parquet writer** is hardened against mixed-type object columns (retries with object columns stringified instead of returning a 500).
- **Upload hardening**: unparseable uploads return a clean 400 and the orphaned files are cleaned up.
- **Frontend**: upload accepts all five extensions with generalized validation/copy.

Fixes #174

## Type of Change

- [ ] Bug fix
- [X] New feature
- [X] Breaking change
- [ ] Documentation update

## How Has This Been Tested?
- Registry round-trips per format, JSON nesting rules, TSV tab parsing, mixed-type parquet recovery.
- Endpoint-level upload + transform/revert lifecycle per format.
- Broken-input handling (malformed / corrupt / empty / unsupported → 400).
- Working-copy naming logic per extension.

- [X] Existing tests pass
- [X] New tests added
- [X] Manual testing

## Checklist

- [X] My code follows the project's style guidelines
- [X] I have performed a self-review
- [X] I have added/updated documentation as needed
- [X] My changes generate no new warnings
- [X] Tests pass locally
