### PR TITLE
fix(backend+frontend): preserve null vs empty-string response semantics

### DIFF
--- a/dataloom-backend/app/utils/pandas_helpers.py
+++ b/dataloom-backend/app/utils/pandas_helpers.py
@@ -79,10 +79,16 @@ def dataframe_to_response(df: pd.DataFrame) -> dict[str, Any]:
     """
 
     dtypes = {col: _map_dtype(dtype) for col, dtype in df.dtypes.items()}
-    df = df.fillna("")
-    df = df.replace([float("inf"), float("-inf")], "")
     columns = df.columns.tolist()
-    rows = df.values.tolist()
+
+    # Preserve null semantics: real empty strings stay "", while missing and
+    # non-finite values serialize to null. ``where`` over an object-typed frame
+    # is a vectorized C-level dispatch, not a Python-level per-cell loop.
+    normalized_df = df.astype(object)
+    normalized_df = normalized_df.where(pd.notna(normalized_df), None)
+    normalized_df = normalized_df.replace([float("inf"), float("-inf")], None)
+
+    rows = normalized_df.values.tolist()
     return {
         "columns": columns,
         "rows": rows,

--- a/dataloom-backend/tests/test_dtypes.py
+++ b/dataloom-backend/tests/test_dtypes.py
@@ -65,3 +65,34 @@ class TestDataframeToResponse:
         assert response["columns"] == ["name", "age", "city"]
         assert response["row_count"] == 3
         assert len(response["rows"]) == 3
+
+    def test_preserves_nulls_without_coercing_them_to_empty_strings(self):
+        df = pd.DataFrame(
+            {
+                "maybe_missing": [None, ""],
+                "score": [float("inf"), 5.5],
+                "when": pd.to_datetime(["2024-01-01", None]),
+            }
+        )
+
+        response = dataframe_to_response(df)
+
+        assert response["rows"][0][0] is None
+        assert response["rows"][1][0] == ""
+        assert response["rows"][0][1] is None
+        assert response["rows"][1][1] == 5.5
+        assert response["rows"][0][2] == pd.Timestamp("2024-01-01")
+        assert response["rows"][1][2] is None
+
+    def test_preserves_non_scalar_cells_without_isna_truthiness_errors(self):
+        df = pd.DataFrame(
+            {
+                "payload": [[1, 2], [None], {"ok": True}],
+            }
+        )
+
+        response = dataframe_to_response(df)
+
+        assert response["rows"][0][0] == [1, 2]
+        assert response["rows"][1][0] == [None]
+        assert response["rows"][2][0] == {"ok": True}

--- a/dataloom-backend/tests/test_new_features.py
+++ b/dataloom-backend/tests/test_new_features.py
@@ -171,6 +171,13 @@ class TestAddDeleteColumnEndpoint:
         )
         assert response.status_code == 422
 
+    def test_add_column_with_blank_name_returns_422(self, client, uploaded_project):
+        response = client.post(
+            f"/projects/{uploaded_project}/transform",
+            json={"operation_type": "addCol", "add_col_params": {"index": 1, "name": "   "}},
+        )
+        assert response.status_code == 422
+
     def test_add_column_with_legacy_col_params_returns_400(self, client, sample_csv, db):
         with open(sample_csv, "rb") as f:
             response = client.post(

--- a/dataloom-backend/tests/test_response_serialization.py
+++ b/dataloom-backend/tests/test_response_serialization.py
@@ -1,0 +1,27 @@
+"""Regression tests for API response serialization semantics."""
+
+import csv
+
+
+def test_upload_response_preserves_missing_values_as_null(client, tmp_path, db):
+    csv_path = tmp_path / "missing_values.csv"
+    with open(csv_path, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["name", "age", "city"])
+        writer.writerow(["Alice", "", "New York"])
+        writer.writerow(["Bob", "25", "Los Angeles"])
+
+    with open(csv_path, "rb") as f:
+        response = client.post(
+            "/projects/upload",
+            files={"file": ("missing_values.csv", f, "text/csv")},
+            data={
+                "projectName": "Missing Values Project",
+                "projectDescription": "Regression fixture for response null semantics",
+            },
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["rows"][0][1] is None
+    assert payload["rows"][1][1] == 25.0

--- a/dataloom-frontend/src/Components/Table.jsx
+++ b/dataloom-frontend/src/Components/Table.jsx
@@ -280,7 +280,9 @@ const Table = ({ projectId, data: externalData }) => {
   const handleCellClick = (rowIndex, cellIndex, cellValue) => {
     if (cellIndex !== 0) {
       setEditingCell({ rowIndex, cellIndex });
-      setEditValue(cellValue);
+      // Coerce null/undefined (missing cells now serialize to null) to "" so the
+      // controlled input stays controlled and never renders the literal "null".
+      setEditValue(cellValue ?? "");
     }
   };
 


### PR DESCRIPTION
## Why

Slim follow-up to closed PR #270, as requested by @ivantha. Most of #270's bundle already landed on `main` via other paths (Pydantic v2 in #282, `add_col_params`/`del_col_params` frontend keys in #302, alembic-on-pytest in `a5eb4c5`, and the `AddColumn.name` validator). This PR carries **only** the substance that was still genuinely missing, in the exact shape the maintainer outlined.

## What changed

- **`app/utils/pandas_helpers.py`** — `dataframe_to_response` now preserves null semantics: real empty strings stay `""`, while missing and non-finite values serialize to `null`. Implemented via `df.astype(object).where(pd.notna(...), None)`, which is a vectorized C-level dispatch (not a Python per-cell loop).
- **`dataloom-frontend/src/Components/Table.jsx`** — `handleCellClick` now does `setEditValue(cellValue ?? "")`, so missing cells (now `null`) don't make the controlled input uncontrolled or render the literal string `"null"`. This is the coordinated frontend half of the API contract change.

### Tests
- `tests/test_dtypes.py` — `test_preserves_nulls_without_coercing_them_to_empty_strings` and `test_preserves_non_scalar_cells_without_isna_truthiness_errors`.
- `tests/test_response_serialization.py` (new) — API-level assertion that uploaded missing values come back as `null`.
- `tests/test_new_features.py` — `test_add_column_with_blank_name_returns_422` paired with the existing schema-layer validator.

## Not included (already on `main`)
The `AddColumn.name` `field_validator`, the Pydantic v2 migration, the `pytest-asyncio` dep, the frontend payload-key changes, and the alembic-on-pytest handling were all verified present on current `main`, so they're intentionally omitted to keep this focused.

## Validation
- Backend: `uv run pytest -q` → **296 passed**; `uv run ruff check .` clean.
- Frontend: `npm run test` → **56 passed**; `npm run lint` and Prettier clean.

## Reference
- Follow-up to: #270 (supersedes #221)