### PR TITLE
test(backend): cover last_modified advancing on checkpoint create

### DIFF
--- a/dataloom-backend/tests/test_last_modified.py
+++ b/dataloom-backend/tests/test_last_modified.py
@@ -13,6 +13,7 @@ from sqlmodel import Session, SQLModel, create_engine
 
 from app import models
 from app.services.project_service import (
+    create_checkpoint,
     create_project,
     get_recent_projects,
     log_transformation,
@@ -150,3 +151,79 @@ class TestLastModifiedUpdatesOnTransform:
         fake_id = uuid.uuid4()
         # Should not raise — the `if project:` guard handles the None case
         log_transformation(mem_db, fake_id, "addRow", {"row_params": {"index": 0}})
+
+
+class TestLastModifiedUpdatesOnCheckpoint:
+    """last_modified must advance each time create_checkpoint() is called."""
+
+    def test_last_modified_advances_after_checkpoint(self, mem_db):
+        project = _make_project(mem_db, "CP Basic")
+        ts_before = project.last_modified
+
+        time.sleep(0.05)
+        create_checkpoint(mem_db, project.project_id, "first save")
+
+        mem_db.refresh(project)
+        ts_after = project.last_modified
+
+        assert ts_after > ts_before, f"last_modified was not updated: before={ts_before}, after={ts_after}"
+
+    def test_checkpoint_after_transform_advances_timestamp(self, mem_db):
+        """A checkpoint following a transform should push last_modified forward again."""
+        project = _make_project(mem_db, "CP After Transform")
+
+        time.sleep(0.05)
+        log_transformation(
+            mem_db,
+            project.project_id,
+            "addRow",
+            {"operation_type": "addRow", "row_params": {"index": 0}},
+        )
+        mem_db.refresh(project)
+        ts_after_transform = project.last_modified
+
+        time.sleep(0.05)
+        create_checkpoint(mem_db, project.project_id, "save after transform")
+        mem_db.refresh(project)
+        ts_after_checkpoint = project.last_modified
+
+        assert ts_after_checkpoint > ts_after_transform, (
+            f"checkpoint did not advance last_modified: "
+            f"transform={ts_after_transform}, checkpoint={ts_after_checkpoint}"
+        )
+
+    def test_most_recently_checkpointed_project_appears_first_in_recent(self, mem_db):
+        """Project A, created first but checkpointed last, should lead /recent."""
+        project_a = _make_project(mem_db, "CP Order A")
+        time.sleep(0.05)
+        project_b = _make_project(mem_db, "CP Order B")
+
+        time.sleep(0.05)
+        create_checkpoint(mem_db, project_a.project_id, "save A")
+
+        recent = get_recent_projects(mem_db, owner_id=_make_user(mem_db).id, limit=10)
+        ids = [str(p.project_id) for p in recent]
+
+        idx_a = ids.index(str(project_a.project_id))
+        idx_b = ids.index(str(project_b.project_id))
+
+        assert idx_a < idx_b, f"Project A (last checkpointed) should appear before B. Order: {ids}"
+
+    def test_checkpoint_still_marks_pending_logs_applied(self, mem_db):
+        """Adding last_modified update must not break the existing applied-logs behavior."""
+        project = _make_project(mem_db, "CP Logs")
+        log_transformation(
+            mem_db,
+            project.project_id,
+            "addRow",
+            {"operation_type": "addRow", "row_params": {"index": 0}},
+        )
+
+        checkpoint = create_checkpoint(mem_db, project.project_id, "save logs")
+
+        logs = (
+            mem_db.query(models.ProjectChangeLog).filter(models.ProjectChangeLog.project_id == project.project_id).all()
+        )
+        assert len(logs) == 1
+        assert logs[0].applied is True
+        assert logs[0].checkpoint_id == checkpoint.id


### PR DESCRIPTION
## Why

Slim follow-up to closed PR #269, as requested by @ivantha. Most of #269's bundle already landed on `main` via other paths (the `last_modified`-on-checkpoint fix in #286, alembic-on-pytest + `test_user_logs` rewrite in `a5eb4c5`, `pytest-asyncio` already present, and a stronger `test_del_row` than #269 would have left behind). The one piece `main` genuinely lacked is the regression coverage for checkpoints advancing `last_modified` — that's all this PR adds.

## What changed

Adds `TestLastModifiedUpdatesOnCheckpoint` to `tests/test_last_modified.py` (4 tests):

- `test_last_modified_advances_after_checkpoint` — `create_checkpoint` pushes `last_modified` forward.
- `test_checkpoint_after_transform_advances_timestamp` — a checkpoint after a transform advances it again.
- `test_most_recently_checkpointed_project_appears_first_in_recent` — the project checkpointed last leads `/recent`.
- `test_checkpoint_still_marks_pending_logs_applied` — the timestamp touch doesn't regress the applied-logs/`checkpoint_id` behavior.

The class works against current `main` because the underlying fix is already there (inline touch in `create_checkpoint` at `project_service.py` + `onupdate=func.now()` on `models.Project.last_modified`).

### One adaptation from #269
The `/recent` test calls `get_recent_projects(mem_db, owner_id=_make_user(mem_db).id, limit=10)` to match `main`'s per-user-ownership signature (#299), which postdated PR #269. The original #269 call (`limit=10` only) would now fail against the current API.

## Not included (already on `main`)
The `create_checkpoint` fix itself (#286), the alembic-on-pytest handling and `test_user_logs` rewrite (`a5eb4c5`), `pytest-asyncio`, and the stale-test edits — all verified present on current `main`, so they're intentionally omitted to keep this focused.

## Validation
- `uv run pytest -q` → **296 passed** (10 in `test_last_modified.py`, incl. the 4 new).
- `uv run ruff check .` and `ruff format --check` → clean.

## Reference
- Follow-up to: #269 (supersedes #267, #268)