### PR TITLE
chore: ignore root-level Python bytecode and scratch artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,17 @@ Desktop.ini
 .env.local
 .env.*.local
 
+# Python bytecode (root-level scratch scripts, tools, etc.)
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Binary artifacts and scratch output
+*.pdf
+*.pid
+tmp/
+output/
+
 # Playwright
 test-results/
 playwright-report/


### PR DESCRIPTION
## Why

Optional hygiene follow-up to closed PR #269, as @ivantha suggested ("a separate hygiene PR with the `.gitignore` additions. Skip `.claude/` for now").

Most of #269's `.gitignore` additions already landed on `main` independently (Playwright dirs, `node_modules/`, `*.db`/`*.sqlite`/`*.sqlite3`, and `.claude/`). This PR adds only the rules still missing from the **root** `.gitignore`.

## What changed

Two new sections in the root `.gitignore`:

- **Python bytecode**: `__pycache__/`, `*.py[cod]`, `*$py.class` — these existed only in `dataloom-backend/.gitignore`, so bytecode from root-level scripts/tools wasn't covered.
- **Binary artifacts and scratch output**: `*.pdf`, `*.pid`, `tmp/`, `output/` — closing the gap that let binary artifacts leak into earlier PRs.

`.claude/` is intentionally left untouched (it's already present on `main`, and per the maintainer there's no project-wide stance to codify here).

## Reference
- Follow-up to: #269