### PR TITLE
fix(transform): align operation_type key and guard detail in toast handler

### DIFF
--- a/dataloom-frontend/src/Components/forms/StringReplaceForm.jsx
+++ b/dataloom-frontend/src/Components/forms/StringReplaceForm.jsx
@@ -18,7 +18,7 @@ const StringReplaceForm = ({ projectId, onClose, onTransform }) => {
 
     try {
       const response = await transformProject(projectId, {
-        transformation_type: STRING_REPLACE,
+        operation_type: STRING_REPLACE,
         string_replace_params: {
           column,
           find_value: findValue,
@@ -30,7 +30,15 @@ const StringReplaceForm = ({ projectId, onClose, onTransform }) => {
       onClose();
     } catch (error) {
       console.error("Error replacing string:", error);
-      showToast(error.response?.data?.detail || "Failed to replace string.", "error");
+      const detail = error.response?.data?.detail;
+      const message =
+        typeof detail === "string"
+          ? detail
+          : Array.isArray(detail)
+            ? detail.map((e) => e.msg ?? JSON.stringify(e)).join(", ")
+            : "Failed to replace string.";
+
+      showToast(message, "error");
     }
   };
 


### PR DESCRIPTION
## Description

Fixes two compounding bugs that prevented the String Replace transformation from working and crashed the app when it failed.

1. The frontend was sending `transformation_type` but the backend registry dispatches on `operation_type`, causing every transform to resolve as `<unknown>` and return a 400.
2. The catch block passed `error.response.data.detail` directly to `showToast`. On 422s FastAPI returns detail as an array of objects `{ type, loc, msg, input }`, which React cannot render as a child, throwing an ErrorBoundary crash.

Fixes #335 

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

- [x] Manual testing

**Following scenarios were tested:**
- Submitted a valid String Replace transformation and confirmed it applies correctly and returns the updated table.
- Submitted with an empty `find_value` to trigger a 422 and confirmed the toast shows a readable message without crashing.
- Verified other transformation types are unaffected.

## Screen Recording

https://github.com/user-attachments/assets/0b03906c-26e0-4ea0-98fd-023076da01d8



## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally