### PR TITLE
fix(transforms): preserve drag column order across all transformation forms

### DIFF
--- a/dataloom-frontend/src/Components/MenuNavbar.jsx
+++ b/dataloom-frontend/src/Components/MenuNavbar.jsx
@@ -45,7 +45,7 @@ import {
 } from "react-icons/lu";
 import { useProjectContext } from "../context/ProjectContext";
 
-const MenuNavbar = ({ projectId, onTransform }) => {
+const MenuNavbar = ({ projectId }) => {
   const [showGroupByForm, setShowGroupByForm] = useState(false);
   const [showFilterForm, setShowFilterForm] = useState(false);
   const [showSortForm, setShowSortForm] = useState(false);
@@ -152,7 +152,10 @@ const MenuNavbar = ({ projectId, onTransform }) => {
       onConfirm: async () => {
         try {
           const response = await revertToCheckpoint(projectId, checkpointId);
-          onTransform(response);
+          updateData(response.columns, response.rows, {
+            dtypes: response.dtypes,
+            resetColumnOrder: false,
+          });
           setToast({ message: "Project reverted successfully!", type: "success" });
         } catch {
           setToast({ message: "Failed to revert project.", type: "error" });
@@ -545,7 +548,6 @@ const MenuNavbar = ({ projectId, onTransform }) => {
 
 MenuNavbar.propTypes = {
   projectId: proptype.string.isRequired,
-  onTransform: proptype.func.isRequired,
 };
 
 export default MenuNavbar;

--- a/dataloom-frontend/src/Components/MenuNavbar.jsx
+++ b/dataloom-frontend/src/Components/MenuNavbar.jsx
@@ -116,9 +116,9 @@ const MenuNavbar = ({ projectId, onTransform }) => {
       setShowFilterForm(false);
       setShowSortForm(false);
       setActiveForm(null);
-      updateData([], [], {});
+      updateData([], [], { resetColumnOrder: false });
       const data = await getProjectDetails(projectId);
-      updateData(data.columns, data.rows, data.dtypes);
+      updateData(data.columns, data.rows, { dtypes: data.dtypes, resetColumnOrder: false });
       await fetchLogs();
       setToast({ message: "Last transformation undone!", type: "success" });
     } catch (error) {
@@ -424,7 +424,6 @@ const MenuNavbar = ({ projectId, onTransform }) => {
             setActiveForm(null);
           }}
           projectId={projectId}
-          onTransform={onTransform}
         />
       )}
       {showDropDuplicateForm && (
@@ -434,7 +433,6 @@ const MenuNavbar = ({ projectId, onTransform }) => {
             setShowDropDuplicateForm(false);
             setActiveForm(null);
           }}
-          onTransform={onTransform}
         />
       )}
       {showAdvQueryFilterForm && (
@@ -463,7 +461,6 @@ const MenuNavbar = ({ projectId, onTransform }) => {
             setShowCastDataTypeForm(false);
             setActiveForm(null);
           }}
-          onTransform={onTransform}
         />
       )}
       {showTrimWhitespaceForm && (
@@ -473,7 +470,6 @@ const MenuNavbar = ({ projectId, onTransform }) => {
             setShowTrimWhitespaceForm(false);
             setActiveForm(null);
           }}
-          onTransform={onTransform}
         />
       )}
       {showStringReplaceForm && (
@@ -483,7 +479,6 @@ const MenuNavbar = ({ projectId, onTransform }) => {
             setShowStringReplaceForm(false);
             setActiveForm(null);
           }}
-          onTransform={onTransform}
         />
       )}
       {showLogs && (
@@ -512,7 +507,6 @@ const MenuNavbar = ({ projectId, onTransform }) => {
             setShowGroupByForm(false);
             setActiveForm(null);
           }}
-          onTransform={onTransform}
         />
       )}
       {showSampleRowsForm && (
@@ -522,7 +516,6 @@ const MenuNavbar = ({ projectId, onTransform }) => {
             setShowSampleRowsForm(false);
             setActiveForm(null);
           }}
-          onTransform={onTransform}
         />
       )}
 

--- a/dataloom-frontend/src/Components/forms/CastDataTypeForm.jsx
+++ b/dataloom-frontend/src/Components/forms/CastDataTypeForm.jsx
@@ -8,7 +8,7 @@ import FormErrorAlert from "../common/FormErrorAlert";
 import ColumnSelect from "../common/ColumnSelect";
 import { useProjectContext } from "../../context/ProjectContext";
 
-const CastDataTypeForm = ({ projectId, onClose, onTransform }) => {
+const CastDataTypeForm = ({ projectId, onClose }) => {
   const { showToast } = useToast();
 
   const [column, setColumn] = useState("");
@@ -29,8 +29,10 @@ const CastDataTypeForm = ({ projectId, onClose, onTransform }) => {
         },
       });
 
-      onTransform(response);
-      updateData(response.columns, response.rows, response.dtypes);
+      updateData(response.columns, response.rows, {
+        dtypes: response.dtypes,
+        resetColumnOrder: false,
+      });
       onClose();
     } catch (err) {
       console.error("Error casting data type:", err);
@@ -95,7 +97,6 @@ const CastDataTypeForm = ({ projectId, onClose, onTransform }) => {
 CastDataTypeForm.propTypes = {
   projectId: PropTypes.string.isRequired,
   onClose: PropTypes.func.isRequired,
-  onTransform: PropTypes.func.isRequired,
 };
 
 export default CastDataTypeForm;

--- a/dataloom-frontend/src/Components/forms/DropDuplicateForm.jsx
+++ b/dataloom-frontend/src/Components/forms/DropDuplicateForm.jsx
@@ -4,11 +4,13 @@ import { transformProject } from "../../api";
 import { DROP_DUPLICATE } from "../../constants/operationTypes";
 import useError from "../../hooks/useError";
 import FormErrorAlert from "../common/FormErrorAlert";
+import { useProjectContext } from "../../context/ProjectContext";
 
-const DropDuplicateForm = ({ projectId, onClose, onTransform }) => {
+const DropDuplicateForm = ({ projectId, onClose }) => {
   const [columns, setColumns] = useState("");
   const [keep, setKeep] = useState("first");
   const { error, clearError, handleError } = useError();
+  const { updateData } = useProjectContext();
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -23,7 +25,10 @@ const DropDuplicateForm = ({ projectId, onClose, onTransform }) => {
     clearError();
     try {
       const response = await transformProject(projectId, transformationInput);
-      onTransform(response); // Pass data to parent component
+      updateData(response.columns, response.rows, {
+        dtypes: response.dtypes,
+        resetColumnOrder: false,
+      });
       onClose(); // Close the form after submission
     } catch (err) {
       console.error("Error transforming project:", err);
@@ -83,7 +88,6 @@ const DropDuplicateForm = ({ projectId, onClose, onTransform }) => {
 DropDuplicateForm.propTypes = {
   projectId: PropTypes.string.isRequired,
   onClose: PropTypes.func.isRequired,
-  onTransform: PropTypes.func.isRequired,
 };
 
 export default DropDuplicateForm;

--- a/dataloom-frontend/src/Components/forms/FilterForm.jsx
+++ b/dataloom-frontend/src/Components/forms/FilterForm.jsx
@@ -36,7 +36,10 @@ const FilterForm = ({ projectId, onClose }) => {
         parameters: filterParams,
       });
       setResult(response);
-      updateData(response.columns, response.rows, response.dtypes);
+      updateData(response.columns, response.rows, {
+        dtypes: response.dtypes,
+        resetColumnOrder: false,
+      });
     } catch (err) {
       console.error("Error applying filter:", err.response?.data || err.message);
       handleError(err);

--- a/dataloom-frontend/src/Components/forms/FilterForm.jsx
+++ b/dataloom-frontend/src/Components/forms/FilterForm.jsx
@@ -8,7 +8,7 @@ import FormErrorAlert from "../common/FormErrorAlert";
 import ColumnSelect from "../common/ColumnSelect";
 import { useProjectContext } from "../../context/ProjectContext";
 
-const FilterForm = ({ projectId, onClose, onTransform }) => {
+const FilterForm = ({ projectId, onClose }) => {
   const [filterParams, setFilterParams] = useState({
     column: "",
     condition: "=",
@@ -36,7 +36,6 @@ const FilterForm = ({ projectId, onClose, onTransform }) => {
         parameters: filterParams,
       });
       setResult(response);
-      if (onTransform) onTransform(response);
       updateData(response.columns, response.rows, response.dtypes);
     } catch (err) {
       console.error("Error applying filter:", err.response?.data || err.message);
@@ -118,7 +117,6 @@ const FilterForm = ({ projectId, onClose, onTransform }) => {
 FilterForm.propTypes = {
   projectId: PropTypes.string.isRequired,
   onClose: PropTypes.func.isRequired,
-  onTransform: PropTypes.func,
 };
 
 export default FilterForm;

--- a/dataloom-frontend/src/Components/forms/GroupByForm.jsx
+++ b/dataloom-frontend/src/Components/forms/GroupByForm.jsx
@@ -7,7 +7,7 @@ import useError from "../../hooks/useError";
 import FormErrorAlert from "../common/FormErrorAlert";
 import { useProjectContext } from "../../context/ProjectContext";
 
-const GroupByForm = ({ projectId, onClose, onTransform }) => {
+const GroupByForm = ({ projectId, onClose }) => {
   const { columns: availableColumns, updateData } = useProjectContext();
   const [selectedColumns, setSelectedColumns] = useState([]);
   const [aggColumn, setAggColumn] = useState("");
@@ -39,8 +39,10 @@ const GroupByForm = ({ projectId, onClose, onTransform }) => {
         },
       });
       setResult(response);
-      if (onTransform) onTransform(response);
-      updateData(response.columns, response.rows, response.dtypes);
+      updateData(response.columns, response.rows, {
+        dtypes: response.dtypes,
+        resetColumnOrder: false,
+      });
     } catch (err) {
       handleError(err);
     } finally {
@@ -133,7 +135,6 @@ const GroupByForm = ({ projectId, onClose, onTransform }) => {
 GroupByForm.propTypes = {
   projectId: PropTypes.string.isRequired,
   onClose: PropTypes.func.isRequired,
-  onTransform: PropTypes.func,
 };
 
 export default GroupByForm;

--- a/dataloom-frontend/src/Components/forms/SampleRowsForm.jsx
+++ b/dataloom-frontend/src/Components/forms/SampleRowsForm.jsx
@@ -7,7 +7,7 @@ import useError from "../../hooks/useError";
 import FormErrorAlert from "../common/FormErrorAlert";
 import { useProjectContext } from "../../context/ProjectContext";
 
-const SampleRowsForm = ({ projectId, onClose, onTransform }) => {
+const SampleRowsForm = ({ projectId, onClose }) => {
   const { updateData } = useProjectContext();
   const [sampleSize, setSampleSize] = useState("");
   const [randomSeed, setRandomSeed] = useState("");
@@ -46,8 +46,10 @@ const SampleRowsForm = ({ projectId, onClose, onTransform }) => {
         sample_params: params,
       });
       setResult(response);
-      if (onTransform) onTransform(response);
-      updateData(response.columns, response.rows, response.dtypes);
+      updateData(response.columns, response.rows, {
+        dtypes: response.dtypes,
+        resetColumnOrder: false,
+      });
     } catch (err) {
       handleError(err);
     } finally {
@@ -115,7 +117,6 @@ const SampleRowsForm = ({ projectId, onClose, onTransform }) => {
 SampleRowsForm.propTypes = {
   projectId: PropTypes.string.isRequired,
   onClose: PropTypes.func.isRequired,
-  onTransform: PropTypes.func,
 };
 
 export default SampleRowsForm;

--- a/dataloom-frontend/src/Components/forms/SortForm.jsx
+++ b/dataloom-frontend/src/Components/forms/SortForm.jsx
@@ -12,7 +12,7 @@ import { useProjectContext } from "../../context/ProjectContext";
  * SortForm component for multi-column sorting.
  * Allows users to add, remove, and reorder multiple sort criteria.
  */
-const SortForm = ({ projectId, onClose, onTransform }) => {
+const SortForm = ({ projectId, onClose }) => {
   const { updateData } = useProjectContext();
   const [criteria, setCriteria] = useState([{ id: 1, column: "", ascending: true }]);
   const [nextId, setNextId] = useState(2);
@@ -89,8 +89,10 @@ const SortForm = ({ projectId, onClose, onTransform }) => {
         },
       });
       setResult(response);
-      if (onTransform) onTransform(response);
-      updateData(response.columns, response.rows, { dtypes: response.dtypes });
+      updateData(response.columns, response.rows, {
+        dtypes: response.dtypes,
+        resetColumnOrder: false,
+      });
     } catch (err) {
       handleError(err);
     } finally {
@@ -217,7 +219,6 @@ const SortForm = ({ projectId, onClose, onTransform }) => {
 SortForm.propTypes = {
   projectId: PropTypes.string.isRequired,
   onClose: PropTypes.func.isRequired,
-  onTransform: PropTypes.func,
 };
 
 export default SortForm;

--- a/dataloom-frontend/src/Components/forms/StringReplaceForm.jsx
+++ b/dataloom-frontend/src/Components/forms/StringReplaceForm.jsx
@@ -5,8 +5,8 @@ import { useProjectContext } from "../../context/ProjectContext";
 import { useToast } from "../../context/ToastContext";
 import { STRING_REPLACE } from "../../constants/operationTypes";
 
-const StringReplaceForm = ({ projectId, onClose, onTransform }) => {
-  const { columns } = useProjectContext();
+const StringReplaceForm = ({ projectId, onClose }) => {
+  const { columns, updateData } = useProjectContext();
   const { showToast } = useToast();
 
   const [column, setColumn] = useState("");
@@ -26,7 +26,10 @@ const StringReplaceForm = ({ projectId, onClose, onTransform }) => {
         },
       });
 
-      onTransform(response);
+      updateData(response.columns, response.rows, {
+        dtypes: response.dtypes,
+        resetColumnOrder: false,
+      });
       onClose();
     } catch (error) {
       console.error("Error replacing string:", error);
@@ -117,7 +120,6 @@ const StringReplaceForm = ({ projectId, onClose, onTransform }) => {
 StringReplaceForm.propTypes = {
   projectId: PropTypes.string.isRequired,
   onClose: PropTypes.func.isRequired,
-  onTransform: PropTypes.func.isRequired,
 };
 
 export default StringReplaceForm;

--- a/dataloom-frontend/src/Components/forms/TransformResultPreview.jsx
+++ b/dataloom-frontend/src/Components/forms/TransformResultPreview.jsx
@@ -1,6 +1,9 @@
 import PropTypes from "prop-types";
+import { useProjectContext } from "../../context/ProjectContext";
 
 const TransformResultPreview = ({ columns, rows }) => {
+  const { columnOrder } = useProjectContext();
+
   if (!rows || rows.length === 0) {
     return <p className="text-gray-500 mt-4 text-xs font-medium">No data available</p>;
   }
@@ -9,8 +12,15 @@ const TransformResultPreview = ({ columns, rows }) => {
     return <p className="text-gray-500 mt-4 text-xs font-medium">No columns available</p>;
   }
 
-  const displayColumns = ["S.No.", ...columns];
-  const displayRows = rows.map((row, index) => [index + 1, ...row]);
+  const orderedColumns =
+    columnOrder.length === columns.length ? columnOrder.map((i) => columns[i]) : columns;
+
+  const orderedRows = rows.map((row) =>
+    columnOrder.length === row.length ? columnOrder.map((i) => row[i]) : row,
+  );
+
+  const displayColumns = ["S.No.", ...orderedColumns];
+  const displayRows = orderedRows.map((row, index) => [index + 1, ...row]);
 
   return (
     <div

--- a/dataloom-frontend/src/Components/forms/TrimWhitespaceForm.jsx
+++ b/dataloom-frontend/src/Components/forms/TrimWhitespaceForm.jsx
@@ -5,8 +5,8 @@ import { TRIM_WHITESPACE } from "../../constants/operationTypes";
 import { useProjectContext } from "../../context/ProjectContext";
 import { useToast } from "../../context/ToastContext";
 
-const TrimWhitespaceForm = ({ projectId, onClose, onTransform }) => {
-  const { columns } = useProjectContext();
+const TrimWhitespaceForm = ({ projectId, onClose }) => {
+  const { columns, updateData } = useProjectContext();
   const { showToast } = useToast();
 
   const [column, setColumn] = useState("");
@@ -24,7 +24,10 @@ const TrimWhitespaceForm = ({ projectId, onClose, onTransform }) => {
         },
       });
 
-      onTransform(response);
+      updateData(response.columns, response.rows, {
+        dtypes: response.dtypes,
+        resetColumnOrder: false,
+      });
       onClose();
     } catch (error) {
       console.error("Error trimming whitespace:", error);
@@ -83,7 +86,6 @@ const TrimWhitespaceForm = ({ projectId, onClose, onTransform }) => {
 TrimWhitespaceForm.propTypes = {
   projectId: PropTypes.string.isRequired,
   onClose: PropTypes.func.isRequired,
-  onTransform: PropTypes.func.isRequired,
 };
 
 export default TrimWhitespaceForm;

--- a/dataloom-frontend/src/test/TransformResultPreview.test.jsx
+++ b/dataloom-frontend/src/test/TransformResultPreview.test.jsx
@@ -1,0 +1,152 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import TransformResultPreview from "../Components/forms/TransformResultPreview";
+import FilterForm from "../Components/forms/FilterForm";
+import { transformProject } from "../api";
+
+vi.mock("../api", () => ({
+  transformProject: vi.fn(),
+}));
+
+const mockContext = {
+  columns: ["City", "Amount", "Date"],
+  columnOrder: [0, 1, 2],
+  updateData: vi.fn(),
+};
+
+vi.mock("../context/ProjectContext", () => ({
+  useProjectContext: () => mockContext,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockContext.columnOrder = [0, 1, 2];
+});
+
+// TransformResultPreview — column-ordering logic
+describe("TransformResultPreview — column ordering", () => {
+  const columns = ["City", "Amount", "Date"];
+  const rows = [["New York", "100", "2024-01-01"]];
+
+  it("renders columns in default order [0, 1, 2]", () => {
+    mockContext.columnOrder = [0, 1, 2];
+
+    render(<TransformResultPreview columns={columns} rows={rows} />);
+
+    const headers = screen.getAllByRole("columnheader");
+    // first header is S.No.
+    expect(headers[1]).toHaveTextContent("City");
+    expect(headers[2]).toHaveTextContent("Amount");
+    expect(headers[3]).toHaveTextContent("Date");
+  });
+
+  it("reorders columns when columnOrder is [2, 0, 1]", () => {
+    mockContext.columnOrder = [2, 0, 1];
+
+    render(<TransformResultPreview columns={columns} rows={rows} />);
+
+    const headers = screen.getAllByRole("columnheader");
+    expect(headers[1]).toHaveTextContent("Date");
+    expect(headers[2]).toHaveTextContent("City");
+    expect(headers[3]).toHaveTextContent("Amount");
+  });
+
+  it("reorders row cells to match column order", () => {
+    mockContext.columnOrder = [2, 0, 1];
+
+    render(<TransformResultPreview columns={columns} rows={rows} />);
+
+    const cells = screen.getAllByRole("cell");
+    // cells[0] = S.No. (1), cells[1] = Date, cells[2] = City, cells[3] = Amount
+    expect(cells[1]).toHaveTextContent("2024-01-01");
+    expect(cells[2]).toHaveTextContent("New York");
+    expect(cells[3]).toHaveTextContent("100");
+  });
+
+  it("falls back to raw order when columnOrder length mismatches columns", () => {
+    mockContext.columnOrder = [0, 1]; // length 2, columns length 3 — mismatch
+
+    render(<TransformResultPreview columns={columns} rows={rows} />);
+
+    const headers = screen.getAllByRole("columnheader");
+    expect(headers[1]).toHaveTextContent("City");
+    expect(headers[2]).toHaveTextContent("Amount");
+    expect(headers[3]).toHaveTextContent("Date");
+  });
+
+  it("renders empty state when rows is empty", () => {
+    render(<TransformResultPreview columns={columns} rows={[]} />);
+
+    expect(screen.getByText("No data available")).toBeInTheDocument();
+  });
+
+  it("renders empty state when columns is empty", () => {
+    render(<TransformResultPreview columns={[]} rows={rows} />);
+
+    expect(screen.getByText("No columns available")).toBeInTheDocument();
+  });
+
+  it("prepends S.No. column with correct row index", () => {
+    mockContext.columnOrder = [0, 1, 2];
+
+    const multiRows = [
+      ["New York", "100", "2024-01-01"],
+      ["London", "200", "2024-01-02"],
+    ];
+
+    render(<TransformResultPreview columns={columns} rows={multiRows} />);
+
+    const allRows = screen.getAllByRole("row");
+    // allRows[0] = header, allRows[1] = first data row, allRows[2] = second
+    expect(allRows[1].firstChild).toHaveTextContent("1");
+    expect(allRows[2].firstChild).toHaveTextContent("2");
+  });
+});
+
+// FilterForm — updateData propagation
+describe("FilterForm — updateData propagation", () => {
+  it("calls updateData with dtypes and resetColumnOrder:false after successful transform", async () => {
+    transformProject.mockResolvedValueOnce({
+      columns: ["City", "Amount"],
+      rows: [["Paris", "300"]],
+      dtypes: { City: "string", Amount: "float" },
+    });
+
+    const { getByTestId, getByText } = render(<FilterForm projectId="proj-1" onClose={vi.fn()} />);
+
+    // Fill required fields
+    // ColumnSelect renders a select; pick first real column
+    const columnSelect = getByTestId("filter-column");
+    // fire change on the underlying select
+    const { fireEvent } = await import("@testing-library/react");
+    fireEvent.change(columnSelect, { target: { value: "City" } });
+
+    const valueInput = getByTestId("filter-value");
+    fireEvent.change(valueInput, { target: { value: "Paris" } });
+
+    fireEvent.click(getByText("Apply Filter"));
+
+    await vi.waitFor(() => {
+      expect(mockContext.updateData).toHaveBeenCalledWith(["City", "Amount"], [["Paris", "300"]], {
+        dtypes: { City: "string", Amount: "float" },
+        resetColumnOrder: false,
+      });
+    });
+  });
+
+  it("does not call updateData when transform fails", async () => {
+    transformProject.mockRejectedValueOnce(new Error("Server error"));
+
+    const { getByTestId, getByText } = render(<FilterForm projectId="proj-1" onClose={vi.fn()} />);
+
+    const { fireEvent } = await import("@testing-library/react");
+    const valueInput = getByTestId("filter-value");
+    fireEvent.change(valueInput, { target: { value: "Paris" } });
+
+    fireEvent.click(getByText("Apply Filter"));
+
+    await vi.waitFor(() => {
+      expect(mockContext.updateData).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Description

Fixes multiple compounding bugs across all transformation forms that caused the user's drag-and-drop column order to be  lost and stale data to be shown after transforms.

**Preview order fix**
`TransformResultPreview` now pulls `columnOrder` from context directly and reorders columns and rows before rendering. Fixes all forms in one place without per-form changes.

**Column order reset fix**
All mutating transform forms (`SortForm`, `FilterForm`, `DropDuplicateForm`, `GroupByForm`, `CastDataTypeForm`, `TrimWhitespaceForm`, `SampleRowsForm`, `StringReplaceForm`) have been updated to:
- Remove `onTransform(response)` calls which bypassed context and pushed raw API data directly into the table
- Pass `resetColumnOrder: false` to `updateData` so the stored drag order is never clobbered
- Add missing `updateData` calls where they were absent entirely (`DropDuplicateForm`, `StringReplaceForm`)

Fixes #337 

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

- [x] Existing tests pass
- [x] New test cases added
- [x] Manual testing

**Following scenarios were tested:**
- Reordered columns via drag and drop
- Applied every mutating transformation and verified the table retains drag order after closing the form
- Verified all transformation previews render in the custom drag order
- Applied undo and verified drag order is still preserved
- Verified query-only forms (Pivot, Melt, AdvQuery) are unaffected 

## Screen Recording

https://github.com/user-attachments/assets/63b0bcb6-087d-468e-b3e4-ee69ba66c8a2





## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally