### PR TITLE
fix(logs): add empty state message when no logs are available

### DIFF
--- a/dataloom-frontend/src/Components/history/LogsPanel.jsx
+++ b/dataloom-frontend/src/Components/history/LogsPanel.jsx
@@ -41,19 +41,27 @@ const LogsPanel = ({ logs, onClose }) => {
             </tr>
           </thead>
           <tbody>
-            {logs.map((log) => (
-              <tr
-                key={log.id}
-                className="border-b border-gray-100 hover:bg-gray-50 transition-colors duration-150"
-              >
-                <td className="py-3 px-4 text-sm text-gray-700">{log.action_type}</td>
-                <td className="py-3 px-4 text-sm text-gray-700">
-                  {new Date(log.timestamp).toLocaleString()}
+            {logs.length > 0 ? (
+              logs.map((log) => (
+                <tr
+                  key={log.id}
+                  className="border-b border-gray-100 hover:bg-gray-50 transition-colors duration-150"
+                >
+                  <td className="py-3 px-4 text-sm text-gray-700">{log.action_type}</td>
+                  <td className="py-3 px-4 text-sm text-gray-700">
+                    {new Date(log.timestamp).toLocaleString()}
+                  </td>
+                  <td className="py-3 px-4 text-sm text-gray-700">{log.checkpoint_id || "-"}</td>
+                  <td className="py-3 px-4 text-sm text-gray-700">{log.applied ? "Yes" : "No"}</td>
+                </tr>
+              ))
+            ) : (
+              <tr>
+                <td colSpan="4" className="py-4 px-4 text-center text-sm text-gray-500">
+                  No logs available
                 </td>
-                <td className="py-3 px-4 text-sm text-gray-700">{log.checkpoint_id || "-"}</td>
-                <td className="py-3 px-4 text-sm text-gray-700">{log.applied ? "Yes" : "No"}</td>
               </tr>
-            ))}
+            )}
           </tbody>
         </table>
       </div>


### PR DESCRIPTION
## Description

Adds an empty state to the Logs panel consistent with the Checkpoints panel. Previously the panel rendered blank when there were no logs, giving the user no feedback.

Fixes #340 

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

- [x] Existing tests pass
- [x] Manual testing

**Following test cases were tested:**
- Opened the Logs panel on a project with no transformation history
- Verified empty state message renders correctly
- Verified logs render correctly when history exists
 
## Screenshots
<img width="1409" height="187" alt="Screenshot 2026-06-05 at 19 38 32" src="https://github.com/user-attachments/assets/4381ec2a-3be9-4ba4-9871-0349c6d31c30" />


## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally