### PR TITLE
fix: persist page size to localStorage and enforce pagination after transforms

### DIFF
--- a/dataloom-frontend/src/Components/MenuNavbar.jsx
+++ b/dataloom-frontend/src/Components/MenuNavbar.jsx
@@ -20,7 +20,6 @@ import {
   getLogs,
   getCheckpoints,
   revertToCheckpoint,
-  getProjectDetails,
   undoLastTransformation,
 } from "../api";
 import proptype from "prop-types";
@@ -66,7 +65,7 @@ const MenuNavbar = ({ projectId }) => {
   const [confirmData, setConfirmData] = useState(null);
   const [toast, setToast] = useState(null);
 
-  const { updateData, projectName } = useProjectContext();
+  const { updateData, refreshProject, pageSize, projectName } = useProjectContext();
 
   const fetchLogs = useCallback(async () => {
     try {
@@ -118,8 +117,7 @@ const MenuNavbar = ({ projectId }) => {
       setShowSortForm(false);
       setActiveForm(null);
       updateData([], [], { resetColumnOrder: false });
-      const data = await getProjectDetails(projectId);
-      updateData(data.columns, data.rows, { dtypes: data.dtypes, resetColumnOrder: false });
+      await refreshProject(projectId, 1, pageSize);
       await fetchLogs();
       setToast({ message: "Last transformation undone!", type: "success" });
     } catch (error) {

--- a/dataloom-frontend/src/Components/forms/AdvQueryFilterForm.jsx
+++ b/dataloom-frontend/src/Components/forms/AdvQueryFilterForm.jsx
@@ -5,12 +5,14 @@ import { transformProject } from "../../api";
 import { ADV_QUERY_FILTER } from "../../constants/operationTypes";
 import useError from "../../hooks/useError";
 import FormErrorAlert from "../common/FormErrorAlert";
+import { useProjectContext } from "../../context/ProjectContext";
 
 const AdvQueryFilterForm = ({ projectId, onClose }) => {
   const [query, setQuery] = useState("");
   const [result, setResult] = useState(null);
   const [loading, setLoading] = useState(false);
   const { error, clearError, handleError } = useError();
+  const { updateData, refreshProject, pageSize } = useProjectContext();
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -22,6 +24,11 @@ const AdvQueryFilterForm = ({ projectId, onClose }) => {
         adv_query: { query },
       });
       setResult(response);
+      updateData(response.columns, response.rows, {
+        dtypes: response.dtypes,
+        resetColumnOrder: false,
+      });
+      await refreshProject(projectId, 1, pageSize);
     } catch (err) {
       console.error("Error applying query:", err.message);
       handleError(err);

--- a/dataloom-frontend/src/Components/forms/CastDataTypeForm.jsx
+++ b/dataloom-frontend/src/Components/forms/CastDataTypeForm.jsx
@@ -14,7 +14,7 @@ const CastDataTypeForm = ({ projectId, onClose }) => {
   const [column, setColumn] = useState("");
   const [targetType, setTargetType] = useState("string");
   const { error, clearError, handleError } = useError();
-  const { updateData } = useProjectContext();
+  const { updateData, refreshProject, pageSize } = useProjectContext();
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -33,6 +33,7 @@ const CastDataTypeForm = ({ projectId, onClose }) => {
         dtypes: response.dtypes,
         resetColumnOrder: false,
       });
+      await refreshProject(projectId, 1, pageSize);
       onClose();
     } catch (err) {
       console.error("Error casting data type:", err);

--- a/dataloom-frontend/src/Components/forms/DropDuplicateForm.jsx
+++ b/dataloom-frontend/src/Components/forms/DropDuplicateForm.jsx
@@ -10,7 +10,7 @@ const DropDuplicateForm = ({ projectId, onClose }) => {
   const [columns, setColumns] = useState("");
   const [keep, setKeep] = useState("first");
   const { error, clearError, handleError } = useError();
-  const { updateData } = useProjectContext();
+  const { updateData, refreshProject, pageSize } = useProjectContext();
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -29,6 +29,7 @@ const DropDuplicateForm = ({ projectId, onClose }) => {
         dtypes: response.dtypes,
         resetColumnOrder: false,
       });
+      await refreshProject(projectId, 1, pageSize);
       onClose(); // Close the form after submission
     } catch (err) {
       console.error("Error transforming project:", err);

--- a/dataloom-frontend/src/Components/forms/FilterForm.jsx
+++ b/dataloom-frontend/src/Components/forms/FilterForm.jsx
@@ -17,7 +17,7 @@ const FilterForm = ({ projectId, onClose }) => {
   const [result, setResult] = useState(null);
   const [loading, setLoading] = useState(false);
   const { error, clearError, handleError } = useError();
-  const { updateData } = useProjectContext();
+  const { updateData, refreshProject, pageSize } = useProjectContext();
 
   const handleInputChange = (e) => {
     setFilterParams({
@@ -40,6 +40,7 @@ const FilterForm = ({ projectId, onClose }) => {
         dtypes: response.dtypes,
         resetColumnOrder: false,
       });
+      await refreshProject(projectId, 1, pageSize);
     } catch (err) {
       console.error("Error applying filter:", err.response?.data || err.message);
       handleError(err);

--- a/dataloom-frontend/src/Components/forms/GroupByForm.jsx
+++ b/dataloom-frontend/src/Components/forms/GroupByForm.jsx
@@ -8,7 +8,7 @@ import FormErrorAlert from "../common/FormErrorAlert";
 import { useProjectContext } from "../../context/ProjectContext";
 
 const GroupByForm = ({ projectId, onClose }) => {
-  const { columns: availableColumns, updateData } = useProjectContext();
+  const { columns: availableColumns, updateData, refreshProject, pageSize } = useProjectContext();
   const [selectedColumns, setSelectedColumns] = useState([]);
   const [aggColumn, setAggColumn] = useState("");
   const [aggFunction, setAggFunction] = useState("sum");
@@ -43,6 +43,7 @@ const GroupByForm = ({ projectId, onClose }) => {
         dtypes: response.dtypes,
         resetColumnOrder: false,
       });
+      await refreshProject(projectId, 1, pageSize);
     } catch (err) {
       handleError(err);
     } finally {

--- a/dataloom-frontend/src/Components/forms/MeltForm.jsx
+++ b/dataloom-frontend/src/Components/forms/MeltForm.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import TransformResultPreview from "./TransformResultPreview";
 import { transformProject, getProjectDetails } from "../../api";
+import { useProjectContext } from "../../context/ProjectContext";
 
 const MeltForm = ({ projectId, onClose }) => {
   const [columns, setColumns] = useState([]);
@@ -12,6 +13,7 @@ const MeltForm = ({ projectId, onClose }) => {
   const [result, setResult] = useState(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
+  const { updateData, refreshProject, pageSize } = useProjectContext();
 
   useEffect(() => {
     const fetchProjectDetails = async () => {
@@ -62,6 +64,11 @@ const MeltForm = ({ projectId, onClose }) => {
         },
       });
       setResult(response);
+      updateData(response.columns, response.rows, {
+        dtypes: response.dtypes,
+        resetColumnOrder: false,
+      });
+      await refreshProject(projectId, 1, pageSize);
     } catch (err) {
       setError(err.response?.data?.detail || err.message);
     } finally {

--- a/dataloom-frontend/src/Components/forms/PivotTableForm.jsx
+++ b/dataloom-frontend/src/Components/forms/PivotTableForm.jsx
@@ -6,6 +6,7 @@ import { PIVOT_TABLES } from "../../constants/operationTypes";
 import useError from "../../hooks/useError";
 import FormErrorAlert from "../common/FormErrorAlert";
 import ColumnSelect from "../common/ColumnSelect";
+import { useProjectContext } from "../../context/ProjectContext";
 
 const PivotTableForm = ({ projectId, onClose }) => {
   const [index, setIndex] = useState("");
@@ -15,6 +16,7 @@ const PivotTableForm = ({ projectId, onClose }) => {
   const [result, setResult] = useState(null);
   const [loading, setLoading] = useState(false);
   const { error, clearError, handleError } = useError();
+  const { updateData, refreshProject, pageSize } = useProjectContext();
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -26,6 +28,11 @@ const PivotTableForm = ({ projectId, onClose }) => {
         pivot_query: { index, column, value, aggfun },
       });
       setResult(response);
+      updateData(response.columns, response.rows, {
+        dtypes: response.dtypes,
+        resetColumnOrder: false,
+      });
+      await refreshProject(projectId, 1, pageSize);
     } catch (err) {
       console.error("Error applying pivot table:", err.message);
       handleError(err);

--- a/dataloom-frontend/src/Components/forms/SampleRowsForm.jsx
+++ b/dataloom-frontend/src/Components/forms/SampleRowsForm.jsx
@@ -8,7 +8,7 @@ import FormErrorAlert from "../common/FormErrorAlert";
 import { useProjectContext } from "../../context/ProjectContext";
 
 const SampleRowsForm = ({ projectId, onClose }) => {
-  const { updateData } = useProjectContext();
+  const { updateData, refreshProject, pageSize } = useProjectContext();
   const [sampleSize, setSampleSize] = useState("");
   const [randomSeed, setRandomSeed] = useState("");
   const [result, setResult] = useState(null);
@@ -50,6 +50,7 @@ const SampleRowsForm = ({ projectId, onClose }) => {
         dtypes: response.dtypes,
         resetColumnOrder: false,
       });
+      await refreshProject(projectId, 1, pageSize);
     } catch (err) {
       handleError(err);
     } finally {

--- a/dataloom-frontend/src/Components/forms/SortForm.jsx
+++ b/dataloom-frontend/src/Components/forms/SortForm.jsx
@@ -13,7 +13,7 @@ import { useProjectContext } from "../../context/ProjectContext";
  * Allows users to add, remove, and reorder multiple sort criteria.
  */
 const SortForm = ({ projectId, onClose }) => {
-  const { updateData } = useProjectContext();
+  const { updateData, refreshProject, pageSize } = useProjectContext();
   const [criteria, setCriteria] = useState([{ id: 1, column: "", ascending: true }]);
   const [nextId, setNextId] = useState(2);
   const [result, setResult] = useState(null);
@@ -93,6 +93,7 @@ const SortForm = ({ projectId, onClose }) => {
         dtypes: response.dtypes,
         resetColumnOrder: false,
       });
+      await refreshProject(projectId, 1, pageSize);
     } catch (err) {
       handleError(err);
     } finally {

--- a/dataloom-frontend/src/Components/forms/StringReplaceForm.jsx
+++ b/dataloom-frontend/src/Components/forms/StringReplaceForm.jsx
@@ -6,7 +6,7 @@ import { useToast } from "../../context/ToastContext";
 import { STRING_REPLACE } from "../../constants/operationTypes";
 
 const StringReplaceForm = ({ projectId, onClose }) => {
-  const { columns, updateData } = useProjectContext();
+  const { columns, updateData, refreshProject, pageSize } = useProjectContext();
   const { showToast } = useToast();
 
   const [column, setColumn] = useState("");
@@ -30,6 +30,7 @@ const StringReplaceForm = ({ projectId, onClose }) => {
         dtypes: response.dtypes,
         resetColumnOrder: false,
       });
+      await refreshProject(projectId, 1, pageSize);
       onClose();
     } catch (error) {
       console.error("Error replacing string:", error);

--- a/dataloom-frontend/src/Components/forms/TrimWhitespaceForm.jsx
+++ b/dataloom-frontend/src/Components/forms/TrimWhitespaceForm.jsx
@@ -6,7 +6,7 @@ import { useProjectContext } from "../../context/ProjectContext";
 import { useToast } from "../../context/ToastContext";
 
 const TrimWhitespaceForm = ({ projectId, onClose }) => {
-  const { columns, updateData } = useProjectContext();
+  const { columns, updateData, refreshProject, pageSize } = useProjectContext();
   const { showToast } = useToast();
 
   const [column, setColumn] = useState("");
@@ -28,6 +28,7 @@ const TrimWhitespaceForm = ({ projectId, onClose }) => {
         dtypes: response.dtypes,
         resetColumnOrder: false,
       });
+      await refreshProject(projectId, 1, pageSize);
       onClose();
     } catch (error) {
       console.error("Error trimming whitespace:", error);

--- a/dataloom-frontend/src/context/ProjectContext.jsx
+++ b/dataloom-frontend/src/context/ProjectContext.jsx
@@ -29,7 +29,14 @@ export function ProjectProvider({ children }) {
   const [totalRows, setTotalRows] = useState(0);
   const [totalPages, setTotalPages] = useState(1);
   const [page, setPage] = useState(1);
-  const [pageSize, setPageSize] = useState(50);
+  const [pageSize, setPageSize] = useState(() => {
+    try {
+      const stored = localStorage.getItem("pageSize");
+      return stored ? parseInt(stored, 10) : 50;
+    } catch {
+      return 50;
+    }
+  });
 
   // Initialize "columnOrders" from localStorage
   const [columnOrders, setColumnOrders] = useState(() => {
@@ -59,6 +66,14 @@ export function ProjectProvider({ children }) {
       // localStorage unavailable — fail silently
     }
   }, [columnOrders]);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem("pageSize", String(pageSize));
+    } catch {
+      // localStorage unavailable — fail silently
+    }
+  }, [pageSize]);
 
   const refreshProject = useCallback(
     async (id, targetPage, preferredSize) => {


### PR DESCRIPTION
## Description
Fixes two related pagination bugs after applying transformations.

1. Page size was not persisted — `pageSize` was held only in React state with a hardcoded default of 50, so any user preference was lost on reload.
2. Transform forms bypassed pagination entirely — after a transform, `updateData` was called with the full API response, ignoring the user's chosen page size.
3. Undo transformation also bypassed pagination — `handleUndo` in `MenuNavbar` was not passing `pageSize` to `refreshProject`, causing all rows to render regardless of chosen page size.

Fix persists `pageSize` to localStorage in `ProjectContext` and calls `refreshProject(projectId, 1, pageSize)` after `updateData` in all mutating transform forms.

Fixes #339 

## Type of Change
- [x] Bug fix

## How Has This Been Tested?
- Changed page size to 10, applied transformations — table correctly shows 10 rows
- Refreshed page — page size persisted as 10, not reset to 50
- Changed page size to 10, applied a transform, undid it — table correctly shows 10 rows after undo
- [x] Existing tests pass
- [x] Manual testing

## Screenshot
<img width="1412" height="244" alt="Screenshot 2026-06-06 at 19 25 11" src="https://github.com/user-attachments/assets/6acfad9b-37e3-4e49-889f-49053730fcc1" />

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally