### PR TITLE
fix(backend): guard change_cell_value index bounds (#259)

### DIFF
--- a/dataloom-backend/app/services/transformation_service.py
+++ b/dataloom-backend/app/services/transformation_service.py
@@ -224,7 +224,9 @@ def change_cell_value(df: pd.DataFrame, row_index: int, col_index: int, value) -
     """
     df = df.copy()
 
-    if row_index >= len(df) or col_index >= len(df.columns) + 1:
+    # col_index is 1-based (1..len(columns)); row_index is 0-based. Guard both
+    # ends so a negative index can't silently wrap to the wrong cell.
+    if row_index < 0 or row_index >= len(df) or col_index < 1 or col_index >= len(df.columns) + 1:
         raise TransformationError("Row or column index out of bounds")
 
     # col_index is 1-based from frontend (accounting for S.No. column)

--- a/dataloom-backend/tests/test_transformations.py
+++ b/dataloom-backend/tests/test_transformations.py
@@ -203,6 +203,24 @@ class TestChangeCellValue:
         result = change_cell_value(sample_df, 0, 1, "Alice Updated")
         assert result.iloc[0]["name"] == "Alice Updated"
 
+    # out-of-bounds indices — col_index is 1-based, row_index 0-based
+    def test_negative_row_index_raises(self, sample_df):
+        with pytest.raises(TransformationError, match="out of bounds"):
+            change_cell_value(sample_df, -1, 1, "x")
+
+    def test_negative_col_index_raises(self, sample_df):
+        # col_index < 1 must be rejected, not silently wrap to the last column.
+        with pytest.raises(TransformationError, match="out of bounds"):
+            change_cell_value(sample_df, 0, 0, "x")
+
+    def test_row_index_past_end_raises(self, sample_df):
+        with pytest.raises(TransformationError, match="out of bounds"):
+            change_cell_value(sample_df, len(sample_df), 1, "x")
+
+    def test_col_index_past_end_raises(self, sample_df):
+        with pytest.raises(TransformationError, match="out of bounds"):
+            change_cell_value(sample_df, 0, len(sample_df.columns) + 1, "x")
+
     # int column — frontend always sends strings
     def test_int_cell_with_numeric_string_preserves_dtype(self, sample_df):
         result = change_cell_value(sample_df, 0, 2, "31")


### PR DESCRIPTION
## Summary
`change_cell_value` only validated the upper bound, so a negative `row_index` or `col_index` (or `col_index = 0`) would silently wrap to the wrong cell instead of being rejected. Added lower-bound guards.

`col_index` is 1-based from the frontend (it skips the S.No. display column), so the valid range is `1..len(columns)`; `row_index` is 0-based.

## Tests
- Added 4 out-of-bounds cases: negative row, zero/negative col, past-end row, past-end col.
- `pytest tests/test_transformations.py`: passes. `ruff check` / `ruff format --check`: clean.

Closes #259