### PR TITLE
refactor(backend): remove unused index validators (#261)

### DIFF
--- a/dataloom-backend/app/utils/pandas_helpers.py
+++ b/dataloom-backend/app/utils/pandas_helpers.py
@@ -95,37 +95,3 @@ def dataframe_to_response(df: pd.DataFrame) -> dict[str, Any]:
         "row_count": len(rows),
         "dtypes": dtypes,
     }
-
-
-def validate_row_index(df: pd.DataFrame, index: int) -> None:
-    """Validate that a row index is within DataFrame bounds.
-
-    Args:
-        df: Source DataFrame.
-        index: Row index to validate.
-
-    Raises:
-        HTTPException: If index is out of range.
-    """
-    if index < 0 or index >= len(df):
-        raise HTTPException(
-            status_code=400,
-            detail=f"Row index {index} out of range (0-{len(df) - 1})",
-        )
-
-
-def validate_column_index(df: pd.DataFrame, index: int) -> None:
-    """Validate that a column index is within DataFrame bounds.
-
-    Args:
-        df: Source DataFrame.
-        index: Column index to validate.
-
-    Raises:
-        HTTPException: If index is out of range.
-    """
-    if index < 0 or index >= len(df.columns):
-        raise HTTPException(
-            status_code=400,
-            detail=f"Column index {index} out of range (0-{len(df.columns) - 1})",
-        )


### PR DESCRIPTION
## Summary
`validate_row_index` and `validate_column_index` in `pandas_helpers.py` have no callers anywhere in the backend. Removing them as dead code. The `HTTPException` import is retained — it is still used by the file I/O helpers above.

Closes #261