### PR TITLE
feat: display full checkpoint history with revert support

### DIFF
--- a/dataloom-backend/app/api/endpoints/user_logs.py
+++ b/dataloom-backend/app/api/endpoints/user_logs.py
@@ -1,10 +1,11 @@
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends
 from sqlmodel import Session
 
 from app import database, models, schemas
 from app.api import dependencies
+from app.services.project_service import get_checkpoints
 
 router = APIRouter()
 
@@ -35,22 +36,11 @@ def get_logs(
     ]
 
 
-@router.get("/checkpoints/{project_id}", response_model=schemas.CheckpointResponse)
-def get_last_checkpoint(
+@router.get("/checkpoints/{project_id}", response_model=list[schemas.CheckpointResponse])
+def get_project_checkpoints(
     project_id: uuid.UUID,
     db: Session = Depends(database.get_db),
     _project: models.Project = Depends(dependencies.get_project_or_404),
 ):
-    last_checkpoint = (
-        db.query(models.Checkpoint)
-        .filter(models.Checkpoint.project_id == project_id)
-        .order_by(models.Checkpoint.created_at.desc())
-        .first()
-    )
-
-    if not last_checkpoint:
-        raise HTTPException(status_code=404, detail=f"No checkpoints found for project ID {project_id}")
-
-    return schemas.CheckpointResponse(
-        id=last_checkpoint.id, message=last_checkpoint.message, created_at=last_checkpoint.created_at
-    )
+    """Fetch all checkpoints for a project ordered by creation time."""
+    return get_checkpoints(db, project_id)

--- a/dataloom-backend/app/schemas.py
+++ b/dataloom-backend/app/schemas.py
@@ -338,6 +338,8 @@ class CheckpointResponse(BaseModel):
     message: str
     created_at: datetime.datetime
 
+    model_config = ConfigDict(from_attributes=True)
+
 
 class LogResponse(BaseModel):
     """Response for change log entries."""

--- a/dataloom-backend/app/services/project_service.py
+++ b/dataloom-backend/app/services/project_service.py
@@ -172,6 +172,24 @@ def create_checkpoint(db: Session, project_id: uuid.UUID, message: str) -> model
     return checkpoint
 
 
+def get_checkpoints(db: Session, project_id: uuid.UUID) -> list[models.Checkpoint]:
+    """Fetch all checkpoints for a project ordered by creation time descending.
+
+    Args:
+        db: Database session.
+        project_id: The project to query.
+
+    Returns:
+        List of Checkpoint model instances ordered by created_at desc.
+    """
+    return (
+        db.query(models.Checkpoint)
+        .filter(models.Checkpoint.project_id == project_id)
+        .order_by(models.Checkpoint.created_at.desc())
+        .all()
+    )
+
+
 def get_last_change_log(db: Session, project_id: uuid.UUID) -> models.ProjectChangeLog | None:
     """Get the most recent change log entry for a project.
 

--- a/dataloom-frontend/src/Components/history/CheckpointsPanel.jsx
+++ b/dataloom-frontend/src/Components/history/CheckpointsPanel.jsx
@@ -1,10 +1,7 @@
 import PropTypes from "prop-types";
 
 const CheckpointsPanel = ({ checkpoints, onClose, onRevert }) => {
-  const hasCheckpoints =
-    checkpoints && Array.isArray(checkpoints)
-      ? checkpoints.length > 0
-      : checkpoints && checkpoints.id;
+  const hasCheckpoints = Array.isArray(checkpoints) && checkpoints.length > 0;
 
   return (
     <div
@@ -12,7 +9,7 @@ const CheckpointsPanel = ({ checkpoints, onClose, onRevert }) => {
       className="p-4 bg-white border border-gray-200 rounded-lg shadow-sm mx-auto relative group"
     >
       <div className="flex items-center justify-between mb-4">
-        <h3 className="text-lg font-semibold text-gray-900">Last Checkpoint</h3>
+        <h3 className="text-lg font-semibold text-gray-900">Checkpoints</h3>
         <button
           onClick={onClose}
           className="text-gray-400 hover:text-gray-600 font-medium transition-opacity opacity-0 group-hover:opacity-100"
@@ -27,9 +24,9 @@ const CheckpointsPanel = ({ checkpoints, onClose, onRevert }) => {
         </button>
       </div>
 
-      <div className="overflow-x-auto">
+      <div className="overflow-x-auto overflow-y-auto max-h-72">
         <table className="min-w-full bg-white rounded-lg overflow-hidden">
-          <thead className="bg-gray-50">
+          <thead className="bg-gray-50 sticky top-0">
             <tr>
               <th className="py-3 px-4 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                 Message
@@ -44,24 +41,29 @@ const CheckpointsPanel = ({ checkpoints, onClose, onRevert }) => {
           </thead>
           <tbody>
             {hasCheckpoints ? (
-              <tr className="border-b border-gray-100 hover:bg-gray-50 transition-colors duration-150">
-                <td className="py-3 px-4 text-sm text-gray-700">{checkpoints.message}</td>
-                <td className="py-3 px-4 text-sm text-gray-500">
-                  {new Date(checkpoints.created_at).toLocaleString()}
-                </td>
-                <td className="py-3 px-4 text-center">
-                  <button
-                    onClick={() => onRevert(checkpoints.id)}
-                    className="bg-blue-500 hover:bg-blue-600 text-white text-sm font-medium px-3 py-1.5 rounded-md transition-colors duration-150"
-                  >
-                    Revert
-                  </button>
-                </td>
-              </tr>
+              checkpoints.map((checkpoint) => (
+                <tr
+                  key={checkpoint.id}
+                  className="border-b border-gray-100 hover:bg-gray-50 transition-colors duration-150"
+                >
+                  <td className="py-3 px-4 text-sm text-gray-700">{checkpoint.message}</td>
+                  <td className="py-3 px-4 text-sm text-gray-500">
+                    {new Date(checkpoint.created_at).toLocaleString()}
+                  </td>
+                  <td className="py-3 px-4 text-center">
+                    <button
+                      onClick={() => onRevert(checkpoint.id)}
+                      className="bg-blue-500 hover:bg-blue-600 text-white text-sm font-medium px-3 py-1.5 rounded-md transition-colors duration-150"
+                    >
+                      Revert
+                    </button>
+                  </td>
+                </tr>
+              ))
             ) : (
               <tr>
                 <td colSpan="3" className="py-4 px-4 text-center text-sm text-gray-500">
-                  No checkpoint available
+                  No checkpoints available
                 </td>
               </tr>
             )}
@@ -73,11 +75,13 @@ const CheckpointsPanel = ({ checkpoints, onClose, onRevert }) => {
 };
 
 CheckpointsPanel.propTypes = {
-  checkpoints: PropTypes.shape({
-    id: PropTypes.string,
-    message: PropTypes.string,
-    created_at: PropTypes.string,
-  }),
+  checkpoints: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      message: PropTypes.string.isRequired,
+      created_at: PropTypes.string.isRequired,
+    }),
+  ),
   onClose: PropTypes.func.isRequired,
   onRevert: PropTypes.func.isRequired,
 };

--- a/dataloom-frontend/src/api/logs.js
+++ b/dataloom-frontend/src/api/logs.js
@@ -15,9 +15,9 @@ export const getLogs = async (projectId) => {
 };
 
 /**
- * Fetch checkpoints for a project.
+ * Fetch all checkpoints for a project.
  * @param {string} projectId - The project ID.
- * @returns {Promise<Object>} Checkpoint data.
+ * @returns {Promise<Array>} List of checkpoints ordered by creation time.
  */
 export const getCheckpoints = async (projectId) => {
   const response = await client.get(`/logs/checkpoints/${projectId}`);


### PR DESCRIPTION
## Description
The CheckpointsPanel previously only displayed the most recent checkpoint as a single object, making it impossible for users to view or revert to older save points.

This PR replaces the single-checkpoint view with a full scrollable checkpoint history. The backend now exposes a dedicated endpoint returning all checkpoints for a project ordered by creation time, and the frontend panel maps over the full list, showing each checkpoint's message, timestamp, and a Revert button.

Fixes #88 

## Type of Change
- [x] New feature

## How Has This Been Tested?
- [x] Existing tests pass
- [x] Manual testing

**Following scenarios were tested manually:**
- Saved multiple checkpoints on a project
- Opened Checkpoints panel —> all checkpoints displayed in order
- Reverted to an older checkpoint —> data restored correctly
- Opened panel with no checkpoints —> empty state message shown
- Panel scrolls correctly with many checkpoints

## Screen Recording

https://github.com/user-attachments/assets/42d9dbd3-0533-49e0-adc7-043a87005449



## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally