### PR TITLE
feat: add delete checkpoint functionality with log unlinking

### DIFF
--- a/dataloom-backend/app/api/endpoints/user_logs.py
+++ b/dataloom-backend/app/api/endpoints/user_logs.py
@@ -5,7 +5,7 @@ from sqlmodel import Session
 
 from app import database, models, schemas
 from app.api import dependencies
-from app.services.project_service import get_checkpoints
+from app.services.project_service import delete_checkpoint, get_checkpoints
 
 router = APIRouter()
 
@@ -44,3 +44,16 @@ def get_project_checkpoints(
 ):
     """Fetch all checkpoints for a project ordered by creation time."""
     return get_checkpoints(db, project_id)
+
+
+@router.delete("/checkpoints/{project_id}/{checkpoint_id}")
+def delete_project_checkpoint(
+    project_id: uuid.UUID,
+    checkpoint_id: uuid.UUID,
+    db: Session = Depends(database.get_db),
+    _project: models.Project = Depends(dependencies.get_project_or_404),
+):
+    """Delete a checkpoint and unlink its associated logs."""
+    delete_checkpoint(db, checkpoint_id, project_id)
+    db.commit()
+    return {"success": True, "message": "Checkpoint deleted"}

--- a/dataloom-backend/app/services/project_service.py
+++ b/dataloom-backend/app/services/project_service.py
@@ -218,3 +218,41 @@ def delete_change_log(db: Session, log: models.ProjectChangeLog) -> None:
     db.delete(log)
     db.flush()
     logger.debug("Deleted change log: id=%s, project_id=%s", log.change_log_id, log.project_id)
+
+
+def delete_checkpoint(db: Session, checkpoint_id: uuid.UUID, project_id: uuid.UUID) -> None:
+    """Delete a checkpoint and unlink its associated logs.
+
+    Logs that referenced this checkpoint are not deleted — they are unlinked
+    (checkpoint_id set to None) so the transformation history is preserved.
+
+    Args:
+        db: Database session.
+        checkpoint_id: The checkpoint to delete.
+        project_id: The project the checkpoint belongs to.
+
+    Raises:
+        HTTPException: If the checkpoint is not found.
+    """
+    from fastapi import HTTPException
+
+    checkpoint = (
+        db.query(models.Checkpoint)
+        .filter(
+            models.Checkpoint.id == checkpoint_id,
+            models.Checkpoint.project_id == project_id,
+        )
+        .first()
+    )
+
+    if not checkpoint:
+        raise HTTPException(status_code=404, detail="Checkpoint not found")
+
+    # Unlink logs referencing this checkpoint
+    db.query(models.ProjectChangeLog).filter(models.ProjectChangeLog.checkpoint_id == checkpoint_id).update(
+        {"checkpoint_id": None}, synchronize_session="evaluate"
+    )
+
+    db.delete(checkpoint)
+    db.commit()
+    logger.info("Deleted checkpoint: id=%s, project_id=%s", checkpoint_id, project_id)

--- a/dataloom-backend/app/services/project_service.py
+++ b/dataloom-backend/app/services/project_service.py
@@ -3,6 +3,7 @@
 import uuid
 from datetime import UTC, datetime
 
+from fastapi import HTTPException
 from sqlalchemy.exc import SQLAlchemyError
 from sqlmodel import Session
 
@@ -234,7 +235,6 @@ def delete_checkpoint(db: Session, checkpoint_id: uuid.UUID, project_id: uuid.UU
     Raises:
         HTTPException: If the checkpoint is not found.
     """
-    from fastapi import HTTPException
 
     checkpoint = (
         db.query(models.Checkpoint)
@@ -254,5 +254,5 @@ def delete_checkpoint(db: Session, checkpoint_id: uuid.UUID, project_id: uuid.UU
     )
 
     db.delete(checkpoint)
-    db.commit()
+    db.flush()
     logger.info("Deleted checkpoint: id=%s, project_id=%s", checkpoint_id, project_id)

--- a/dataloom-backend/tests/test_user_logs.py
+++ b/dataloom-backend/tests/test_user_logs.py
@@ -21,8 +21,6 @@ class TestLogsEndpoint:
         assert "not found" in detail.lower()
 
     def test_get_logs_existing_project_returns_200(self, client, db, test_user):
-        # Projects are created by CSV upload in production; inserting the row
-        # directly is enough to exercise the /logs endpoint.
         project = create_project(
             db, name="logs-test-project", file_path="/tmp/test.csv", description="", owner_id=test_user.id
         )
@@ -39,3 +37,59 @@ class TestLogsEndpoint:
         response = client.get(f"/logs/{project.project_id}")
         assert response.status_code == 200
         assert response.json() == []
+
+    def test_delete_checkpoint_nonexistent_returns_404(self, client, db, test_user):
+        project = create_project(
+            db, name="delete-checkpoint-404-project", file_path="/tmp/test.csv", description="", owner_id=test_user.id
+        )
+        nonexistent_checkpoint_id = uuid.uuid4()
+
+        response = client.delete(f"/logs/checkpoints/{project.project_id}/{nonexistent_checkpoint_id}")
+        assert response.status_code == 404
+        detail = response.json()["detail"]
+        assert isinstance(detail, str)
+        assert "not found" in detail.lower()
+
+    def test_delete_checkpoint_removes_checkpoint(self, client, db, test_user):
+        from app.models import Checkpoint
+        from app.services.project_service import create_checkpoint
+
+        project = create_project(
+            db,
+            name="delete-checkpoint-removed-project",
+            file_path="/tmp/test.csv",
+            description="",
+            owner_id=test_user.id,
+        )
+        checkpoint = create_checkpoint(db, project.project_id, "to be deleted")
+
+        response = client.delete(f"/logs/checkpoints/{project.project_id}/{checkpoint.id}")
+        assert response.status_code == 200
+        assert response.json()["success"] is True
+
+        deleted = db.query(Checkpoint).filter(Checkpoint.id == checkpoint.id).first()
+        assert deleted is None
+
+    def test_delete_checkpoint_unlinks_logs(self, client, db, test_user):
+        from app.models import ProjectChangeLog
+        from app.services.project_service import create_checkpoint, log_transformation
+
+        project = create_project(
+            db,
+            name="delete-checkpoint-unlink-project",
+            file_path="/tmp/test.csv",
+            description="",
+            owner_id=test_user.id,
+        )
+        log_transformation(db, project.project_id, "filter", {"column": "a"})
+        checkpoint = create_checkpoint(db, project.project_id, "checkpoint to delete")
+
+        log = db.query(ProjectChangeLog).filter(ProjectChangeLog.project_id == project.project_id).first()
+        assert log.checkpoint_id == checkpoint.id
+
+        response = client.delete(f"/logs/checkpoints/{project.project_id}/{checkpoint.id}")
+        assert response.status_code == 200
+        assert response.json()["success"] is True
+
+        db.refresh(log)
+        assert log.checkpoint_id is None

--- a/dataloom-frontend/src/Components/MenuNavbar.jsx
+++ b/dataloom-frontend/src/Components/MenuNavbar.jsx
@@ -79,9 +79,15 @@ const MenuNavbar = ({ projectId }) => {
   const fetchCheckpoints = useCallback(async () => {
     try {
       const checkpointsResponse = await getCheckpoints(projectId);
-      setCheckpoints(checkpointsResponse);
+
+      if (Array.isArray(checkpointsResponse)) {
+        setCheckpoints(checkpointsResponse.length > 0 ? checkpointsResponse[0] : null);
+      } else {
+        setCheckpoints(checkpointsResponse?.id ? checkpointsResponse : null);
+      }
     } catch (error) {
       console.error("Error fetching checkpoints:", error);
+      setCheckpoints(null);
     }
   }, [projectId]);
 
@@ -479,12 +485,14 @@ const MenuNavbar = ({ projectId }) => {
       )}
       {showCheckpoints && (
         <CheckpointsPanel
+          projectId={projectId}
           checkpoints={checkpoints}
           onClose={() => {
             setShowCheckpoints(false);
             setActiveForm(null);
           }}
           onRevert={handleRevert}
+          onCheckpointDeleted={fetchCheckpoints}
         />
       )}
       {showGroupByForm && (

--- a/dataloom-frontend/src/Components/MenuNavbar.jsx
+++ b/dataloom-frontend/src/Components/MenuNavbar.jsx
@@ -79,11 +79,13 @@ const MenuNavbar = ({ projectId }) => {
   const fetchCheckpoints = useCallback(async () => {
     try {
       const checkpointsResponse = await getCheckpoints(projectId);
-
+      console.log(checkpointsResponse);
       if (Array.isArray(checkpointsResponse)) {
-        setCheckpoints(checkpointsResponse.length > 0 ? checkpointsResponse[0] : null);
+        setCheckpoints(checkpointsResponse);
+      } else if (checkpointsResponse?.id) {
+        setCheckpoints([checkpointsResponse]);
       } else {
-        setCheckpoints(checkpointsResponse?.id ? checkpointsResponse : null);
+        setCheckpoints([]);
       }
     } catch (error) {
       console.error("Error fetching checkpoints:", error);

--- a/dataloom-frontend/src/Components/history/CheckpointsPanel.jsx
+++ b/dataloom-frontend/src/Components/history/CheckpointsPanel.jsx
@@ -1,7 +1,23 @@
+import { useState } from "react";
+import { deleteCheckpoint } from "../../api";
 import PropTypes from "prop-types";
+import Modal from "../common/Modal";
 
-const CheckpointsPanel = ({ checkpoints, onClose, onRevert }) => {
+const CheckpointsPanel = ({ projectId, checkpoints, onClose, onRevert, onCheckpointDeleted }) => {
+  const [confirmDeleteId, setConfirmDeleteId] = useState(null);
+
   const hasCheckpoints = Array.isArray(checkpoints) && checkpoints.length > 0;
+
+  const handleDeleteConfirm = async () => {
+    try {
+      await deleteCheckpoint(projectId, confirmDeleteId);
+      await onCheckpointDeleted();
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setConfirmDeleteId(null);
+    }
+  };
 
   return (
     <div
@@ -13,12 +29,7 @@ const CheckpointsPanel = ({ checkpoints, onClose, onRevert }) => {
         <button
           onClick={onClose}
           className="text-gray-400 hover:text-gray-600 font-medium transition-opacity opacity-0 group-hover:opacity-100"
-          style={{
-            transition: "opacity 0.3s",
-            background: "transparent",
-            border: "none",
-            cursor: "pointer",
-          }}
+          style={{ transition: "opacity 0.3s", background: "transparent", border: "none", cursor: "pointer" }}
         >
           Close
         </button>
@@ -35,7 +46,7 @@ const CheckpointsPanel = ({ checkpoints, onClose, onRevert }) => {
                 Created At
               </th>
               <th className="py-3 px-4 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">
-                Action
+                Actions
               </th>
             </tr>
           </thead>
@@ -51,12 +62,20 @@ const CheckpointsPanel = ({ checkpoints, onClose, onRevert }) => {
                     {new Date(checkpoint.created_at).toLocaleString()}
                   </td>
                   <td className="py-3 px-4 text-center">
-                    <button
-                      onClick={() => onRevert(checkpoint.id)}
-                      className="bg-blue-500 hover:bg-blue-600 text-white text-sm font-medium px-3 py-1.5 rounded-md transition-colors duration-150"
-                    >
-                      Revert
-                    </button>
+                    <div className="flex items-center justify-center gap-2">
+                      <button
+                        onClick={() => onRevert(checkpoint.id)}
+                        className="bg-blue-500 hover:bg-blue-600 text-white text-sm font-medium px-3 py-1.5 rounded-md transition-colors duration-150"
+                      >
+                        Revert
+                      </button>
+                      <button
+                        onClick={() => setConfirmDeleteId(checkpoint.id)}
+                        className="bg-red-500 hover:bg-red-600 text-white text-sm font-medium px-3 py-1.5 rounded-md transition-colors duration-150"
+                      >
+                        Delete
+                      </button>
+                    </div>
                   </td>
                 </tr>
               ))
@@ -70,11 +89,36 @@ const CheckpointsPanel = ({ checkpoints, onClose, onRevert }) => {
           </tbody>
         </table>
       </div>
+
+      <Modal
+        isOpen={!!confirmDeleteId}
+        onClose={() => setConfirmDeleteId(null)}
+        title="Delete Checkpoint"
+      >
+        <p className="text-gray-700 text-sm mb-6">
+          Are you sure you want to delete this checkpoint? This action cannot be undone.
+        </p>
+        <div className="flex justify-end gap-2">
+          <button
+            onClick={() => setConfirmDeleteId(null)}
+            className="px-4 py-2 text-sm text-gray-600 border border-gray-300 rounded-md hover:bg-gray-50"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleDeleteConfirm}
+            className="px-4 py-2 text-sm text-white bg-red-500 hover:bg-red-600 rounded-md"
+          >
+            Delete
+          </button>
+        </div>
+      </Modal>
     </div>
   );
 };
 
 CheckpointsPanel.propTypes = {
+  projectId: PropTypes.string.isRequired,
   checkpoints: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.string.isRequired,
@@ -84,6 +128,7 @@ CheckpointsPanel.propTypes = {
   ),
   onClose: PropTypes.func.isRequired,
   onRevert: PropTypes.func.isRequired,
+  onCheckpointDeleted: PropTypes.func.isRequired,
 };
 
 export default CheckpointsPanel;

--- a/dataloom-frontend/src/Components/history/CheckpointsPanel.jsx
+++ b/dataloom-frontend/src/Components/history/CheckpointsPanel.jsx
@@ -2,15 +2,18 @@ import { useState } from "react";
 import { deleteCheckpoint } from "../../api";
 import PropTypes from "prop-types";
 import Modal from "../common/Modal";
+import { useToast } from "../../context/ToastContext";
 
 const CheckpointsPanel = ({ projectId, checkpoints, onClose, onRevert, onCheckpointDeleted }) => {
   const [confirmDeleteId, setConfirmDeleteId] = useState(null);
+  const { showToast } = useToast();
 
   const hasCheckpoints = Array.isArray(checkpoints) && checkpoints.length > 0;
 
   const handleDeleteConfirm = async () => {
     try {
       await deleteCheckpoint(projectId, confirmDeleteId);
+      showToast("Checkpoint deleted successfully", "success");
       await onCheckpointDeleted();
     } catch (err) {
       console.error(err);
@@ -29,7 +32,12 @@ const CheckpointsPanel = ({ projectId, checkpoints, onClose, onRevert, onCheckpo
         <button
           onClick={onClose}
           className="text-gray-400 hover:text-gray-600 font-medium transition-opacity opacity-0 group-hover:opacity-100"
-          style={{ transition: "opacity 0.3s", background: "transparent", border: "none", cursor: "pointer" }}
+          style={{
+            transition: "opacity 0.3s",
+            background: "transparent",
+            border: "none",
+            cursor: "pointer",
+          }}
         >
           Close
         </button>

--- a/dataloom-frontend/src/api/index.js
+++ b/dataloom-frontend/src/api/index.js
@@ -11,6 +11,6 @@ export {
   exportProject,
   deleteProject,
 } from "./projects";
-export { getLogs, getCheckpoints } from "./logs";
+export { getLogs, getCheckpoints, deleteCheckpoint } from "./logs";
 export { transformProject, groupByTransform, undoLastTransformation } from "./transforms";
 export { signup, signin, logout, getCurrentUser } from "./auth";

--- a/dataloom-frontend/src/api/logs.js
+++ b/dataloom-frontend/src/api/logs.js
@@ -23,3 +23,14 @@ export const getCheckpoints = async (projectId) => {
   const response = await client.get(`/logs/checkpoints/${projectId}`);
   return response.data;
 };
+
+/**
+ * Delete a checkpoint.
+ * @param {string} projectId - The project ID.
+ * @param {string} checkpointId - The checkpoint ID to delete.
+ * @returns {Promise<Object>} Success confirmation.
+ */
+export const deleteCheckpoint = async (projectId, checkpointId) => {
+  const response = await client.delete(`/logs/checkpoints/${projectId}/${checkpointId}`);
+  return response.data;
+};


### PR DESCRIPTION
## Description
Users had no way to delete checkpoints once created. This PR adds a Delete button to each checkpoint entry in the CheckpointsPanel. Deleting a checkpoint removes it from the database and unlinks its associated logs, preserving transformation history without the checkpoint reference.

Fixes #354 

## Type of Change
- [x] New feature

## How Has This Been Tested?
- [x] Existing tests pass
- [x] New tests added
- [x] Manual testing

**Following scenarios were tested manually:**
- Created multiple checkpoints, deleted each —> panel refreshes correctly
- Verified logs are unlinked (`checkpoint_id` set to null) not deleted after checkpoint removal
- Verified 404 returned when deleting nonexistent checkpoint

## Screen Recording

https://github.com/user-attachments/assets/1ede40e5-11e4-44a1-ab1f-2b41a0c90932



## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally