### PR TITLE
fix: refresh checkpoints panel after saving a checkpoint

### DIFF
--- a/dataloom-frontend/src/Components/MenuNavbar.jsx
+++ b/dataloom-frontend/src/Components/MenuNavbar.jsx
@@ -104,6 +104,7 @@ const MenuNavbar = ({ projectId }) => {
 
     try {
       await saveProject(projectId, message);
+      await fetchCheckpoints();
       setToast({ message: "Project saved successfully!", type: "success" });
     } catch {
       setToast({ message: "Failed to save project.", type: "error" });


### PR DESCRIPTION
## Description
The CheckpointsPanel did not update in real-time after saving a checkpoint, requiring a page refresh to reflect changes. Root cause was that `fetchCheckpoints()` was not called after a successful save in `MenuNavbar.handleSubmitCommit`.

Fixes #356 

## Type of Change
- [x] Bug fix

## How Has This Been Tested?
- [x] Existing tests pass
- [x] Manual testing

**Following scenarios were tested manually:**
- Saved a checkpoint with no existing checkpoints —> panel immediately shows new checkpoint
- Saved multiple checkpoints —> panel updates after each save

## Screen Recording

https://github.com/user-attachments/assets/1bb54d62-74f5-443f-b277-d62e82b88ea1



## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally