### PR TITLE
docs: update README for multiple file format support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,19 @@
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
-A web-based GUI for data wrangling — manage and transform tabular datasets (CSV) through a graphical interface powered by pandas, without writing code.
+A web-based GUI for data wrangling — manage and transform tabular datasets (CSV, TSV, JSON, XLSX, Parquet) through a graphical interface powered by pandas, without writing code.
+
+## Supported File Formats
+
+- CSV (.csv)
+- TSV (.tsv)
+- JSON (.json)
+- XLSX (.xlsx)
+- Parquet (.parquet)
 
 ## Features
 
-- Upload and manage CSV datasets through a graphical interface
+- Upload and manage datasets in CSV, TSV, JSON, XLSX, and Parquet formats through a graphical interface
 - Apply pandas-powered transformations: filter, sort, pivot, deduplicate, and more
 - Inline cell editing and row/column management
 - Checkpoint system — save and revert dataset states


### PR DESCRIPTION
## Summary

Updates the README to reflect support for multiple dataset formats.

### Changes
- Added a Supported File Formats section.
- Documented support for CSV, TSV, JSON, XLSX, and Parquet.
- Updated the project description to mention multi-format support.
- Replaced CSV-specific wording with generic dataset wording.

Closes #334