### PR TITLE
refactor: replace inline form buttons with shared Button component

### DIFF
--- a/dataloom-frontend/src/Components/common/Button.jsx
+++ b/dataloom-frontend/src/Components/common/Button.jsx
@@ -1,7 +1,8 @@
 /**
- * Reusable button component with variant support.
+ * Reusable button component with variant and size support.
  * @param {Object} props
  * @param {'primary'|'secondary'|'danger'|'ghost'} [props.variant='primary'] - Visual style variant.
+ * @param {'sm'|'md'} [props.size='md'] - Button size.
  * @param {React.ReactNode} props.children - Button content.
  * @param {string} [props.className] - Additional CSS classes.
  * @param {Object} [props.rest] - Additional props passed to the button element.
@@ -13,10 +14,23 @@ const VARIANT_CLASSES = {
   ghost: "text-gray-500 hover:text-gray-700 hover:bg-gray-100",
 };
 
-export default function Button({ variant = "primary", children, className = "", ...rest }) {
+const SIZE_CLASSES = {
+  sm: "px-3 py-1.5 text-sm",
+  md: "px-4 py-2",
+};
+
+export default function Button({
+  variant = "primary",
+  size = "md",
+  children,
+  className = "",
+  ...rest
+}) {
   return (
     <button
-      className={`px-4 py-2 rounded-md font-medium transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2 ${VARIANT_CLASSES[variant] || VARIANT_CLASSES.primary} ${className}`}
+      className={`rounded-md font-medium transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed ${
+        SIZE_CLASSES[size] || SIZE_CLASSES.md
+      } ${VARIANT_CLASSES[variant] || VARIANT_CLASSES.primary} ${className}`}
       {...rest}
     >
       {children}

--- a/dataloom-frontend/src/Components/forms/AdvQueryFilterForm.jsx
+++ b/dataloom-frontend/src/Components/forms/AdvQueryFilterForm.jsx
@@ -54,7 +54,9 @@ const AdvQueryFilterForm = ({ projectId, onClose }) => {
           />
         </div>
         <div className="flex justify-between">
-          <Button disabled={loading}>Submit</Button>
+          <Button disabled={loading} type="submit">
+            Submit
+          </Button>
 
           <Button type="button" variant="secondary" onClick={onClose}>
             Cancel

--- a/dataloom-frontend/src/Components/forms/AdvQueryFilterForm.jsx
+++ b/dataloom-frontend/src/Components/forms/AdvQueryFilterForm.jsx
@@ -6,6 +6,7 @@ import { ADV_QUERY_FILTER } from "../../constants/operationTypes";
 import useError from "../../hooks/useError";
 import FormErrorAlert from "../common/FormErrorAlert";
 import { useProjectContext } from "../../context/ProjectContext";
+import Button from "../common/Button";
 
 const AdvQueryFilterForm = ({ projectId, onClose }) => {
   const [query, setQuery] = useState("");
@@ -53,20 +54,11 @@ const AdvQueryFilterForm = ({ projectId, onClose }) => {
           />
         </div>
         <div className="flex justify-between">
-          <button
-            type="submit"
-            className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-md font-medium transition-colors duration-150"
-            disabled={loading}
-          >
-            Submit
-          </button>
-          <button
-            type="button"
-            onClick={onClose}
-            className="bg-white border border-gray-300 text-gray-700 hover:bg-gray-50 px-4 py-2 rounded-md font-medium transition-colors duration-150"
-          >
+          <Button disabled={loading}>Submit</Button>
+
+          <Button type="button" variant="secondary" onClick={onClose}>
             Cancel
-          </button>
+          </Button>
         </div>
       </form>
       <FormErrorAlert message={error} />

--- a/dataloom-frontend/src/Components/forms/CastDataTypeForm.jsx
+++ b/dataloom-frontend/src/Components/forms/CastDataTypeForm.jsx
@@ -7,6 +7,7 @@ import useError from "../../hooks/useError";
 import FormErrorAlert from "../common/FormErrorAlert";
 import ColumnSelect from "../common/ColumnSelect";
 import { useProjectContext } from "../../context/ProjectContext";
+import Button from "../common/Button";
 
 const CastDataTypeForm = ({ projectId, onClose }) => {
   const { showToast } = useToast();
@@ -74,20 +75,11 @@ const CastDataTypeForm = ({ projectId, onClose }) => {
         </div>
 
         <div className="flex justify-between">
-          <button
-            type="submit"
-            className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-md font-medium transition-colors duration-150"
-          >
-            Apply
-          </button>
+          <Button type="submit">Apply</Button>
 
-          <button
-            type="button"
-            onClick={onClose}
-            className="bg-white border border-gray-300 text-gray-700 hover:bg-gray-50 px-4 py-2 rounded-md font-medium transition-colors duration-150"
-          >
+          <Button type="button" variant="secondary" onClick={onClose}>
             Cancel
-          </button>
+          </Button>
         </div>
       </form>
       <FormErrorAlert message={error} />

--- a/dataloom-frontend/src/Components/forms/DropDuplicateForm.jsx
+++ b/dataloom-frontend/src/Components/forms/DropDuplicateForm.jsx
@@ -5,6 +5,7 @@ import { DROP_DUPLICATE } from "../../constants/operationTypes";
 import useError from "../../hooks/useError";
 import FormErrorAlert from "../common/FormErrorAlert";
 import { useProjectContext } from "../../context/ProjectContext";
+import Button from "../common/Button";
 
 const DropDuplicateForm = ({ projectId, onClose }) => {
   const [columns, setColumns] = useState("");
@@ -66,19 +67,10 @@ const DropDuplicateForm = ({ projectId, onClose }) => {
           </div>
         </div>
         <div className="flex justify-between">
-          <button
-            type="submit"
-            className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-md font-medium transition-colors duration-150"
-          >
-            Submit
-          </button>
-          <button
-            type="button"
-            onClick={onClose}
-            className="bg-white border border-gray-300 text-gray-700 hover:bg-gray-50 px-4 py-2 rounded-md font-medium transition-colors duration-150"
-          >
+          <Button type="submit">Submit</Button>
+          <Button type="button" variant="secondary" onClick={onClose}>
             Cancel
-          </button>
+          </Button>
         </div>
       </form>
       <FormErrorAlert message={error} />

--- a/dataloom-frontend/src/Components/forms/FilterForm.jsx
+++ b/dataloom-frontend/src/Components/forms/FilterForm.jsx
@@ -7,6 +7,7 @@ import useError from "../../hooks/useError";
 import FormErrorAlert from "../common/FormErrorAlert";
 import ColumnSelect from "../common/ColumnSelect";
 import { useProjectContext } from "../../context/ProjectContext";
+import Button from "../common/Button";
 
 const FilterForm = ({ projectId, onClose }) => {
   const [filterParams, setFilterParams] = useState({
@@ -96,20 +97,12 @@ const FilterForm = ({ projectId, onClose }) => {
           </div>
         </div>
         <div className="flex justify-between">
-          <button
-            type="submit"
-            className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-md font-medium transition-colors duration-150"
-            disabled={loading}
-          >
+          <Button type="submit" disabled={loading}>
             Apply Filter
-          </button>
-          <button
-            type="button"
-            onClick={onClose}
-            className="bg-white border border-gray-300 text-gray-700 hover:bg-gray-50 px-4 py-2 rounded-md font-medium transition-colors duration-150"
-          >
+          </Button>
+          <Button type="button" variant="secondary" onClick={onClose}>
             Cancel
-          </button>
+          </Button>
         </div>
       </form>
       <FormErrorAlert message={error} />

--- a/dataloom-frontend/src/Components/forms/GroupByForm.jsx
+++ b/dataloom-frontend/src/Components/forms/GroupByForm.jsx
@@ -6,6 +6,7 @@ import TransformResultPreview from "./TransformResultPreview";
 import useError from "../../hooks/useError";
 import FormErrorAlert from "../common/FormErrorAlert";
 import { useProjectContext } from "../../context/ProjectContext";
+import Button from "../common/Button";
 
 const GroupByForm = ({ projectId, onClose }) => {
   const { columns: availableColumns, updateData, refreshProject, pageSize } = useProjectContext();
@@ -111,20 +112,12 @@ const GroupByForm = ({ projectId, onClose }) => {
           </div>
         </div>
         <div className="flex justify-between">
-          <button
-            type="submit"
-            className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-md font-medium transition-colors duration-150"
-            disabled={loading || selectedColumns.length === 0 || !aggColumn}
-          >
+          <Button type="submit" disabled={loading || selectedColumns.length === 0 || !aggColumn}>
             Apply GroupBy
-          </button>
-          <button
-            type="button"
-            onClick={onClose}
-            className="bg-white border border-gray-300 text-gray-700 hover:bg-gray-50 px-4 py-2 rounded-md font-medium transition-colors duration-150"
-          >
+          </Button>
+          <Button type="button" variant="secondary" onClick={onClose}>
             Cancel
-          </button>
+          </Button>
         </div>
       </form>
       <FormErrorAlert message={error} />

--- a/dataloom-frontend/src/Components/forms/MeltForm.jsx
+++ b/dataloom-frontend/src/Components/forms/MeltForm.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import TransformResultPreview from "./TransformResultPreview";
 import { transformProject, getProjectDetails } from "../../api";
 import { useProjectContext } from "../../context/ProjectContext";
+import Button from "../common/Button";
 
 const MeltForm = ({ projectId, onClose }) => {
   const [columns, setColumns] = useState([]);
@@ -180,20 +181,12 @@ const MeltForm = ({ projectId, onClose }) => {
 
         <div className="flex justify-between pt-2">
           <div className="flex gap-2">
-            <button
-              type="submit"
-              className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-md font-medium transition-colors duration-150 text-sm disabled:opacity-50"
-              disabled={loading}
-            >
+            <Button type="submit" disabled={loading}>
               {loading ? "Processing..." : "Apply Melt"}
-            </button>
-            <button
-              type="button"
-              onClick={onClose}
-              className="bg-white border border-gray-300 text-gray-700 hover:bg-gray-50 px-4 py-2 rounded-md font-medium transition-colors duration-150 text-sm"
-            >
+            </Button>
+            <Button type="button" variant="secondary" onClick={onClose}>
               Cancel
-            </button>
+            </Button>
           </div>
         </div>
       </form>

--- a/dataloom-frontend/src/Components/forms/PivotTableForm.jsx
+++ b/dataloom-frontend/src/Components/forms/PivotTableForm.jsx
@@ -7,6 +7,7 @@ import useError from "../../hooks/useError";
 import FormErrorAlert from "../common/FormErrorAlert";
 import ColumnSelect from "../common/ColumnSelect";
 import { useProjectContext } from "../../context/ProjectContext";
+import Button from "../common/Button";
 
 const PivotTableForm = ({ projectId, onClose }) => {
   const [index, setIndex] = useState("");
@@ -91,20 +92,12 @@ const PivotTableForm = ({ projectId, onClose }) => {
           </div>
         </div>
         <div className="flex justify-between">
-          <button
-            type="submit"
-            className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-md font-medium transition-colors duration-150"
-            disabled={loading}
-          >
-            {loading ? "Loading..." : "Submit"}
-          </button>
-          <button
-            type="button"
-            onClick={onClose}
-            className="bg-white border border-gray-300 text-gray-700 hover:bg-gray-50 px-4 py-2 rounded-md font-medium transition-colors duration-150"
-          >
+          <Button type="submit" disabled={loading}>
+            {loading ? "Submitting..." : "Submit"}
+          </Button>
+          <Button type="button" variant="secondary" onClick={onClose}>
             Cancel
-          </button>
+          </Button>
         </div>
       </form>
       <FormErrorAlert message={error} />

--- a/dataloom-frontend/src/Components/forms/SampleRowsForm.jsx
+++ b/dataloom-frontend/src/Components/forms/SampleRowsForm.jsx
@@ -6,6 +6,7 @@ import TransformResultPreview from "./TransformResultPreview";
 import useError from "../../hooks/useError";
 import FormErrorAlert from "../common/FormErrorAlert";
 import { useProjectContext } from "../../context/ProjectContext";
+import Button from "../common/Button";
 
 const SampleRowsForm = ({ projectId, onClose }) => {
   const { updateData, refreshProject, pageSize } = useProjectContext();
@@ -93,20 +94,12 @@ const SampleRowsForm = ({ projectId, onClose }) => {
           </div>
         </div>
         <div className="flex justify-between">
-          <button
-            type="submit"
-            className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-md font-medium transition-colors duration-150"
-            disabled={loading || !sampleSize}
-          >
+          <Button type="submit" disabled={loading || !sampleSize}>
             Apply Sample
-          </button>
-          <button
-            type="button"
-            onClick={onClose}
-            className="bg-white border border-gray-300 text-gray-700 hover:bg-gray-50 px-4 py-2 rounded-md font-medium transition-colors duration-150"
-          >
+          </Button>
+          <Button type="button" variant="secondary" onClick={onClose}>
             Cancel
-          </button>
+          </Button>
         </div>
       </form>
       <FormErrorAlert message={error} />

--- a/dataloom-frontend/src/Components/forms/SortForm.jsx
+++ b/dataloom-frontend/src/Components/forms/SortForm.jsx
@@ -7,6 +7,7 @@ import useError from "../../hooks/useError";
 import FormErrorAlert from "../common/FormErrorAlert";
 import ColumnSelect from "../common/ColumnSelect";
 import { useProjectContext } from "../../context/ProjectContext";
+import Button from "../common/Button";
 
 /**
  * SortForm component for multi-column sorting.
@@ -195,20 +196,12 @@ const SortForm = ({ projectId, onClose }) => {
           Add Sort Criterion
         </button>
         <div className="flex justify-between pt-4 border-t border-gray-200">
-          <button
-            type="submit"
-            className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-md font-medium transition-colors duration-150 disabled:opacity-50 disabled:cursor-not-allowed"
-            disabled={loading || criteria.length === 0}
-          >
+          <Button type="submit" disabled={loading || criteria.length === 0}>
             {loading ? "Applying..." : "Apply Sort"}
-          </button>
-          <button
-            type="button"
-            onClick={onClose}
-            className="bg-white border border-gray-300 text-gray-700 hover:bg-gray-50 px-4 py-2 rounded-md font-medium transition-colors duration-150"
-          >
+          </Button>
+          <Button type="button" variant="secondary" onClick={onClose}>
             Cancel
-          </button>
+          </Button>
         </div>
       </form>
       <FormErrorAlert message={error} />

--- a/dataloom-frontend/src/Components/forms/StringReplaceForm.jsx
+++ b/dataloom-frontend/src/Components/forms/StringReplaceForm.jsx
@@ -4,6 +4,7 @@ import { transformProject } from "../../api";
 import { useProjectContext } from "../../context/ProjectContext";
 import { useToast } from "../../context/ToastContext";
 import { STRING_REPLACE } from "../../constants/operationTypes";
+import Button from "../common/Button";
 
 const StringReplaceForm = ({ projectId, onClose }) => {
   const { columns, updateData, refreshProject, pageSize } = useProjectContext();
@@ -98,20 +99,11 @@ const StringReplaceForm = ({ projectId, onClose }) => {
         </div>
 
         <div className="flex justify-between">
-          <button
-            type="submit"
-            className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-md font-medium transition-colors duration-150"
-          >
-            Apply
-          </button>
+          <Button type="submit">Apply</Button>
 
-          <button
-            type="button"
-            onClick={onClose}
-            className="bg-white border border-gray-300 text-gray-700 hover:bg-gray-50 px-4 py-2 rounded-md font-medium transition-colors duration-150"
-          >
+          <Button type="button" variant="secondary" onClick={onClose}>
             Cancel
-          </button>
+          </Button>
         </div>
       </form>
     </div>

--- a/dataloom-frontend/src/Components/forms/TrimWhitespaceForm.jsx
+++ b/dataloom-frontend/src/Components/forms/TrimWhitespaceForm.jsx
@@ -4,6 +4,7 @@ import { transformProject } from "../../api";
 import { TRIM_WHITESPACE } from "../../constants/operationTypes";
 import { useProjectContext } from "../../context/ProjectContext";
 import { useToast } from "../../context/ToastContext";
+import Button from "../common/Button";
 
 const TrimWhitespaceForm = ({ projectId, onClose }) => {
   const { columns, updateData, refreshProject, pageSize } = useProjectContext();
@@ -63,21 +64,13 @@ const TrimWhitespaceForm = ({ projectId, onClose }) => {
         </div>
 
         <div className="flex justify-between">
-          <button
-            type="submit"
-            disabled={loading}
-            className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-md font-medium transition-colors duration-150 disabled:opacity-50 disabled:cursor-not-allowed"
-          >
+          <Button type="submit" disabled={loading}>
             {loading ? "Applying..." : "Apply"}
-          </button>
+          </Button>
 
-          <button
-            type="button"
-            onClick={onClose}
-            className="bg-white border border-gray-300 text-gray-700 hover:bg-gray-50 px-4 py-2 rounded-md font-medium transition-colors duration-150"
-          >
+          <Button type="button" variant="secondary" onClick={onClose}>
             Cancel
-          </button>
+          </Button>
         </div>
       </form>
     </div>

--- a/dataloom-frontend/src/Components/history/CheckpointsPanel.jsx
+++ b/dataloom-frontend/src/Components/history/CheckpointsPanel.jsx
@@ -3,6 +3,7 @@ import { deleteCheckpoint } from "../../api";
 import PropTypes from "prop-types";
 import Modal from "../common/Modal";
 import { useToast } from "../../context/ToastContext";
+import Button from "../common/Button";
 
 const CheckpointsPanel = ({ projectId, checkpoints, onClose, onRevert, onCheckpointDeleted }) => {
   const [confirmDeleteId, setConfirmDeleteId] = useState(null);
@@ -71,18 +72,16 @@ const CheckpointsPanel = ({ projectId, checkpoints, onClose, onRevert, onCheckpo
                   </td>
                   <td className="py-3 px-4 text-center">
                     <div className="flex items-center justify-center gap-2">
-                      <button
-                        onClick={() => onRevert(checkpoint.id)}
-                        className="bg-blue-500 hover:bg-blue-600 text-white text-sm font-medium px-3 py-1.5 rounded-md transition-colors duration-150"
-                      >
+                      <Button onClick={() => onRevert(checkpoint.id)} className="text-sm">
                         Revert
-                      </button>
-                      <button
+                      </Button>
+                      <Button
+                        variant="danger"
                         onClick={() => setConfirmDeleteId(checkpoint.id)}
-                        className="bg-red-500 hover:bg-red-600 text-white text-sm font-medium px-3 py-1.5 rounded-md transition-colors duration-150"
+                        className="text-sm"
                       >
                         Delete
-                      </button>
+                      </Button>
                     </div>
                   </td>
                 </tr>
@@ -107,18 +106,12 @@ const CheckpointsPanel = ({ projectId, checkpoints, onClose, onRevert, onCheckpo
           Are you sure you want to delete this checkpoint? This action cannot be undone.
         </p>
         <div className="flex justify-end gap-2">
-          <button
-            onClick={() => setConfirmDeleteId(null)}
-            className="px-4 py-2 text-sm text-gray-600 border border-gray-300 rounded-md hover:bg-gray-50"
-          >
+          <Button variant="secondary" onClick={() => setConfirmDeleteId(null)}>
             Cancel
-          </button>
-          <button
-            onClick={handleDeleteConfirm}
-            className="px-4 py-2 text-sm text-white bg-red-500 hover:bg-red-600 rounded-md"
-          >
+          </Button>
+          <Button variant="danger" onClick={handleDeleteConfirm}>
             Delete
-          </button>
+          </Button>
         </div>
       </Modal>
     </div>

--- a/dataloom-frontend/src/Components/history/CheckpointsPanel.jsx
+++ b/dataloom-frontend/src/Components/history/CheckpointsPanel.jsx
@@ -72,13 +72,13 @@ const CheckpointsPanel = ({ projectId, checkpoints, onClose, onRevert, onCheckpo
                   </td>
                   <td className="py-3 px-4 text-center">
                     <div className="flex items-center justify-center gap-2">
-                      <Button onClick={() => onRevert(checkpoint.id)} className="text-sm">
+                      <Button size="sm" onClick={() => onRevert(checkpoint.id)}>
                         Revert
                       </Button>
                       <Button
+                        size="sm"
                         variant="danger"
                         onClick={() => setConfirmDeleteId(checkpoint.id)}
-                        className="text-sm"
                       >
                         Delete
                       </Button>


### PR DESCRIPTION
## Description

Replaced inline `<button>` implementations across transformation forms with the shared Button component from `src/Components/common/Button.jsx`.

### Changes Made
- Migrated Apply actions to use variant="primary".
- Migrated Cancel actions to use variant="secondary".
- Removed duplicated Tailwind button styles from individual forms.
- Standardized button appearance and behavior across all transformation forms.
- Improved maintainability by centralizing button styling in a single reusable component.

### Affected forms:
- Transformation forms:
  - `AdvQueryFilterForm.jsx`
  - `CastDataTypeForm.jsx`
  - `DropDuplicateForm.jsx`
  - `FilterForm.jsx`
  - `GroupByForm.jsx`
  - `MeltForm.jsx`
  - `PivotTableForm.jsx`
  - `SampleRowsForm.jsx`
  - `SortForm.jsx`
  - `StringReplaceForm.jsx`
  - `TrimWhitespaceForm.jsx`

- History forms:
  - `CheckpointsPanel.jsx`

Fixes #363 

## Type of Change

- [x] Refactor

## How Has This Been Tested?

Describe the tests you ran to verify your changes.

- [x] Existing tests pass
- [x] Manual testing

**Tested the following scenarios manuall:**
- Verified all transformation forms render correctly.
- Verified Apply buttons trigger their respective actions.
- Verified Cancel buttons close forms as expected.
- Verified button styling is consistent across all affected forms.
- Verified no visual regressions in form layouts.

## Screenshots (if applicable)
N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally