### PR TITLE
feat: add user profile page with email and password management

### DIFF
--- a/dataloom-backend/app/api/endpoints/auth.py
+++ b/dataloom-backend/app/api/endpoints/auth.py
@@ -98,3 +98,39 @@ async def reset_password(
         raise HTTPException(status_code=400, detail=str(e)) from e
 
     return {"message": "Password reset successful"}
+
+
+@router.patch("/me/email", response_model=schemas.UserResponse)
+def update_email(
+    payload: schemas.UpdateEmailRequest,
+    current_user: models.User = Depends(get_current_user),
+    db: Session = Depends(database.get_db),
+):
+    """Update the currently authenticated user's email."""
+    try:
+        return auth_service.update_user_email(db, current_user, payload.email)
+    except ValueError as e:
+        raise HTTPException(status_code=409, detail=str(e)) from e
+
+
+@router.patch("/me/password")
+def change_password(
+    payload: schemas.ChangePasswordRequest,
+    current_user: models.User = Depends(get_current_user),
+    db: Session = Depends(database.get_db),
+):
+    """Change the currently authenticated user's password."""
+    if len(payload.new_password) < 8:
+        raise HTTPException(status_code=422, detail="Password must be at least 8 characters")
+
+    try:
+        auth_service.change_user_password(
+            db,
+            current_user,
+            payload.current_password,
+            payload.new_password,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
+    return {"message": "Password changed successfully"}

--- a/dataloom-backend/app/main.py
+++ b/dataloom-backend/app/main.py
@@ -52,7 +52,7 @@ app.add_middleware(
     CORSMiddleware,
     allow_origins=get_settings().cors_origins,
     allow_credentials=True,
-    allow_methods=["GET", "POST", "PUT", "DELETE"],
+    allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE"],
     allow_headers=["*"],
     expose_headers=["Content-Disposition"],
 )

--- a/dataloom-backend/app/schemas.py
+++ b/dataloom-backend/app/schemas.py
@@ -421,3 +421,16 @@ class ResetPasswordRequest(BaseModel):
 
     token: str
     new_password: str
+
+
+class UpdateEmailRequest(BaseModel):
+    """Request body for updating the authenticated user's email."""
+
+    email: EmailStr
+
+
+class ChangePasswordRequest(BaseModel):
+    """Request body for changing the authenticated user's password."""
+
+    current_password: str
+    new_password: str

--- a/dataloom-backend/app/services/auth_service.py
+++ b/dataloom-backend/app/services/auth_service.py
@@ -153,3 +153,35 @@ def reset_user_password(db: Session, reset_token: models.PasswordResetToken, new
     reset_token.used = True
     db.commit()
     logger.info("Password reset successful for user: %s", user.id)
+
+
+def update_user_email(db: Session, user: models.User, new_email: str) -> models.User:
+    """Update a user's email address."""
+    existing_user = get_user_by_email(db, new_email)
+    if existing_user and existing_user.id != user.id:
+        raise ValueError("An account with this email already exists")
+
+    user.email = new_email
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+
+    logger.info("Updated email for user: %s", user.id)
+    return user
+
+
+def change_user_password(
+    db: Session,
+    user: models.User,
+    current_password: str,
+    new_password: str,
+) -> None:
+    """Change a user's password after validating the current password."""
+    if not verify_password(current_password, user.password_hash):
+        raise ValueError("Current password is incorrect")
+
+    user.password_hash = hash_password(new_password)
+    db.add(user)
+    db.commit()
+
+    logger.info("Password changed for user: %s", user.id)

--- a/dataloom-backend/tests/test_auth.py
+++ b/dataloom-backend/tests/test_auth.py
@@ -87,6 +87,90 @@ class TestCurrentUser:
         assert resp.status_code == 401
 
 
+class TestProfileManagement:
+    def test_update_email_success(self, client, test_user):
+        """Should update the authenticated user's email."""
+        response = client.patch("/auth/me/email", json={"email": "updated@test.com"})
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["email"] == "updated@test.com"
+        assert body["id"] == str(test_user.id)
+
+    def test_update_email_requires_auth(self, anon_client):
+        """Should reject email updates without authentication."""
+        response = anon_client.patch("/auth/me/email", json={"email": "updated@test.com"})
+
+        assert response.status_code == 401
+
+    def test_update_email_duplicate_returns_409(self, client, db):
+        """Should reject email updates when another account already uses the email."""
+        create_user(db, "existing@test.com", "password123")
+
+        response = client.patch("/auth/me/email", json={"email": "existing@test.com"})
+
+        assert response.status_code == 409
+
+    def test_update_email_invalid_returns_422(self, client):
+        """Should reject invalid email format."""
+        response = client.patch("/auth/me/email", json={"email": "not-an-email"})
+
+        assert response.status_code == 422
+
+    def test_change_password_success(self, client, test_user, db):
+        """Should change password when current password is valid."""
+        response = client.patch(
+            "/auth/me/password",
+            json={
+                "current_password": "testpassword",
+                "new_password": "newpassword123",
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.json()["message"] == "Password changed successfully"
+
+        db.refresh(test_user)
+        assert verify_password("newpassword123", test_user.password_hash)
+
+    def test_change_password_requires_auth(self, anon_client):
+        """Should reject password changes without authentication."""
+        response = anon_client.patch(
+            "/auth/me/password",
+            json={
+                "current_password": "testpassword",
+                "new_password": "newpassword123",
+            },
+        )
+
+        assert response.status_code == 401
+
+    def test_change_password_wrong_current_password_returns_400(self, client):
+        """Should reject password change when current password is incorrect."""
+        response = client.patch(
+            "/auth/me/password",
+            json={
+                "current_password": "wrongpassword",
+                "new_password": "newpassword123",
+            },
+        )
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Current password is incorrect"
+
+    def test_change_password_too_short_returns_422(self, client):
+        """Should reject new passwords shorter than 8 characters."""
+        response = client.patch(
+            "/auth/me/password",
+            json={
+                "current_password": "testpassword",
+                "new_password": "short",
+            },
+        )
+
+        assert response.status_code == 422
+
+
 class TestLogout:
     def test_logout_clears_cookie(self, anon_client):
         _signup(anon_client, "logout@test.com")

--- a/dataloom-frontend/src/App.jsx
+++ b/dataloom-frontend/src/App.jsx
@@ -12,6 +12,7 @@ import Homescreen from "./Components/Homescreen";
 import DataScreen from "./Components/DataScreen";
 import ForgotPasswordPage from "./pages/ForgotPasswordPage";
 import ResetPasswordPage from "./pages/ResetPasswordPage";
+import ProfilePage from "./pages/ProfilePage";
 
 /**
  * Root application component with routing, providers, and error boundary.
@@ -33,6 +34,7 @@ export default function App() {
                     <Route path="/" element={<Navigate to="/projects" replace />} />
                     <Route path="/projects" element={<Homescreen />} />
                     <Route path="/workspace/:projectId" element={<DataScreen />} />
+                    <Route path="/profile" element={<ProfilePage />} />
                     <Route path="*" element={<NotFoundPage />} />
                   </Route>
                 </Route>

--- a/dataloom-frontend/src/Components/Navbar.jsx
+++ b/dataloom-frontend/src/Components/Navbar.jsx
@@ -3,6 +3,7 @@ import { useProjectContext } from "../context/ProjectContext";
 import { useAuth } from "../context/AuthContext";
 import { ROUTES } from "../constants/routes";
 import DataLoomLogo from "./common/DataLoomLogo";
+import { LuCircleUserRound } from "react-icons/lu";
 
 const Navbar = () => {
   const location = useLocation();
@@ -42,19 +43,31 @@ const Navbar = () => {
             </div>
           )}
           {user && (
-            <span
-              className="hidden sm:inline text-sm text-gray-500 truncate max-w-[180px]"
-              title={user.email}
-            >
-              {user.email}
-            </span>
+            <Link to={ROUTES.profile} className="flex items-center justify-center gap-2">
+              <span
+                className="hidden sm:inline text-sm text-gray-500 truncate max-w-[180px]"
+                title={user.email}
+              >
+                {user.email}
+              </span>
+
+              <div
+                to={ROUTES.profile}
+                title="Profile"
+                aria-label="Profile"
+                className="flex items-center justify-center w-9 h-9 rounded-2xl border border-gray-300 text-gray-600 hover:bg-gray-50 hover:text-gray-900 transition-colors"
+              >
+                <LuCircleUserRound className="w-5 h-5" />
+              </div>
+            </Link>
           )}
           <button
             type="button"
             onClick={handleLogout}
             className="bg-white border border-gray-300 rounded-md text-gray-700 text-sm py-1.5 px-4 hover:bg-gray-50 transition-colors duration-150"
           >
-            Sign out
+            {" "}
+            Sign out{" "}
           </button>
         </div>
       </nav>

--- a/dataloom-frontend/src/Components/Navbar.jsx
+++ b/dataloom-frontend/src/Components/Navbar.jsx
@@ -10,6 +10,7 @@ const Navbar = () => {
   const navigate = useNavigate();
   const { projectName } = useProjectContext();
   const { user, logout } = useAuth();
+
   const isWorkspacePage = location.pathname.startsWith("/workspace/");
   const displayProjectName = projectName || "Untitled Project";
 
@@ -33,6 +34,7 @@ const Navbar = () => {
             <span className="text-base">DataLoom</span>
           </Link>
         </div>
+
         <div className="ml-auto flex items-center gap-3 min-w-0">
           {isWorkspacePage && (
             <div
@@ -42,6 +44,7 @@ const Navbar = () => {
               {displayProjectName}
             </div>
           )}
+
           {user && (
             <Link to={ROUTES.profile} className="flex items-center justify-center gap-2">
               <span
@@ -52,7 +55,6 @@ const Navbar = () => {
               </span>
 
               <div
-                to={ROUTES.profile}
                 title="Profile"
                 aria-label="Profile"
                 className="flex items-center justify-center w-9 h-9 rounded-2xl border border-gray-300 text-gray-600 hover:bg-gray-50 hover:text-gray-900 transition-colors"
@@ -61,13 +63,13 @@ const Navbar = () => {
               </div>
             </Link>
           )}
+
           <button
             type="button"
             onClick={handleLogout}
             className="bg-white border border-gray-300 rounded-md text-gray-700 text-sm py-1.5 px-4 hover:bg-gray-50 transition-colors duration-150"
           >
-            {" "}
-            Sign out{" "}
+            Sign out
           </button>
         </div>
       </nav>

--- a/dataloom-frontend/src/api/auth.ts
+++ b/dataloom-frontend/src/api/auth.ts
@@ -51,6 +51,37 @@ export const getCurrentUser = async (): Promise<User> => {
 };
 
 /**
+ * Update the authenticated user's email address.
+ * @param email - New email address.
+ * @returns Updated user object.
+ */
+export const updateEmail = async (email: string): Promise<User> => {
+  const response = await client.patch<User>("/auth/me/email", {
+    email,
+  });
+  console.log(response);
+  return response.data;
+};
+
+/**
+ * Change the authenticated user's password.
+ * @param currentPassword - Current account password.
+ * @param newPassword - New password to set.
+ * @returns Success response from the API.
+ */
+export const changePassword = async (
+  currentPassword: string,
+  newPassword: string,
+): Promise<{ message: string }> => {
+  const response = await client.patch<{ message: string }>("/auth/me/password", {
+    current_password: currentPassword,
+    new_password: newPassword,
+  });
+
+  return response.data;
+};
+
+/**
  * Request a password reset email for an existing account. If the email exists, the server sends a password reset link/token.
  * @param email - The account's email address.
  * @returns nothing.

--- a/dataloom-frontend/src/api/auth.ts
+++ b/dataloom-frontend/src/api/auth.ts
@@ -59,7 +59,6 @@ export const updateEmail = async (email: string): Promise<User> => {
   const response = await client.patch<User>("/auth/me/email", {
     email,
   });
-  console.log(response);
   return response.data;
 };
 

--- a/dataloom-frontend/src/constants/routes.js
+++ b/dataloom-frontend/src/constants/routes.js
@@ -14,6 +14,8 @@ export const ROUTES = {
   forgotPassword: "/forgot-password",
   /** Reset-password page path */
   resetPassword: "/reset-password",
+  /** User profile page path */
+  profile: "/profile",
   /** Workspace view path */
   workspace: "/workspace/:projectId",
   /**

--- a/dataloom-frontend/src/context/AuthContext.ts
+++ b/dataloom-frontend/src/context/AuthContext.ts
@@ -7,6 +7,7 @@ export interface AuthContextValue {
   signin: (email: string, password: string) => Promise<User>;
   signup: (email: string, password: string) => Promise<User>;
   logout: () => Promise<void>;
+  setUser: React.Dispatch<React.SetStateAction<User | null>>;
 }
 
 export const AuthContext = createContext<AuthContextValue | null>(null);

--- a/dataloom-frontend/src/context/AuthProvider.tsx
+++ b/dataloom-frontend/src/context/AuthProvider.tsx
@@ -42,7 +42,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, []);
 
   return (
-    <AuthContext.Provider value={{ user, loading, signin, signup, logout }}>
+    <AuthContext.Provider value={{ user, loading, signin, signup, logout, setUser }}>
       {children}
     </AuthContext.Provider>
   );

--- a/dataloom-frontend/src/pages/ProfilePage.jsx
+++ b/dataloom-frontend/src/pages/ProfilePage.jsx
@@ -1,0 +1,405 @@
+import { useEffect, useState } from "react";
+import {
+  CalendarDays,
+  Check,
+  CornerDownLeft,
+  KeyRound,
+  Mail,
+  Pencil,
+  UserRound,
+  X,
+} from "lucide-react";
+import { changePassword, getCurrentUser, updateEmail } from "../api/auth";
+import DataLoomLogo from "../Components/common/DataLoomLogo";
+import Toast from "../Components/common/Toast";
+import { useAuth } from "../context/AuthContext";
+
+const INPUT_CLASS =
+  "block w-full rounded-lg border border-gray-300 bg-white px-3.5 py-2.5 text-sm text-gray-900 " +
+  "placeholder-gray-400 focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent";
+
+const getErrorMessage = (error, fallback) => {
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "response" in error &&
+    typeof error.response === "object" &&
+    error.response !== null &&
+    "data" in error.response &&
+    typeof error.response.data === "object" &&
+    error.response.data !== null &&
+    "detail" in error.response.data &&
+    typeof error.response.data.detail === "string"
+  ) {
+    return error.response.data.detail;
+  }
+
+  return fallback;
+};
+
+const ProfilePage = () => {
+  const [user, setUser] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [toast, setToast] = useState(null);
+
+  const [isEditingEmail, setIsEditingEmail] = useState(false);
+  const [email, setEmail] = useState("");
+
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirm, setConfirm] = useState("");
+  const [showCurrentPassword, setShowCurrentPassword] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+
+  const [savingEmail, setSavingEmail] = useState(false);
+  const [submittingPassword, setSubmittingPassword] = useState(false);
+
+  const { setUser: setAuthUser } = useAuth();
+
+  useEffect(() => {
+    const fetchUser = async () => {
+      try {
+        const res = await getCurrentUser();
+        setUser(res);
+        setEmail(res.email);
+      } catch (error) {
+        setToast({
+          message: getErrorMessage(error, "Failed to load profile."),
+          type: "error",
+        });
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchUser();
+  }, []);
+
+  const formatDate = (value) => {
+    if (!value) return "—";
+
+    return new Date(value).toLocaleDateString("en-IN", {
+      day: "2-digit",
+      month: "short",
+      year: "numeric",
+    });
+  };
+
+  const handleEditEmail = () => {
+    setEmail(user?.email || "");
+    setIsEditingEmail(true);
+  };
+
+  const handleCancelEmailEdit = () => {
+    setEmail(user?.email || "");
+    setIsEditingEmail(false);
+  };
+
+  const handleSaveEmail = async () => {
+    const trimmedEmail = email.trim();
+
+    if (!trimmedEmail) {
+      setToast({ message: "Email is required.", type: "error" });
+      return;
+    }
+
+    setSavingEmail(true);
+
+    try {
+      const updatedUser = await updateEmail(trimmedEmail);
+      setUser(updatedUser);
+      setAuthUser(updatedUser);
+      setEmail(updatedUser.email);
+      setIsEditingEmail(false);
+
+      setToast({
+        message: "Email updated successfully.",
+        type: "success",
+      });
+    } catch (error) {
+      setToast({
+        message: getErrorMessage(error, "Failed to update email."),
+        type: "error",
+      });
+    } finally {
+      setSavingEmail(false);
+    }
+  };
+
+  const handlePasswordSubmit = async (event) => {
+    event.preventDefault();
+
+    if (!currentPassword) {
+      setToast({ message: "Current password is required.", type: "error" });
+      return;
+    }
+
+    if (password !== confirm) {
+      setToast({ message: "Passwords do not match.", type: "error" });
+      return;
+    }
+
+    if (password.length < 8) {
+      setToast({
+        message: "Password must be at least 8 characters.",
+        type: "error",
+      });
+      return;
+    }
+
+    setSubmittingPassword(true);
+
+    try {
+      const response = await changePassword(currentPassword, password);
+
+      setToast({
+        message: response.message || "Password changed successfully.",
+        type: "success",
+      });
+
+      setCurrentPassword("");
+      setPassword("");
+      setConfirm("");
+    } catch (error) {
+      setToast({
+        message: getErrorMessage(error, "Failed to change password."),
+        type: "error",
+      });
+    } finally {
+      setSubmittingPassword(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-slate-50 px-6 py-10">
+      <div className="mx-auto max-w-5xl">
+        <div className="mb-8 flex items-center gap-2">
+          <DataLoomLogo className="h-7 w-7" />
+          <span className="text-xl font-semibold text-slate-900">DataLoom</span>
+        </div>
+
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold tracking-tight text-slate-900">Profile</h1>
+          <p className="mt-1.5 text-sm text-gray-500">
+            View your account details and manage password settings.
+          </p>
+        </div>
+
+        {loading ? (
+          <div className="rounded-2xl border border-gray-200 bg-white p-6 text-sm text-gray-500 shadow-sm">
+            Loading profile...
+          </div>
+        ) : (
+          <div className="grid gap-6 lg:grid-cols-[1fr_1.2fr]">
+            <section className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+              <div className="flex items-center gap-4">
+                <div className="flex h-14 w-14 items-center justify-center rounded-full bg-accent/10 text-accent">
+                  <UserRound className="h-7 w-7" />
+                </div>
+
+                <div>
+                  <h2 className="text-lg font-semibold text-slate-900">Account details</h2>
+                  <p className="text-sm text-gray-500">Your profile details.</p>
+                </div>
+              </div>
+
+              <div className="mt-6 space-y-4">
+                <div className="rounded-xl border border-gray-100 bg-slate-50 p-4">
+                  <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-wide text-gray-400">
+                    <Mail className="h-4 w-4" />
+                    Email
+                  </div>
+
+                  {isEditingEmail ? (
+                    <div className="mt-2 space-y-2">
+                      <input
+                        type="email"
+                        required
+                        className={INPUT_CLASS}
+                        value={email}
+                        onChange={(event) => setEmail(event.target.value)}
+                        placeholder="you@example.com"
+                      />
+
+                      <div className="flex gap-2">
+                        <button
+                          type="button"
+                          onClick={handleSaveEmail}
+                          disabled={savingEmail}
+                          className="inline-flex items-center gap-1.5 rounded-lg bg-accent px-3 py-2 text-xs font-medium text-white transition-colors hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-60"
+                        >
+                          <Check className="h-3.5 w-3.5" />
+                          {savingEmail ? "Saving..." : "Save"}
+                        </button>
+
+                        <button
+                          type="button"
+                          onClick={handleCancelEmailEdit}
+                          disabled={savingEmail}
+                          className="inline-flex items-center gap-1.5 rounded-lg border border-gray-300 bg-white px-3 py-2 text-xs font-medium text-gray-700 transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60"
+                        >
+                          <X className="h-3.5 w-3.5" />
+                          Cancel
+                        </button>
+                      </div>
+                    </div>
+                  ) : (
+                    <div className="mt-1 flex items-center justify-between gap-3">
+                      <p className="break-all text-sm font-medium text-slate-900">
+                        {user?.email || "—"}
+                      </p>
+
+                      <button
+                        type="button"
+                        onClick={handleEditEmail}
+                        className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-gray-200 bg-white text-gray-500 transition-colors hover:border-accent hover:text-accent"
+                        aria-label="Edit email"
+                      >
+                        <Pencil className="h-4 w-4" />
+                      </button>
+                    </div>
+                  )}
+                </div>
+
+                <div className="rounded-xl border border-gray-100 bg-slate-50 p-4">
+                  <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-wide text-gray-400">
+                    <CalendarDays className="h-4 w-4" />
+                    Joined
+                  </div>
+                  <p className="mt-1 text-sm font-medium text-slate-900">
+                    {formatDate(user?.created_at)}
+                  </p>
+                </div>
+              </div>
+            </section>
+
+            <section className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+              <div className="flex items-center gap-4">
+                <div className="flex h-14 w-14 items-center justify-center rounded-full bg-accent/10 text-accent">
+                  <KeyRound className="h-7 w-7" />
+                </div>
+
+                <div>
+                  <h2 className="text-lg font-semibold text-slate-900">Change password</h2>
+                  <p className="text-sm text-gray-500">
+                    Enter your current password and set a new one.
+                  </p>
+                </div>
+              </div>
+
+              <form onSubmit={handlePasswordSubmit} className="mt-6">
+                <div className="space-y-4">
+                  <div>
+                    <label
+                      htmlFor="currentPassword"
+                      className="mb-1.5 block text-sm font-medium text-gray-700"
+                    >
+                      Current password
+                    </label>
+                    <div className="relative">
+                      <input
+                        id="currentPassword"
+                        type={showCurrentPassword ? "text" : "password"}
+                        autoComplete="current-password"
+                        required
+                        className={`${INPUT_CLASS} pr-16`}
+                        value={currentPassword}
+                        onChange={(event) => setCurrentPassword(event.target.value)}
+                        placeholder="Enter current password"
+                      />
+                      <button
+                        type="button"
+                        onClick={() => setShowCurrentPassword((value) => !value)}
+                        className="absolute inset-y-0 right-0 flex items-center pr-3 text-xs font-medium tracking-wide text-gray-400 transition-colors hover:text-gray-600"
+                      >
+                        {showCurrentPassword ? "Hide" : "Show"}
+                      </button>
+                    </div>
+                  </div>
+
+                  <div>
+                    <label
+                      htmlFor="password"
+                      className="mb-1.5 block text-sm font-medium text-gray-700"
+                    >
+                      New password
+                    </label>
+                    <div className="relative">
+                      <input
+                        id="password"
+                        type={showPassword ? "text" : "password"}
+                        autoComplete="new-password"
+                        required
+                        className={`${INPUT_CLASS} pr-16`}
+                        value={password}
+                        onChange={(event) => setPassword(event.target.value)}
+                        placeholder="Minimum 8 characters"
+                      />
+                      <button
+                        type="button"
+                        onClick={() => setShowPassword((value) => !value)}
+                        className="absolute inset-y-0 right-0 flex items-center pr-3 text-xs font-medium tracking-wide text-gray-400 transition-colors hover:text-gray-600"
+                      >
+                        {showPassword ? "Hide" : "Show"}
+                      </button>
+                    </div>
+                  </div>
+
+                  <div>
+                    <label
+                      htmlFor="confirm"
+                      className="mb-1.5 block text-sm font-medium text-gray-700"
+                    >
+                      Confirm password
+                    </label>
+                    <div className="relative">
+                      <input
+                        id="confirm"
+                        type={showConfirmPassword ? "text" : "password"}
+                        autoComplete="new-password"
+                        required
+                        className={`${INPUT_CLASS} pr-16`}
+                        value={confirm}
+                        onChange={(event) => setConfirm(event.target.value)}
+                        placeholder="Repeat your password"
+                      />
+                      <button
+                        type="button"
+                        onClick={() => setShowConfirmPassword((value) => !value)}
+                        className="absolute inset-y-0 right-0 flex items-center pr-3 text-xs font-medium tracking-wide text-gray-400 transition-colors hover:text-gray-600"
+                      >
+                        {showConfirmPassword ? "Hide" : "Show"}
+                      </button>
+                    </div>
+                  </div>
+                </div>
+
+                <button
+                  type="submit"
+                  disabled={submittingPassword}
+                  className="mt-6 flex w-full items-center justify-between rounded-lg bg-accent px-4 py-3 text-sm font-medium text-white transition-colors hover:bg-accent-hover focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  <span>{submittingPassword ? "Submitting..." : "Change password"}</span>
+                  {!submittingPassword && (
+                    <span className="flex h-6 w-6 items-center justify-center">
+                      <CornerDownLeft className="h-3.5 w-3.5" />
+                    </span>
+                  )}
+                </button>
+              </form>
+            </section>
+          </div>
+        )}
+      </div>
+
+      {toast && (
+        <div className="fixed bottom-4 right-4 z-50">
+          <Toast message={toast.message} type={toast.type} onDismiss={() => setToast(null)} />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ProfilePage;


### PR DESCRIPTION
## Description

Adds a user profile page that allows authenticated users to view and manage their account information.

### Features Added

- Added a dedicated `/profile` page
- Display authenticated user's email and account creation date
- Added inline email editing with save/cancel actions
- Added password change functionality with current password verification
- Added loading states for email updates and password changes
- Added success/error toast notifications for profile actions
- Added profile navigation from the navbar
- Synced AuthContext after profile updates to keep global user state consistent

### Backend Changes

- Added authenticated email update endpoint
- Added authenticated password change endpoint
- Added service-layer logic for updating email and changing passwords

### Testing

- Added backend test coverage for:

  - Email update success and failure scenarios
  - Password change success and failure scenarios
  - Authentication and validation checks

Fixes #365 

## Type of Change

- [x] New feature

## How Has This Been Tested?

- [x] Existing tests pass
- [x] New tests added
- [x] Manual testing

**Following scenarios were verified manually:**

- Verified profile page loads authenticated user data
- Verified email edit/save/cancel flow
- Verified password change flow
- Verified loading states during API requests
- Verified success and error toast notifications
- Verified navbar profile navigation
- Verified AuthContext updates immediately after email changes

## Screen Recording

https://github.com/user-attachments/assets/a6bbccc7-5e5e-4cd8-823f-aa75c0a4f711



## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally
