### PR TITLE
feat: add data profiling endpoints with type-aware column stats

### DIFF
--- a/dataloom-backend/app/api/endpoints/profiling.py
+++ b/dataloom-backend/app/api/endpoints/profiling.py
@@ -1,0 +1,79 @@
+"""Data profiling API endpoints.
+
+Three read-only routes over a project's current working copy: a dataset
+summary, a per-column profile, and a numeric correlation matrix. All are
+descriptive — quality assessment is out of scope here.
+"""
+
+import uuid
+
+import pandas as pd
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from app import models, schemas
+from app.api.dependencies import get_project_or_404
+from app.services import profiling_service
+from app.utils.logging import get_logger
+from app.utils.pandas_helpers import read_table_safe
+
+logger = get_logger(__name__)
+
+router = APIRouter()
+
+
+def _load_project_df(project: models.Project) -> pd.DataFrame:
+    """Read the project's working copy, redacting any path from error details.
+
+    ``read_table_safe`` embeds the absolute file path in its 404/500 details;
+    surface a generic message to the client instead, matching the transform
+    endpoint's handling.
+    """
+    try:
+        return read_table_safe(project.file_path)
+    except HTTPException as e:
+        if e.status_code == 404:
+            raise HTTPException(status_code=404, detail="Project data file not found") from e
+        logger.warning(
+            "Failed to read project file for profiling project_id=%s status=%s", project.project_id, e.status_code
+        )
+        raise HTTPException(status_code=e.status_code, detail="Could not read project data") from e
+
+
+@router.get("/{project_id}/profile/summary", response_model=schemas.DatasetSummaryResponse)
+async def get_dataset_summary(
+    project_id: uuid.UUID,
+    project: models.Project = Depends(get_project_or_404),
+):
+    """Return a top-level summary of the project's dataset."""
+    df = _load_project_df(project)
+    return profiling_service.dataset_summary(df)
+
+
+@router.get("/{project_id}/profile/column", response_model=schemas.ColumnProfileResponse)
+async def get_column_profile(
+    project_id: uuid.UUID,
+    column_name: str = Query(..., description="Name of the column to profile"),
+    project: models.Project = Depends(get_project_or_404),
+):
+    """Return a type-aware profile of a single column.
+
+    The column name is taken as a query parameter rather than a path segment so
+    that names containing slashes (or other reserved characters) route reliably
+    across servers and reverse proxies, which handle ``%2F`` in paths
+    inconsistently.
+    """
+    df = _load_project_df(project)
+    try:
+        return profiling_service.column_profile(df, column_name)
+    except KeyError as e:
+        raise HTTPException(status_code=404, detail=f"Column '{column_name}' not found") from e
+
+
+@router.get("/{project_id}/profile/correlation", response_model=schemas.CorrelationResponse)
+async def get_correlation_matrix(
+    project_id: uuid.UUID,
+    project: models.Project = Depends(get_project_or_404),
+):
+    """Return the pairwise Pearson correlation over numeric columns."""
+    df = _load_project_df(project)
+    return profiling_service.correlation_matrix(df)

--- a/dataloom-backend/app/main.py
+++ b/dataloom-backend/app/main.py
@@ -10,7 +10,7 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
-from app.api.endpoints import auth, projects, transformations, user_logs
+from app.api.endpoints import auth, profiling, projects, transformations, user_logs
 from app.config import get_settings
 from app.database import verify_database_connection
 from app.exceptions import AppException, app_exception_handler
@@ -68,6 +68,7 @@ app.add_exception_handler(AppException, app_exception_handler)
 app.include_router(auth.router, prefix="/auth", tags=["auth"])
 app.include_router(projects.router, prefix="/projects", tags=["projects"])
 app.include_router(transformations.router, prefix="/projects", tags=["transformations"])
+app.include_router(profiling.router, prefix="/projects", tags=["profiling"])
 app.include_router(user_logs.router, prefix="/logs", tags=["user_logs"])
 
 if __name__ == "__main__":

--- a/dataloom-backend/app/schemas.py
+++ b/dataloom-backend/app/schemas.py
@@ -328,6 +328,86 @@ class ProjectResponse(BaseModel):
     dtypes: dict[str, str] = {}
 
 
+# --- Profiling response schemas ---
+#
+# Descriptive profiling only (dataset/column/correlation). All ``*_percentage``
+# fields are 0–100. Type-specific column fields are optional: a numeric column
+# fills the numeric block and leaves the categorical/datetime blocks null, etc.
+
+
+class DatasetSummaryResponse(BaseModel):
+    """Top-level overview of a dataset."""
+
+    row_count: int
+    column_count: int
+    total_missing_cells: int
+    missing_cell_percentage: float
+    duplicate_row_count: int
+    memory_usage_bytes: int
+    dtype_counts: dict[str, int]
+    numeric_columns: list[str]
+    categorical_columns: list[str]
+    boolean_columns: list[str]
+    datetime_columns: list[str]
+
+
+class TopValue(BaseModel):
+    """A single value/count/percentage entry in a categorical column profile."""
+
+    value: str
+    count: int
+    percentage: float
+
+
+class ColumnProfileResponse(BaseModel):
+    """Type-aware profile of a single column."""
+
+    column: str
+    dtype: str
+    row_count: int
+    null_count: int
+    null_percentage: float
+    unique_count: int
+    unique_percentage: float
+    distribution: str
+
+    # Numeric block
+    mean: float | None = None
+    median: float | None = None
+    min: float | None = None
+    max: float | None = None
+    std: float | None = None
+    q1: float | None = None
+    q3: float | None = None
+    skew: float | None = None
+    zero_count: int | None = None
+    negative_count: int | None = None
+
+    # Categorical block
+    top_values: list[TopValue] | None = None
+    cardinality: int | None = None
+    dominant_value_percentage: float | None = None
+    rare_value_count: int | None = None
+
+    # Boolean block
+    true_count: int | None = None
+    false_count: int | None = None
+    true_percentage: float | None = None
+
+    # Datetime block
+    min_date: str | None = None
+    max_date: str | None = None
+    range_days: int | None = None
+    inferred_granularity: str | None = None
+
+
+class CorrelationResponse(BaseModel):
+    """Pairwise Pearson correlation over numeric columns."""
+
+    columns: list[str]
+    matrix: list[list[float | None]]
+
+
 # --- Other response schemas ---
 
 

--- a/dataloom-backend/app/services/profiling_service.py
+++ b/dataloom-backend/app/services/profiling_service.py
@@ -1,0 +1,344 @@
+"""Data profiling service: descriptive statistics over a DataFrame.
+
+Pure functions, no side effects — each takes a DataFrame and returns plain data;
+the endpoint layer handles I/O. This mirrors ``transformation_service``'s style.
+
+Scope is descriptive only ("what does this dataset look like?"). Quality
+assessment (issue flags, scores, remediation) is a separate, later concern and
+must not leak into these responses.
+
+Conventions:
+- All ``*_percentage`` fields are 0–100 (human-readable), never 0–1.
+- Output is JSON-safe: ``None`` is emitted in place of ``NaN``/``inf`` so the
+  values survive FastAPI serialization.
+"""
+
+import math
+from typing import Any
+
+import pandas as pd
+
+from app.utils.pandas_helpers import map_dtype
+
+# Number of most-frequent categorical values returned in a column profile.
+TOP_VALUES_LIMIT = 10
+# A value rarer than this share of non-null rows counts toward rare_value_count.
+RARE_VALUE_THRESHOLD = 0.01
+# unique_count / row_count at or above this marks a column high-cardinality.
+HIGH_CARDINALITY_RATIO = 0.9
+# |skew| below this (with mean≈median) is treated as roughly symmetric.
+NORMAL_SKEW_THRESHOLD = 0.5
+# Share of values equal to zero at or above this marks a column zero-inflated.
+ZERO_INFLATED_THRESHOLD = 0.5
+# String values treated as missing (matched case-insensitively after trimming).
+MISSING_VALUE_SENTINELS = frozenset({"", "na", "n/a", "null", "none", "nan", "unknown", "-"})
+
+
+def _coerce_sentinels(series: pd.Series) -> pd.Series:
+    """Replace missing-value sentinel strings with NaN for object columns.
+
+    Non-string columns are returned unchanged. Matching is case-insensitive and
+    ignores surrounding whitespace, so "N/A", " na ", and "null" all count as
+    missing alongside real NaN.
+    """
+    if map_dtype(series.dtype) != "str":
+        return series
+    normalized = series.map(lambda v: v.strip().lower() if isinstance(v, str) else v)
+    return series.where(~normalized.isin(MISSING_VALUE_SENTINELS), other=None)
+
+
+def _safe_number(value: Any) -> float | None:
+    """Coerce a numeric value to a JSON-safe float, mapping NaN/inf to None."""
+    if value is None:
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    if math.isnan(number) or math.isinf(number):
+        return None
+    return number
+
+
+def _round(value: Any, ndigits: int = 4) -> float | None:
+    """Round to a JSON-safe float, or None for missing/non-finite input."""
+    number = _safe_number(value)
+    return None if number is None else round(number, ndigits)
+
+
+def dataset_summary(df: pd.DataFrame) -> dict[str, Any]:
+    """Return a top-level overview of the whole dataset.
+
+    Args:
+        df: The DataFrame to summarize.
+
+    Returns:
+        Row/column counts, missing-cell totals, duplicate-row count, memory
+        usage, the dtype mix, and the per-shape column name lists. Each list
+        (numeric/categorical/boolean/datetime) groups columns by the
+        ``column_profile`` block they produce, so a name from a given list is
+        safe to feed back into ``column_profile`` expecting that shape.
+    """
+    row_count = int(df.shape[0])
+    column_count = int(df.shape[1])
+    total_cells = row_count * column_count
+    total_missing = 0
+    dtype_counts: dict[str, int] = {}
+    numeric_columns: list[str] = []
+    categorical_columns: list[str] = []
+    boolean_columns: list[str] = []
+    datetime_columns: list[str] = []
+    for column in df.columns:
+        label = map_dtype(df[column].dtype)
+        dtype_counts[label] = dtype_counts.get(label, 0) + 1
+        total_missing += int(_coerce_sentinels(df[column]).isna().sum())
+        if label in ("int", "float"):
+            numeric_columns.append(str(column))
+        elif label == "str":
+            categorical_columns.append(str(column))
+        elif label == "bool":
+            boolean_columns.append(str(column))
+        elif label == "datetime":
+            datetime_columns.append(str(column))
+
+    missing_percentage = (total_missing / total_cells * 100) if total_cells else 0.0
+
+    return {
+        "row_count": row_count,
+        "column_count": column_count,
+        "total_missing_cells": total_missing,
+        "missing_cell_percentage": round(missing_percentage, 4),
+        "duplicate_row_count": int(df.duplicated().sum()),
+        "memory_usage_bytes": int(df.memory_usage(deep=True).sum()),
+        "dtype_counts": dtype_counts,
+        "numeric_columns": numeric_columns,
+        "categorical_columns": categorical_columns,
+        "boolean_columns": boolean_columns,
+        "datetime_columns": datetime_columns,
+    }
+
+
+def detect_distribution(
+    *,
+    unique_count: int,
+    row_count: int,
+    null_count: int,
+    skew: float | None,
+    zero_fraction: float | None,
+) -> str:
+    """Label the shape of a column's values from already-computed inputs.
+
+    A lightweight, practical classifier — not a statistical test. All inputs are
+    derived elsewhere in the profile, so this adds no extra passes over the data.
+
+    Labels are checked in priority order, so the first match wins. Notably
+    ``binary`` (exactly two distinct values) is tested before ``zero-inflated``,
+    so a column like ``[0, 0, 0, 1]`` is labelled ``binary`` even when its
+    zero share meets ``ZERO_INFLATED_THRESHOLD``; zero-inflation is only
+    reported for columns with three or more distinct values.
+
+    Returns one of: constant, binary, zero-inflated, high-cardinality,
+    right-skewed, left-skewed, normal-ish, unknown.
+    """
+    non_null = row_count - null_count
+    if non_null <= 0:
+        return "unknown"
+    if unique_count == 1:
+        return "constant"
+    if unique_count == 2:
+        return "binary"
+    if zero_fraction is not None and zero_fraction >= ZERO_INFLATED_THRESHOLD:
+        return "zero-inflated"
+    if unique_count / non_null >= HIGH_CARDINALITY_RATIO:
+        return "high-cardinality"
+    if skew is not None:
+        if skew > NORMAL_SKEW_THRESHOLD:
+            return "right-skewed"
+        if skew < -NORMAL_SKEW_THRESHOLD:
+            return "left-skewed"
+        return "normal-ish"
+    return "unknown"
+
+
+def _infer_granularity(series: pd.Series) -> str | None:
+    """Infer a coarse datetime cadence (day/month/year/...) from spacing.
+
+    Uses the modal gap between sorted, de-duplicated timestamps. Returns None
+    when there are fewer than two distinct values to compare.
+    """
+    values = series.dropna().sort_values().unique()
+    if len(values) < 2:
+        return None
+    diffs = pd.Series(values).diff().dropna()
+    if diffs.empty:
+        return None
+    modal = diffs.mode()
+    if modal.empty:
+        return None
+    days = modal.iloc[0] / pd.Timedelta(days=1)
+    if days < 1:
+        return "sub-daily"
+    if days < 2:
+        return "day"
+    if days < 8:
+        return "week"
+    if days < 32:
+        return "month"
+    if days < 250:
+        return "quarter"
+    return "year"
+
+
+def _numeric_block(series: pd.Series) -> dict[str, Any]:
+    """Descriptive statistics for a numeric column."""
+    non_null = series.dropna()
+    return {
+        "mean": _round(series.mean()),
+        "median": _round(series.median()),
+        "min": _round(series.min()),
+        "max": _round(series.max()),
+        "std": _round(series.std()),
+        "q1": _round(series.quantile(0.25)),
+        "q3": _round(series.quantile(0.75)),
+        "skew": _round(series.skew()),
+        "zero_count": int((non_null == 0).sum()),
+        "negative_count": int((non_null < 0).sum()),
+    }
+
+
+def _categorical_block(series: pd.Series) -> dict[str, Any]:
+    """Frequency-based statistics for a categorical (str/bool) column."""
+    non_null = series.dropna()
+    counts = non_null.value_counts()
+    total = int(non_null.shape[0])
+
+    top_values = [
+        {
+            "value": str(value),
+            "count": int(count),
+            "percentage": round(count / total * 100, 4) if total else 0.0,
+        }
+        for value, count in counts.head(TOP_VALUES_LIMIT).items()
+    ]
+
+    dominant_percentage = round(int(counts.iloc[0]) / total * 100, 4) if total else None
+    rare_value_count = int((counts < max(total * RARE_VALUE_THRESHOLD, 1)).sum()) if total else 0
+
+    return {
+        "top_values": top_values,
+        "cardinality": int(counts.shape[0]),
+        "dominant_value_percentage": dominant_percentage,
+        "rare_value_count": rare_value_count,
+    }
+
+
+def _boolean_block(series: pd.Series) -> dict[str, Any]:
+    """True/false counts for a boolean column."""
+    non_null = series.dropna()
+    total = int(non_null.shape[0])
+    true_count = int(non_null.sum())  # bool sums as 1 per True
+    return {
+        "true_count": true_count,
+        "false_count": total - true_count,
+        "true_percentage": round(true_count / total * 100, 4) if total else None,
+    }
+
+
+def _datetime_block(series: pd.Series) -> dict[str, Any]:
+    """Range statistics for a datetime column."""
+    non_null = series.dropna()
+    if non_null.empty:
+        return {"min_date": None, "max_date": None, "range_days": None, "inferred_granularity": None}
+
+    min_date = non_null.min()
+    max_date = non_null.max()
+    range_days = int((max_date - min_date) / pd.Timedelta(days=1))
+    return {
+        "min_date": min_date.isoformat(),
+        "max_date": max_date.isoformat(),
+        "range_days": range_days,
+        "inferred_granularity": _infer_granularity(non_null),
+    }
+
+
+def column_profile(df: pd.DataFrame, column: str) -> dict[str, Any]:
+    """Return a type-aware profile of a single column.
+
+    Args:
+        df: The DataFrame containing the column.
+        column: Name of the column to profile.
+
+    Returns:
+        A common block (dtype, counts, null/unique percentages, distribution
+        label) merged with a type-specific block (numeric, categorical, or
+        datetime). The keys for the irrelevant blocks are simply absent.
+
+    Raises:
+        KeyError: If ``column`` is not present in ``df``.
+    """
+    if column not in df.columns:
+        raise KeyError(column)
+
+    series = _coerce_sentinels(df[column])
+    label = map_dtype(series.dtype)
+    row_count = int(series.shape[0])
+    null_count = int(series.isna().sum())
+    non_null_count = row_count - null_count
+    unique_count = int(series.nunique(dropna=True))
+
+    profile: dict[str, Any] = {
+        "column": column,
+        "dtype": label,
+        "row_count": row_count,
+        "null_count": null_count,
+        "null_percentage": round(null_count / row_count * 100, 4) if row_count else 0.0,
+        "unique_count": unique_count,
+        "unique_percentage": round(unique_count / non_null_count * 100, 4) if non_null_count else 0.0,
+    }
+
+    skew: float | None = None
+    zero_fraction: float | None = None
+    if label in ("int", "float"):
+        numeric_block = _numeric_block(series)
+        profile.update(numeric_block)
+        skew = numeric_block["skew"]
+        if non_null_count:
+            zero_fraction = float((series == 0).sum()) / non_null_count
+    elif label == "bool":
+        profile.update(_boolean_block(series))
+    elif label == "str":
+        profile.update(_categorical_block(series))
+    elif label == "datetime":
+        profile.update(_datetime_block(series))
+
+    profile["distribution"] = detect_distribution(
+        unique_count=unique_count,
+        row_count=row_count,
+        null_count=null_count,
+        skew=skew,
+        zero_fraction=zero_fraction,
+    )
+    return profile
+
+
+def correlation_matrix(df: pd.DataFrame) -> dict[str, Any]:
+    """Return the pairwise Pearson correlation over numeric columns.
+
+    Args:
+        df: The DataFrame to correlate.
+
+    Returns:
+        ``{"columns": [...], "matrix": [[...]]}`` where ``matrix[i][j]`` is the
+        correlation between ``columns[i]`` and ``columns[j]``. Non-finite cells
+        (e.g. a constant column has no variance) serialize to ``None``. With
+        fewer than two numeric columns the result is a 0×0 / 1×1 matrix, never
+        an error.
+    """
+    numeric_df = df.select_dtypes(include=["number"])
+    columns = [str(c) for c in numeric_df.columns]
+    if not columns:
+        return {"columns": [], "matrix": []}
+
+    corr = numeric_df.corr(method="pearson")
+    matrix = [[_round(corr.iat[i, j]) for j in range(len(columns))] for i in range(len(columns))]
+    return {"columns": columns, "matrix": matrix}

--- a/dataloom-backend/app/utils/pandas_helpers.py
+++ b/dataloom-backend/app/utils/pandas_helpers.py
@@ -54,7 +54,7 @@ def save_table_safe(df: pd.DataFrame, path: Path, options: TableWriteOptions | N
         raise HTTPException(status_code=500, detail=f"Error saving file: {str(e)}") from e
 
 
-def _map_dtype(dtype) -> str:
+def map_dtype(dtype) -> str:
     """Map a pandas dtype to a short label string."""
     kind = dtype.kind
     if kind == "i" or kind == "u":
@@ -81,7 +81,7 @@ def dataframe_to_response(df: pd.DataFrame) -> dict[str, Any]:
         Dict with columns (list of str), rows (list of lists), row_count, and dtypes.
     """
 
-    dtypes = {col: _map_dtype(dtype) for col, dtype in df.dtypes.items()}
+    dtypes = {col: map_dtype(dtype) for col, dtype in df.dtypes.items()}
     columns = df.columns.tolist()
 
     # Preserve null semantics: real empty strings stay "", while missing and

--- a/dataloom-backend/tests/test_dtypes.py
+++ b/dataloom-backend/tests/test_dtypes.py
@@ -3,7 +3,7 @@
 import pandas as pd
 import pytest
 
-from app.utils.pandas_helpers import _map_dtype, dataframe_to_response
+from app.utils.pandas_helpers import dataframe_to_response, map_dtype
 
 
 @pytest.fixture
@@ -19,22 +19,22 @@ def sample_df():
 
 class TestMapDtype:
     def test_int_column(self, sample_df):
-        assert _map_dtype(sample_df["age"].dtype) == "int"
+        assert map_dtype(sample_df["age"].dtype) == "int"
 
     def test_float_column(self):
         df = pd.DataFrame({"val": [1.5, 2.7]})
-        assert _map_dtype(df["val"].dtype) == "float"
+        assert map_dtype(df["val"].dtype) == "float"
 
     def test_str_column(self, sample_df):
-        assert _map_dtype(sample_df["name"].dtype) == "str"
+        assert map_dtype(sample_df["name"].dtype) == "str"
 
     def test_bool_column(self):
         df = pd.DataFrame({"val": [True, False]})
-        assert _map_dtype(df["val"].dtype) == "bool"
+        assert map_dtype(df["val"].dtype) == "bool"
 
     def test_datetime_column(self):
         df = pd.DataFrame({"val": pd.to_datetime(["2024-01-01", "2024-06-15"])})
-        assert _map_dtype(df["val"].dtype) == "datetime"
+        assert map_dtype(df["val"].dtype) == "datetime"
 
 
 class TestDataframeToResponse:

--- a/dataloom-backend/tests/test_profiling.py
+++ b/dataloom-backend/tests/test_profiling.py
@@ -1,0 +1,330 @@
+"""Tests for the data profiling service and endpoints."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from app.services import profiling_service as ps
+
+# --- Service: dataset_summary ---
+
+
+class TestDatasetSummary:
+    def test_basic_shape_and_counts(self):
+        df = pd.DataFrame(
+            {
+                "age": [30, 25, 35, 30],
+                "name": ["Alice", "Bob", "Charlie", "Alice"],
+            }
+        )
+        summary = ps.dataset_summary(df)
+        assert summary["row_count"] == 4
+        assert summary["column_count"] == 2
+        assert summary["duplicate_row_count"] == 1
+        assert summary["dtype_counts"] == {"int": 1, "str": 1}
+        assert summary["numeric_columns"] == ["age"]
+        assert summary["categorical_columns"] == ["name"]
+        assert summary["memory_usage_bytes"] > 0
+
+    def test_bool_and_datetime_columns_are_grouped_by_shape(self):
+        df = pd.DataFrame(
+            {
+                "age": [30, 25],
+                "name": ["Alice", "Bob"],
+                "flag": [True, False],
+                "joined": pd.to_datetime(["2020-01-01", "2020-02-01"]),
+            }
+        )
+        summary = ps.dataset_summary(df)
+        # Booleans get their own block in column_profile, so they must not be
+        # reported as categorical; datetimes are no longer dropped entirely.
+        assert summary["numeric_columns"] == ["age"]
+        assert summary["categorical_columns"] == ["name"]
+        assert summary["boolean_columns"] == ["flag"]
+        assert summary["datetime_columns"] == ["joined"]
+
+    def test_missing_cells_as_percentage_0_to_100(self):
+        df = pd.DataFrame({"a": [1, None], "b": [None, None]})  # 3 of 4 cells missing
+        summary = ps.dataset_summary(df)
+        assert summary["total_missing_cells"] == 3
+        assert summary["missing_cell_percentage"] == 75.0
+
+    def test_empty_dataframe(self):
+        summary = ps.dataset_summary(pd.DataFrame())
+        assert summary["row_count"] == 0
+        assert summary["column_count"] == 0
+        assert summary["missing_cell_percentage"] == 0.0
+        assert summary["duplicate_row_count"] == 0
+
+
+# --- Service: column_profile ---
+
+
+class TestColumnProfileCommon:
+    def test_unknown_column_raises_keyerror(self):
+        with pytest.raises(KeyError):
+            ps.column_profile(pd.DataFrame({"a": [1]}), "missing")
+
+    def test_null_and_unique_percentages(self):
+        df = pd.DataFrame({"x": [1, 1, None, 2]})
+        profile = ps.column_profile(df, "x")
+        assert profile["null_count"] == 1
+        assert profile["null_percentage"] == 25.0
+        # unique_percentage is over non-null rows: 2 distinct / 3 non-null
+        assert profile["unique_count"] == 2
+        assert profile["unique_percentage"] == pytest.approx(66.6667, abs=1e-3)
+
+
+class TestMissingValueSentinels:
+    def test_string_sentinels_count_as_null(self):
+        # "N/A" and "null" are missing-value sentinels, not real categories.
+        df = pd.DataFrame({"c": ["a", "N/A", "null", "b"]})
+        profile = ps.column_profile(df, "c")
+        assert profile["null_count"] == 2
+        assert profile["null_percentage"] == 50.0
+
+    def test_sentinels_counted_in_dataset_summary(self):
+        df = pd.DataFrame({"c": ["a", "N/A", "unknown"]})
+        summary = ps.dataset_summary(df)
+        assert summary["total_missing_cells"] == 2
+
+    def test_matching_ignores_case_and_whitespace_but_not_real_values(self):
+        # " Na " is a sentinel; "nathan" is a real value that merely starts with "na".
+        df = pd.DataFrame({"c": [" Na ", "nathan", "b"]})
+        profile = ps.column_profile(df, "c")
+        assert profile["null_count"] == 1
+        assert profile["unique_count"] == 2  # "nathan" and "b" survive
+
+
+class TestColumnProfileNumeric:
+    def test_numeric_stats(self):
+        df = pd.DataFrame({"v": [1, 2, 3, 4]})
+        profile = ps.column_profile(df, "v")
+        assert profile["dtype"] == "int"
+        assert profile["mean"] == 2.5
+        assert profile["median"] == 2.5
+        assert profile["min"] == 1.0
+        assert profile["max"] == 4.0
+        assert profile["q1"] == 1.75
+        assert profile["q3"] == 3.25
+        assert profile["std"] is not None
+
+    def test_zero_and_negative_counts(self):
+        df = pd.DataFrame({"v": [-2, -1, 0, 0, 3, None]})
+        profile = ps.column_profile(df, "v")
+        assert profile["zero_count"] == 2
+        assert profile["negative_count"] == 2
+
+    def test_constant_column_is_json_safe_and_labeled_constant(self):
+        df = pd.DataFrame({"v": [5, 5, 5, 5]})
+        profile = ps.column_profile(df, "v")
+        # A constant column has zero spread; values stay finite (JSON-safe).
+        assert profile["std"] == 0.0
+        assert profile["distribution"] == "constant"
+
+    def test_too_few_values_skew_is_none(self):
+        # skew needs 3+ values; with 2 it is NaN and must serialize as None.
+        df = pd.DataFrame({"v": [1, 2]})
+        profile = ps.column_profile(df, "v")
+        assert profile["skew"] is None
+
+    def test_right_skewed_distribution(self):
+        df = pd.DataFrame({"v": [1, 1, 1, 1, 1, 2, 3, 50]})
+        profile = ps.column_profile(df, "v")
+        assert profile["distribution"] == "right-skewed"
+
+    def test_zero_inflated_distribution(self):
+        df = pd.DataFrame({"v": [0, 0, 0, 0, 0, 0, 1, 7]})
+        profile = ps.column_profile(df, "v")
+        assert profile["distribution"] == "zero-inflated"
+
+    def test_all_null_numeric_column(self):
+        df = pd.DataFrame({"v": pd.Series([None, None, None], dtype="float64")})
+        profile = ps.column_profile(df, "v")
+        assert profile["null_percentage"] == 100.0
+        assert profile["mean"] is None
+        assert profile["distribution"] == "unknown"
+
+
+class TestColumnProfileBoolean:
+    def test_boolean_block_counts(self):
+        df = pd.DataFrame({"flag": pd.Series([True, True, False, None], dtype="boolean")})
+        profile = ps.column_profile(df, "flag")
+        assert profile["dtype"] == "bool"
+        assert profile["true_count"] == 2
+        assert profile["false_count"] == 1
+        # true_percentage is over non-null rows: 2 of 3
+        assert profile["true_percentage"] == pytest.approx(66.6667, abs=1e-3)
+
+    def test_boolean_omits_categorical_block(self):
+        df = pd.DataFrame({"flag": [True, False, True]})
+        profile = ps.column_profile(df, "flag")
+        assert "top_values" not in profile
+        assert "cardinality" not in profile
+
+
+class TestColumnProfileCategorical:
+    def test_top_values_and_cardinality(self):
+        df = pd.DataFrame({"c": ["a", "a", "a", "b", "c"]})
+        profile = ps.column_profile(df, "c")
+        assert profile["dtype"] == "str"
+        assert profile["cardinality"] == 3
+        assert profile["top_values"][0] == {"value": "a", "count": 3, "percentage": 60.0}
+        assert profile["dominant_value_percentage"] == 60.0
+
+    def test_binary_distribution(self):
+        df = pd.DataFrame({"c": ["yes", "no", "yes", "no"]})
+        profile = ps.column_profile(df, "c")
+        assert profile["distribution"] == "binary"
+
+    def test_high_cardinality_distribution(self):
+        df = pd.DataFrame({"c": [f"id-{i}" for i in range(20)]})
+        profile = ps.column_profile(df, "c")
+        assert profile["distribution"] == "high-cardinality"
+
+
+class TestColumnProfileDatetime:
+    def test_datetime_range_and_granularity(self):
+        df = pd.DataFrame({"d": pd.to_datetime(["2020-01-01", "2020-01-02", "2020-01-03"])})
+        profile = ps.column_profile(df, "d")
+        assert profile["dtype"] == "datetime"
+        assert profile["min_date"].startswith("2020-01-01")
+        assert profile["max_date"].startswith("2020-01-03")
+        assert profile["range_days"] == 2
+        assert profile["inferred_granularity"] == "day"
+
+    def test_single_datetime_value_has_no_granularity(self):
+        df = pd.DataFrame({"d": pd.to_datetime(["2020-01-01"])})
+        profile = ps.column_profile(df, "d")
+        assert profile["range_days"] == 0
+        assert profile["inferred_granularity"] is None
+
+
+# --- Service: correlation_matrix ---
+
+
+class TestCorrelationMatrix:
+    def test_pairwise_correlation(self):
+        df = pd.DataFrame({"a": [1, 2, 3, 4], "b": [2, 4, 6, 8], "name": ["w", "x", "y", "z"]})
+        result = ps.correlation_matrix(df)
+        assert result["columns"] == ["a", "b"]  # str column excluded
+        assert result["matrix"][0][0] == 1.0
+        assert result["matrix"][0][1] == pytest.approx(1.0)  # perfectly correlated
+
+    def test_zero_numeric_columns(self):
+        df = pd.DataFrame({"name": ["a", "b"]})
+        assert ps.correlation_matrix(df) == {"columns": [], "matrix": []}
+
+    def test_single_numeric_column(self):
+        df = pd.DataFrame({"a": [1, 2, 3]})
+        result = ps.correlation_matrix(df)
+        assert result["columns"] == ["a"]
+        assert result["matrix"] == [[1.0]]
+
+    def test_constant_column_correlation_is_none_not_nan(self):
+        df = pd.DataFrame({"a": [1, 2, 3], "const": [5, 5, 5]})
+        result = ps.correlation_matrix(df)
+        # corr against a zero-variance column is NaN -> must be None.
+        const_idx = result["columns"].index("const")
+        other_idx = result["columns"].index("a")
+        assert result["matrix"][const_idx][other_idx] is None
+
+
+# --- Service: detect_distribution helper ---
+
+
+class TestDetectDistribution:
+    def test_normal_ish(self):
+        label = ps.detect_distribution(unique_count=50, row_count=100, null_count=0, skew=0.1, zero_fraction=0.0)
+        assert label == "normal-ish"
+
+    def test_left_skewed(self):
+        label = ps.detect_distribution(unique_count=50, row_count=100, null_count=0, skew=-1.2, zero_fraction=0.0)
+        assert label == "left-skewed"
+
+    def test_all_null_is_unknown(self):
+        label = ps.detect_distribution(unique_count=0, row_count=5, null_count=5, skew=None, zero_fraction=None)
+        assert label == "unknown"
+
+
+# --- JSON safety guard across the whole profile ---
+
+
+def test_profile_emits_no_nan_or_inf():
+    """Every numeric leaf must be JSON-safe (None, not NaN/inf)."""
+    df = pd.DataFrame({"v": [1.0, np.inf, np.nan, 5.0], "const": [1, 1, 1, 1]})
+    profile = ps.column_profile(df, "const")
+    for value in profile.values():
+        if isinstance(value, float):
+            assert np.isfinite(value)
+
+
+# --- Endpoints ---
+
+
+@pytest.fixture
+def project(client, sample_csv):
+    """Upload the sample CSV and return the created project payload."""
+    with open(sample_csv, "rb") as f:
+        response = client.post(
+            "/projects/upload",
+            files={"file": ("test.csv", f, "text/csv")},
+            data={"projectName": "Profiling", "projectDescription": "fixture"},
+        )
+    assert response.status_code == 200, response.text
+    return response.json()
+
+
+@pytest.fixture
+def project_id(project):
+    return project["project_id"]
+
+
+class TestProfilingEndpoints:
+    def test_summary(self, client, project_id):
+        response = client.get(f"/projects/{project_id}/profile/summary")
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["row_count"] == 4  # sample_csv has a duplicate row
+        assert body["duplicate_row_count"] == 1
+        assert "age" in body["numeric_columns"]
+
+    def test_column_profile(self, client, project_id):
+        response = client.get(f"/projects/{project_id}/profile/column", params={"column_name": "age"})
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["column"] == "age"
+        assert body["dtype"] == "int"
+        assert body["mean"] is not None
+
+    def test_unknown_column_returns_404(self, client, project_id):
+        response = client.get(f"/projects/{project_id}/profile/column", params={"column_name": "nope"})
+        assert response.status_code == 404
+        assert "not found" in response.json()["detail"].lower()
+
+    def test_column_name_with_slash_is_profiled_not_404(self, client, tmp_path):
+        csv_path = tmp_path / "slash.csv"
+        csv_path.write_text("revenue/cost,n\n1.5,a\n2.5,b\n")
+        with open(csv_path, "rb") as f:
+            upload = client.post(
+                "/projects/upload",
+                files={"file": ("slash.csv", f, "text/csv")},
+                data={"projectName": "Slash", "projectDescription": "fixture"},
+            )
+        assert upload.status_code == 200, upload.text
+        pid = upload.json()["project_id"]
+        # A query param carries the literal slash, so routing never depends on
+        # how the server treats %2F in the path.
+        response = client.get(f"/projects/{pid}/profile/column", params={"column_name": "revenue/cost"})
+        assert response.status_code == 200, response.text
+        assert response.json()["column"] == "revenue/cost"
+
+    def test_correlation(self, client, project_id):
+        response = client.get(f"/projects/{project_id}/profile/correlation")
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["columns"] == ["age"]  # only numeric column in the sample
+
+    def test_requires_auth(self, anon_client, project_id):
+        response = anon_client.get(f"/projects/{project_id}/profile/summary")
+        assert response.status_code == 401

--- a/dataloom-frontend/src/api/index.js
+++ b/dataloom-frontend/src/api/index.js
@@ -14,3 +14,4 @@ export {
 export { getLogs, getCheckpoints, deleteCheckpoint } from "./logs";
 export { transformProject, groupByTransform, undoLastTransformation } from "./transforms";
 export { signup, signin, logout, getCurrentUser } from "./auth";
+export { getDatasetSummary, getColumnProfile, getCorrelationMatrix } from "./profiling";

--- a/dataloom-frontend/src/api/profiling.ts
+++ b/dataloom-frontend/src/api/profiling.ts
@@ -1,0 +1,111 @@
+/**
+ * API functions for data profiling (dataset summary, column profiles, correlation).
+ * @module api/profiling
+ */
+import client from "./client";
+
+/** Top-level overview of a dataset. All percentages are 0–100. */
+export interface DatasetSummary {
+  row_count: number;
+  column_count: number;
+  total_missing_cells: number;
+  missing_cell_percentage: number;
+  duplicate_row_count: number;
+  memory_usage_bytes: number;
+  dtype_counts: Record<string, number>;
+  numeric_columns: string[];
+  categorical_columns: string[];
+  boolean_columns: string[];
+  datetime_columns: string[];
+}
+
+/** A value/count/percentage entry in a categorical column profile. */
+export interface TopValue {
+  value: string;
+  count: number;
+  percentage: number;
+}
+
+/**
+ * Type-aware profile of a single column. The common fields are always present;
+ * the numeric, categorical, and datetime blocks are populated per dtype and
+ * null otherwise.
+ */
+export interface ColumnProfile {
+  column: string;
+  dtype: string;
+  row_count: number;
+  null_count: number;
+  null_percentage: number;
+  unique_count: number;
+  unique_percentage: number;
+  distribution: string;
+
+  // Numeric block
+  mean: number | null;
+  median: number | null;
+  min: number | null;
+  max: number | null;
+  std: number | null;
+  q1: number | null;
+  q3: number | null;
+  skew: number | null;
+  zero_count: number | null;
+  negative_count: number | null;
+
+  // Categorical block
+  top_values: TopValue[] | null;
+  cardinality: number | null;
+  dominant_value_percentage: number | null;
+  rare_value_count: number | null;
+
+  // Boolean block
+  true_count: number | null;
+  false_count: number | null;
+  true_percentage: number | null;
+
+  // Datetime block
+  min_date: string | null;
+  max_date: string | null;
+  range_days: number | null;
+  inferred_granularity: string | null;
+}
+
+/** Pairwise Pearson correlation over numeric columns; cells may be null. */
+export interface Correlation {
+  columns: string[];
+  matrix: (number | null)[][];
+}
+
+/**
+ * Fetch a top-level summary of the project's dataset.
+ * @param projectId - The project ID.
+ * @returns Row/column counts, missing cells, duplicate rows, and dtype mix.
+ */
+export const getDatasetSummary = async (projectId: string): Promise<DatasetSummary> => {
+  const response = await client.get<DatasetSummary>(`/projects/${projectId}/profile/summary`);
+  return response.data;
+};
+
+/**
+ * Fetch a type-aware profile of a single column.
+ * @param projectId - The project ID.
+ * @param columnName - The column to profile.
+ * @returns The column profile.
+ */
+export const getColumnProfile = async (projectId: string, columnName: string): Promise<ColumnProfile> => {
+  const response = await client.get<ColumnProfile>(`/projects/${projectId}/profile/column`, {
+    params: { column_name: columnName },
+  });
+  return response.data;
+};
+
+/**
+ * Fetch the pairwise correlation matrix over the project's numeric columns.
+ * @param projectId - The project ID.
+ * @returns The numeric column names and their correlation matrix.
+ */
+export const getCorrelationMatrix = async (projectId: string): Promise<Correlation> => {
+  const response = await client.get<Correlation>(`/projects/${projectId}/profile/correlation`);
+  return response.data;
+};


### PR DESCRIPTION
## Description

- add profiling service with dataset summary, column profile, and correlation matrix
- expose three read-only GET routes under /projects/{id}/profile (summary, column, correlation)
- treat missing-value sentinels (N/A, null, unknown, -, empty) as nulls, case-insensitively
- branch column profiles by type: numeric (incl. zero/negative counts), categorical, boolean, datetime
- label value distributions (constant, binary, skewed, zero-inflated, high-cardinality, normal-ish)
- export map_dtype helper so profiling dtype labels match the table API
- add thin TypeScript profiling API client and re-export it from the api barrel

Fixes #358

## Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

- [X] Existing tests pass
- [X] New tests added
- [X] Manual testing

## Screenshots

## Checklist

- [X] My code follows the project's style guidelines
- [X] I have performed a self-review
- [X] I have added/updated documentation as needed
- [X] My changes generate no new warnings
- [X] Tests pass locally
