### PR TITLE
fix: remove leftover console.log from fetchCheckpoints

### DIFF
--- a/dataloom-frontend/src/Components/MenuNavbar.jsx
+++ b/dataloom-frontend/src/Components/MenuNavbar.jsx
@@ -79,7 +79,6 @@ const MenuNavbar = ({ projectId }) => {
   const fetchCheckpoints = useCallback(async () => {
     try {
       const checkpointsResponse = await getCheckpoints(projectId);
-      console.log(checkpointsResponse);
       if (Array.isArray(checkpointsResponse)) {
         setCheckpoints(checkpointsResponse);
       } else if (checkpointsResponse?.id) {


### PR DESCRIPTION
## Description
A leftover `console.log(checkpointsResponse)` debug statement in `fetchCheckpoints` (`MenuNavbar.jsx`) was logging checkpoint response data to the browser console in production. This was introduced during development of the checkpoint history feature and was never removed.

Fixes #370 

## Type of Change
- [x] Bug fix

## How Has This Been Tested?
- [x] Existing tests pass
- [x] Manual testing

**Following scenarios were tested manually:**
- Opened Checkpoints panel and verified no console output

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally