### PR TITLE
feat: add account deletion option to user profile page

### DIFF
--- a/dataloom-backend/alembic/versions/c2f56609809e_add_cascade_delete_to_password_reset_.py
+++ b/dataloom-backend/alembic/versions/c2f56609809e_add_cascade_delete_to_password_reset_.py
@@ -1,0 +1,42 @@
+"""add cascade delete to password reset tokens
+
+Revision ID: c2f56609809e
+Revises: 3185ec76af85
+Create Date: 2026-06-15 17:38:22.422079
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c2f56609809e"
+down_revision: str | Sequence[str] | None = "3185ec76af85"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+FK_NAME = "password_reset_tokens_user_id_fkey"
+
+
+def upgrade() -> None:
+    op.drop_constraint(FK_NAME, "password_reset_tokens", type_="foreignkey")
+    op.create_foreign_key(
+        FK_NAME,
+        "password_reset_tokens",
+        "users",
+        ["user_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(FK_NAME, "password_reset_tokens", type_="foreignkey")
+    op.create_foreign_key(
+        FK_NAME,
+        "password_reset_tokens",
+        "users",
+        ["user_id"],
+        ["id"],
+    )

--- a/dataloom-backend/app/api/endpoints/auth.py
+++ b/dataloom-backend/app/api/endpoints/auth.py
@@ -1,6 +1,7 @@
 """Authentication API endpoints: signup, signin, logout, and current user."""
 
-from fastapi import APIRouter, Depends, HTTPException, Response
+from fastapi import APIRouter, Body, Depends, HTTPException, Response
+from sqlalchemy.exc import SQLAlchemyError
 from sqlmodel import Session
 
 from app import database, models, schemas
@@ -134,3 +135,32 @@ def change_password(
         raise HTTPException(status_code=400, detail=str(e)) from e
 
     return {"message": "Password changed successfully"}
+
+
+@router.delete("/me")
+def delete_account(
+    response: Response,
+    payload: schemas.DeleteAccountRequest = Body(...),
+    current_user: models.User = Depends(get_current_user),
+    db: Session = Depends(database.get_db),
+):
+    """Delete the currently authenticated user's account and all associated data."""
+    try:
+        auth_service.delete_user_account(db, current_user, payload.password)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except SQLAlchemyError as e:
+        raise HTTPException(
+            status_code=500,
+            detail="Failed to delete account. Please try again later.",
+        ) from e
+
+    settings = get_settings()
+    response.delete_cookie(
+        key=ACCESS_TOKEN_COOKIE,
+        path="/",
+        httponly=True,
+        secure=settings.cookie_secure,
+        samesite="lax",
+    )
+    return {"message": "Account deleted successfully"}

--- a/dataloom-backend/app/models.py
+++ b/dataloom-backend/app/models.py
@@ -41,7 +41,9 @@ class PasswordResetToken(SQLModel, table=True):
     __tablename__ = "password_reset_tokens"
 
     id: int | None = Field(default=None, primary_key=True)
-    user_id: uuid_mod.UUID = Field(sa_column=Column(sa.Uuid, sa.ForeignKey("users.id"), nullable=False))
+    user_id: uuid_mod.UUID = Field(
+        sa_column=Column(sa.Uuid, sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+    )
     token_hash: str = Field(sa_column=Column(sa.String(64), nullable=False, index=True))
     expires_at: datetime = Field(sa_column=Column(DateTime(timezone=True), nullable=False))
     used: bool = Field(

--- a/dataloom-backend/app/schemas.py
+++ b/dataloom-backend/app/schemas.py
@@ -526,3 +526,9 @@ class ChangePasswordRequest(BaseModel):
 
     current_password: str
     new_password: str
+
+
+class DeleteAccountRequest(BaseModel):
+    """Request body for deleting the authenticated user's account."""
+
+    password: str

--- a/dataloom-backend/app/services/auth_service.py
+++ b/dataloom-backend/app/services/auth_service.py
@@ -7,10 +7,12 @@ from datetime import UTC, datetime, timedelta
 
 import bcrypt
 import jwt
+from sqlalchemy.exc import SQLAlchemyError
 from sqlmodel import Session
 
 from app import models
 from app.config import get_settings
+from app.services.file_service import delete_project_files
 from app.utils.email import send_reset_email
 from app.utils.logging import get_logger
 
@@ -185,3 +187,49 @@ def change_user_password(
     db.commit()
 
     logger.info("Password changed for user: %s", user.id)
+
+
+def delete_user_account(db: Session, user: models.User, password: str) -> None:
+    """Delete a user account along with all owned projects, logs, checkpoints, and files.
+
+    The database deletion (logs, checkpoints, projects, user) happens in a single
+    transaction so a failure partway through leaves no orphaned records. File
+    cleanup happens after the transaction commits, since filesystem operations
+    cannot be rolled back alongside the DB transaction.
+
+    Args:
+        db: Database session.
+        user: The user to delete.
+        password: The user's current password, required for confirmation.
+
+    Raises:
+        ValueError: If the provided password is incorrect.
+    """
+    if not verify_password(password, user.password_hash):
+        raise ValueError("Incorrect password")
+
+    project_ids = [project.project_id for project in user.projects]
+    file_paths = [project.file_path for project in user.projects]
+
+    try:
+        db.query(models.ProjectChangeLog).filter(models.ProjectChangeLog.project_id.in_(project_ids)).delete(
+            synchronize_session=False
+        )
+        db.query(models.Checkpoint).filter(models.Checkpoint.project_id.in_(project_ids)).delete(
+            synchronize_session=False
+        )
+        db.query(models.Project).filter(models.Project.project_id.in_(project_ids)).delete(synchronize_session=False)
+        db.delete(user)
+        db.commit()
+    except SQLAlchemyError:
+        db.rollback()
+        logger.exception("Failed to delete user account database records: id=%s", user.id)
+        raise
+
+    for file_path in file_paths:
+        try:
+            delete_project_files(file_path)
+        except OSError:
+            logger.exception("Failed to delete project files during account deletion: file_path=%s", file_path)
+
+    logger.info("Deleted user account: id=%s, projects_deleted=%d", user.id, len(project_ids))

--- a/dataloom-backend/tests/test_auth.py
+++ b/dataloom-backend/tests/test_auth.py
@@ -170,6 +170,38 @@ class TestProfileManagement:
 
         assert response.status_code == 422
 
+    def test_delete_account_success(self, client, test_user, db):
+        response = client.request(
+            "DELETE",
+            "/auth/me",
+            json={"password": "testpassword"},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["message"] == "Account deleted successfully"
+
+        deleted_user = db.query(models.User).filter(models.User.id == test_user.id).first()
+        assert deleted_user is None
+
+    def test_delete_account_requires_auth(self, anon_client):
+        response = anon_client.request(
+            "DELETE",
+            "/auth/me",
+            json={"password": "testpassword"},
+        )
+
+        assert response.status_code == 401
+
+    def test_delete_account_wrong_password_returns_400(self, client):
+        response = client.request(
+            "DELETE",
+            "/auth/me",
+            json={"password": "wrongpassword"},
+        )
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Incorrect password"
+
 
 class TestLogout:
     def test_logout_clears_cookie(self, anon_client):

--- a/dataloom-frontend/src/api/auth.ts
+++ b/dataloom-frontend/src/api/auth.ts
@@ -98,3 +98,16 @@ export const forgotPassword = async (email: string): Promise<void> => {
 export const resetPassword = async (token: string, newPassword: string): Promise<void> => {
   await client.post("/auth/reset-password", { token, new_password: newPassword });
 };
+
+/**
+ * Delete the authenticated user's account and all associated data.
+ * Requires the current password for confirmation.
+ * @param password - The account's current password.
+ * @returns Success response from the API.
+ */
+export const deleteAccount = async (password: string): Promise<{ message: string }> => {
+  const response = await client.delete<{ message: string }>("/auth/me", {
+    data: { password },
+  });
+  return response.data;
+};

--- a/dataloom-frontend/src/pages/ProfilePage.jsx
+++ b/dataloom-frontend/src/pages/ProfilePage.jsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import {
+  AlertTriangle,
   CalendarDays,
   Check,
   CornerDownLeft,
@@ -9,10 +11,12 @@ import {
   UserRound,
   X,
 } from "lucide-react";
-import { changePassword, getCurrentUser, updateEmail } from "../api/auth";
+import { changePassword, deleteAccount, getCurrentUser, updateEmail } from "../api/auth";
+import Button from "../Components/common/Button";
 import DataLoomLogo from "../Components/common/DataLoomLogo";
-import Toast from "../Components/common/Toast";
+import Modal from "../Components/common/Modal";
 import { useAuth } from "../context/AuthContext";
+import { useToast } from "../context/ToastContext";
 
 const INPUT_CLASS =
   "block w-full rounded-lg border border-gray-300 bg-white px-3.5 py-2.5 text-sm text-gray-900 " +
@@ -40,7 +44,6 @@ const getErrorMessage = (error, fallback) => {
 const ProfilePage = () => {
   const [user, setUser] = useState(null);
   const [loading, setLoading] = useState(true);
-  const [toast, setToast] = useState(null);
 
   const [isEditingEmail, setIsEditingEmail] = useState(false);
   const [email, setEmail] = useState("");
@@ -55,7 +58,13 @@ const ProfilePage = () => {
   const [savingEmail, setSavingEmail] = useState(false);
   const [submittingPassword, setSubmittingPassword] = useState(false);
 
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [deletePassword, setDeletePassword] = useState("");
+  const [deletingAccount, setDeletingAccount] = useState(false);
+
   const { setUser: setAuthUser } = useAuth();
+  const { showToast } = useToast();
+  const navigate = useNavigate();
 
   useEffect(() => {
     const fetchUser = async () => {
@@ -64,17 +73,14 @@ const ProfilePage = () => {
         setUser(res);
         setEmail(res.email);
       } catch (error) {
-        setToast({
-          message: getErrorMessage(error, "Failed to load profile."),
-          type: "error",
-        });
+        showToast(getErrorMessage(error, "Failed to load profile."), "error");
       } finally {
         setLoading(false);
       }
     };
 
     fetchUser();
-  }, []);
+  }, [showToast]);
 
   const formatDate = (value) => {
     if (!value) return "—";
@@ -100,7 +106,7 @@ const ProfilePage = () => {
     const trimmedEmail = email.trim();
 
     if (!trimmedEmail) {
-      setToast({ message: "Email is required.", type: "error" });
+      showToast("Email is required.", "error");
       return;
     }
 
@@ -112,16 +118,9 @@ const ProfilePage = () => {
       setAuthUser(updatedUser);
       setEmail(updatedUser.email);
       setIsEditingEmail(false);
-
-      setToast({
-        message: "Email updated successfully.",
-        type: "success",
-      });
+      showToast("Email updated successfully.", "success");
     } catch (error) {
-      setToast({
-        message: getErrorMessage(error, "Failed to update email."),
-        type: "error",
-      });
+      showToast(getErrorMessage(error, "Failed to update email."), "error");
     } finally {
       setSavingEmail(false);
     }
@@ -131,20 +130,17 @@ const ProfilePage = () => {
     event.preventDefault();
 
     if (!currentPassword) {
-      setToast({ message: "Current password is required.", type: "error" });
+      showToast("Current password is required.", "error");
       return;
     }
 
     if (password !== confirm) {
-      setToast({ message: "Passwords do not match.", type: "error" });
+      showToast("Passwords do not match.", "error");
       return;
     }
 
     if (password.length < 8) {
-      setToast({
-        message: "Password must be at least 8 characters.",
-        type: "error",
-      });
+      showToast("Password must be at least 8 characters.", "error");
       return;
     }
 
@@ -152,22 +148,37 @@ const ProfilePage = () => {
 
     try {
       const response = await changePassword(currentPassword, password);
-
-      setToast({
-        message: response.message || "Password changed successfully.",
-        type: "success",
-      });
+      showToast(response.message || "Password changed successfully.", "success");
 
       setCurrentPassword("");
       setPassword("");
       setConfirm("");
     } catch (error) {
-      setToast({
-        message: getErrorMessage(error, "Failed to change password."),
-        type: "error",
-      });
+      showToast(getErrorMessage(error, "Failed to change password."), "error");
     } finally {
       setSubmittingPassword(false);
+    }
+  };
+
+  const handleDeleteAccount = async () => {
+    if (!deletePassword) {
+      showToast("Password is required.", "error");
+      return;
+    }
+
+    setDeletingAccount(true);
+
+    try {
+      await deleteAccount(deletePassword);
+      showToast("Account deleted successfully.", "success");
+      setShowDeleteModal(false);
+      setDeletePassword("");
+      setAuthUser(null);
+      navigate("/signin");
+    } catch (error) {
+      showToast(getErrorMessage(error, "Failed to delete account."), "error");
+    } finally {
+      setDeletingAccount(false);
     }
   };
 
@@ -223,25 +234,26 @@ const ProfilePage = () => {
                       />
 
                       <div className="flex gap-2">
-                        <button
+                        <Button
                           type="button"
+                          size="sm"
                           onClick={handleSaveEmail}
                           disabled={savingEmail}
-                          className="inline-flex items-center gap-1.5 rounded-lg bg-accent px-3 py-2 text-xs font-medium text-white transition-colors hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-60"
                         >
                           <Check className="h-3.5 w-3.5" />
                           {savingEmail ? "Saving..." : "Save"}
-                        </button>
+                        </Button>
 
-                        <button
+                        <Button
                           type="button"
+                          size="sm"
+                          variant="secondary"
                           onClick={handleCancelEmailEdit}
                           disabled={savingEmail}
-                          className="inline-flex items-center gap-1.5 rounded-lg border border-gray-300 bg-white px-3 py-2 text-xs font-medium text-gray-700 transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60"
                         >
                           <X className="h-3.5 w-3.5" />
                           Cancel
-                        </button>
+                        </Button>
                       </div>
                     </div>
                   ) : (
@@ -270,6 +282,29 @@ const ProfilePage = () => {
                   <p className="mt-1 text-sm font-medium text-slate-900">
                     {formatDate(user?.created_at)}
                   </p>
+                </div>
+
+                <div className="rounded-xl border border-red-100 bg-red-50 p-4">
+                  <div className="flex items-start gap-3">
+                    <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-red-600" />
+                    <div>
+                      <h3 className="text-sm font-semibold text-red-700">Delete account</h3>
+                      <p className="mt-1 text-sm text-red-600">
+                        Permanently delete your account and all associated projects, checkpoints,
+                        and logs. This action cannot be undone.
+                      </p>
+
+                      <Button
+                        type="button"
+                        variant="danger"
+                        size="sm"
+                        className="mt-4"
+                        onClick={() => setShowDeleteModal(true)}
+                      >
+                        Delete account
+                      </Button>
+                    </div>
+                  </div>
                 </div>
               </div>
             </section>
@@ -375,10 +410,10 @@ const ProfilePage = () => {
                   </div>
                 </div>
 
-                <button
+                <Button
                   type="submit"
                   disabled={submittingPassword}
-                  className="mt-6 flex w-full items-center justify-between rounded-lg bg-accent px-4 py-3 text-sm font-medium text-white transition-colors hover:bg-accent-hover focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60"
+                  className="mt-6 flex w-full items-center justify-between rounded-lg px-4 py-3 bg-accent hover:bg-accent-hover focus:ring-accent"
                 >
                   <span>{submittingPassword ? "Submitting..." : "Change password"}</span>
                   {!submittingPassword && (
@@ -386,18 +421,71 @@ const ProfilePage = () => {
                       <CornerDownLeft className="h-3.5 w-3.5" />
                     </span>
                   )}
-                </button>
+                </Button>
               </form>
             </section>
           </div>
         )}
-      </div>
 
-      {toast && (
-        <div className="fixed bottom-4 right-4 z-50">
-          <Toast message={toast.message} type={toast.type} onDismiss={() => setToast(null)} />
-        </div>
-      )}
+        <Modal
+          isOpen={showDeleteModal}
+          onClose={() => {
+            setShowDeleteModal(false);
+            setDeletePassword("");
+          }}
+          title="Delete Account"
+        >
+          <p className="mb-4 text-sm text-gray-700">
+            This will permanently delete your account and all associated projects, checkpoints, and
+            logs. This action cannot be undone.
+          </p>
+
+          <label
+            htmlFor="deletePassword"
+            className="mb-1.5 block text-sm font-medium text-gray-700"
+          >
+            Confirm your password
+          </label>
+          <input
+            id="deletePassword"
+            type="password"
+            autoComplete="current-password"
+            className={INPUT_CLASS}
+            value={deletePassword}
+            onChange={(event) => setDeletePassword(event.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                handleDeleteAccount();
+              }
+            }}
+            placeholder="Enter your password"
+          />
+
+          <div className="mt-6 flex justify-end gap-2">
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() => {
+                setShowDeleteModal(false);
+                setDeletePassword("");
+              }}
+              disabled={deletingAccount}
+            >
+              Cancel
+            </Button>
+
+            <Button
+              type="button"
+              variant="danger"
+              onClick={handleDeleteAccount}
+              disabled={deletingAccount}
+            >
+              {deletingAccount ? "Deleting..." : "Delete account"}
+            </Button>
+          </div>
+        </Modal>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Description
The user profile page (added in #366) allowed updating email and password but had no way for users to delete their account. This PR adds a "Delete account" section to the profile page with a confirmation modal requiring password re-entry, and a backend `DELETE /auth/me` endpoint that removes the user along with all owned projects, their logs, checkpoints, and files.

Fixes #372 

## Type of Change
- [x] New feature

## How Has This Been Tested?
- [x] Existing tests pass
- [x] New tests added
- [x] Manual testing

**Following scenarios were tested manually:**
- Created a user with multiple projects, checkpoints, and logs; deleted the account and verified all DB records and project files are removed
- Attempted deletion with incorrect password — returns 400 with appropriate error
- After deletion, auth cookie is cleared and user is redirected to sign-in

## Screen Recording

https://github.com/user-attachments/assets/89d2fdaa-dcad-415c-bed3-8711b6143900



## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally