### PR TITLE
feat: allow users to rename a project

### DIFF
--- a/dataloom-backend/app/api/endpoints/projects.py
+++ b/dataloom-backend/app/api/endpoints/projects.py
@@ -25,6 +25,7 @@ from app.services.project_service import (
     delete_project,
     get_last_change_log,
     get_recent_projects,
+    rename_project,
 )
 from app.services.transformation_service import apply_logged_transformation
 from app.utils.file_formats import TableWriteOptions, get_format, get_format_for_extension
@@ -131,6 +132,33 @@ def recent_projects(
         )
         for p in projects
     ]
+
+
+@router.patch("/{project_id}/rename", response_model=schemas.ProjectResponse)
+async def rename_project_endpoint(
+    payload: schemas.RenameProjectRequest,
+    db: Session = Depends(database.get_db),
+    project: models.Project = Depends(get_project_or_404),
+):
+    """Rename a project."""
+    try:
+        updated_project = rename_project(db, project, payload.name)
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e)) from e
+
+    df = read_table_safe(updated_project.file_path)
+    total_rows = len(df)
+    resp = dataframe_to_response(df)
+    return {
+        "filename": updated_project.name,
+        "file_path": updated_project.file_path,
+        "project_id": updated_project.project_id,
+        "page": 1,
+        "page_size": total_rows,
+        "total_rows": total_rows,
+        "total_pages": 1,
+        **resp,
+    }
 
 
 @router.post("/{project_id}/save", response_model=schemas.ProjectResponse)

--- a/dataloom-backend/app/api/endpoints/projects.py
+++ b/dataloom-backend/app/api/endpoints/projects.py
@@ -134,7 +134,7 @@ def recent_projects(
     ]
 
 
-@router.patch("/{project_id}/rename", response_model=schemas.ProjectResponse)
+@router.patch("/{project_id}/rename", response_model=schemas.RenameProjectResponse)
 async def rename_project_endpoint(
     payload: schemas.RenameProjectRequest,
     db: Session = Depends(database.get_db),
@@ -146,18 +146,10 @@ async def rename_project_endpoint(
     except ValueError as e:
         raise HTTPException(status_code=422, detail=str(e)) from e
 
-    df = read_table_safe(updated_project.file_path)
-    total_rows = len(df)
-    resp = dataframe_to_response(df)
     return {
+        "project_id": str(updated_project.project_id),
         "filename": updated_project.name,
         "file_path": updated_project.file_path,
-        "project_id": updated_project.project_id,
-        "page": 1,
-        "page_size": total_rows,
-        "total_rows": total_rows,
-        "total_pages": 1,
-        **resp,
     }
 
 

--- a/dataloom-backend/app/schemas.py
+++ b/dataloom-backend/app/schemas.py
@@ -532,3 +532,19 @@ class DeleteAccountRequest(BaseModel):
     """Request body for deleting the authenticated user's account."""
 
     password: str
+
+
+class RenameProjectRequest(BaseModel):
+    """Request body for renaming a project."""
+
+    name: str
+
+
+class RenameProjectResponse(BaseModel):
+    """Response for renaming a project."""
+
+    project_id: str
+    filename: str
+    file_path: str
+
+    model_config = ConfigDict(from_attributes=True)

--- a/dataloom-backend/app/schemas.py
+++ b/dataloom-backend/app/schemas.py
@@ -537,7 +537,7 @@ class DeleteAccountRequest(BaseModel):
 class RenameProjectRequest(BaseModel):
     """Request body for renaming a project."""
 
-    name: str
+    name: str = Field(..., min_length=1, max_length=255)
 
 
 class RenameProjectResponse(BaseModel):

--- a/dataloom-backend/app/services/project_service.py
+++ b/dataloom-backend/app/services/project_service.py
@@ -256,3 +256,29 @@ def delete_checkpoint(db: Session, checkpoint_id: uuid.UUID, project_id: uuid.UU
     db.delete(checkpoint)
     db.flush()
     logger.info("Deleted checkpoint: id=%s, project_id=%s", checkpoint_id, project_id)
+
+
+def rename_project(db: Session, project: models.Project, new_name: str) -> models.Project:
+    """Rename a project.
+
+    Args:
+        db: Database session.
+        project: The project to rename.
+        new_name: The new project name (must be non-empty after trimming).
+
+    Returns:
+        The updated Project model instance.
+
+    Raises:
+        ValueError: If new_name is empty or whitespace-only.
+    """
+    trimmed_name = new_name.strip()
+    if not trimmed_name:
+        raise ValueError("Project name cannot be empty")
+
+    project.name = trimmed_name
+    db.add(project)
+    db.commit()
+    db.refresh(project)
+    logger.info("Renamed project: id=%s, new_name=%s", project.project_id, trimmed_name)
+    return project

--- a/dataloom-backend/tests/test_rename_project.py
+++ b/dataloom-backend/tests/test_rename_project.py
@@ -1,0 +1,156 @@
+"""Tests for project renaming."""
+
+import uuid
+
+import pandas as pd
+import pytest
+
+from app.services.project_service import create_project, rename_project
+
+
+class TestRenameProject:
+    def test_rename_project_updates_name(self, db, test_user):
+        """rename_project should update the project's name."""
+        project = create_project(
+            db,
+            name="Original Name",
+            file_path="/tmp/test.csv",
+            description="",
+            owner_id=test_user.id,
+        )
+
+        updated = rename_project(db, project, "New Name")
+
+        assert updated.name == "New Name"
+
+    def test_rename_project_trims_whitespace(self, db, test_user):
+        """rename_project should trim leading/trailing whitespace."""
+        project = create_project(
+            db,
+            name="Original Name",
+            file_path="/tmp/test.csv",
+            description="",
+            owner_id=test_user.id,
+        )
+
+        updated = rename_project(db, project, "  Trimmed Name  ")
+
+        assert updated.name == "Trimmed Name"
+
+    def test_rename_project_rejects_empty_name(self, db, test_user):
+        """rename_project should raise ValueError for an empty name."""
+        project = create_project(
+            db,
+            name="Original Name",
+            file_path="/tmp/test.csv",
+            description="",
+            owner_id=test_user.id,
+        )
+
+        with pytest.raises(ValueError, match="cannot be empty"):
+            rename_project(db, project, "")
+
+    def test_rename_project_rejects_whitespace_only_name(self, db, test_user):
+        """rename_project should raise ValueError for a whitespace-only name."""
+        project = create_project(
+            db,
+            name="Original Name",
+            file_path="/tmp/test.csv",
+            description="",
+            owner_id=test_user.id,
+        )
+
+        with pytest.raises(ValueError, match="cannot be empty"):
+            rename_project(db, project, "    ")
+
+    def test_rename_project_endpoint_returns_updated_name(self, client, db, test_user, tmp_path):
+        """PATCH /projects/{project_id}/rename should persist and return the new name."""
+        original_path = tmp_path / "rename_test.csv"
+        pd.DataFrame({"a": [1, 2]}).to_csv(original_path, index=False)
+
+        project = create_project(
+            db,
+            name="Old Name",
+            file_path=str(original_path),
+            description="",
+            owner_id=test_user.id,
+        )
+
+        response = client.patch(
+            f"/projects/{project.project_id}/rename",
+            json={"name": "Renamed Project"},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["filename"] == "Renamed Project"
+
+    def test_rename_project_endpoint_does_not_read_project_file(self, client, db, test_user):
+        """PATCH /projects/{project_id}/rename should not require the CSV file to exist."""
+        project = create_project(
+            db,
+            name="Old Name",
+            file_path="/tmp/nonexistent_rename_test.csv",
+            description="",
+            owner_id=test_user.id,
+        )
+
+        response = client.patch(
+            f"/projects/{project.project_id}/rename",
+            json={"name": "Renamed Project"},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["filename"] == "Renamed Project"
+        assert response.json()["project_id"] == str(project.project_id)
+        assert response.json()["file_path"] == project.file_path
+
+    def test_rename_project_endpoint_rejects_empty_name(self, client, db, test_user, tmp_path):
+        """PATCH /projects/{project_id}/rename should return 422 for an empty name."""
+        original_path = tmp_path / "rename_test_empty.csv"
+        pd.DataFrame({"a": [1, 2]}).to_csv(original_path, index=False)
+
+        project = create_project(
+            db,
+            name="Old Name",
+            file_path=str(original_path),
+            description="",
+            owner_id=test_user.id,
+        )
+
+        response = client.patch(
+            f"/projects/{project.project_id}/rename",
+            json={"name": "   "},
+        )
+
+        assert response.status_code == 422
+
+    def test_rename_project_endpoint_rejects_too_long_name(self, client, db, test_user, tmp_path):
+        """PATCH /projects/{project_id}/rename should return 422 for an oversized name."""
+        original_path = tmp_path / "rename_test_long.csv"
+        pd.DataFrame({"a": [1, 2]}).to_csv(original_path, index=False)
+
+        project = create_project(
+            db,
+            name="Old Name",
+            file_path=str(original_path),
+            description="",
+            owner_id=test_user.id,
+        )
+
+        response = client.patch(
+            f"/projects/{project.project_id}/rename",
+            json={"name": "a" * 256},
+        )
+
+        assert response.status_code == 422
+
+    def test_rename_nonexistent_project_returns_404(self, client):
+        """PATCH /projects/{project_id}/rename should return 404 for a nonexistent project."""
+        nonexistent_id = uuid.uuid4()
+
+        response = client.patch(
+            f"/projects/{nonexistent_id}/rename",
+            json={"name": "New Name"},
+        )
+
+        assert response.status_code == 404

--- a/dataloom-frontend/src/Components/Navbar.jsx
+++ b/dataloom-frontend/src/Components/Navbar.jsx
@@ -28,7 +28,6 @@ const Navbar = () => {
   };
 
   const handleCancelEdit = () => {
-    setEditedName(projectName || "");
     setIsEditingName(false);
   };
 

--- a/dataloom-frontend/src/Components/Navbar.jsx
+++ b/dataloom-frontend/src/Components/Navbar.jsx
@@ -1,18 +1,81 @@
+import { useState } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import { useProjectContext } from "../context/ProjectContext";
 import { useAuth } from "../context/AuthContext";
+import { useToast } from "../context/ToastContext";
 import { ROUTES } from "../constants/routes";
+import { renameProject } from "../api/projects";
 import DataLoomLogo from "./common/DataLoomLogo";
-import { LuCircleUserRound } from "react-icons/lu";
+import { LuCircleUserRound, LuCheck, LuX, LuLogOut } from "react-icons/lu";
 
 const Navbar = () => {
   const location = useLocation();
   const navigate = useNavigate();
-  const { projectName } = useProjectContext();
+  const { projectId, projectName, setProjectInfo } = useProjectContext();
   const { user, logout } = useAuth();
+  const { showToast } = useToast();
+
+  const [isEditingName, setIsEditingName] = useState(false);
+  const [editedName, setEditedName] = useState("");
+  const [savingName, setSavingName] = useState(false);
 
   const isWorkspacePage = location.pathname.startsWith("/workspace/");
   const displayProjectName = projectName || "Untitled Project";
+
+  const handleStartEdit = () => {
+    setEditedName(projectName || "");
+    setIsEditingName(true);
+  };
+
+  const handleCancelEdit = () => {
+    setEditedName(projectName || "");
+    setIsEditingName(false);
+  };
+
+  const handleSaveName = async () => {
+    const trimmed = editedName.trim();
+
+    if (!trimmed) {
+      showToast("Project name cannot be empty.", "error");
+      return;
+    }
+
+    if (!projectId) {
+      showToast("Project not found.", "error");
+      return;
+    }
+
+    if (trimmed === projectName) {
+      setIsEditingName(false);
+      return;
+    }
+
+    setSavingName(true);
+
+    try {
+      await renameProject(projectId, trimmed);
+      setProjectInfo(projectId, trimmed);
+      setIsEditingName(false);
+      showToast("Project renamed successfully.", "success");
+    } catch (error) {
+      console.error("Failed to rename project:", error);
+      showToast("Failed to rename project.", "error");
+    } finally {
+      setSavingName(false);
+    }
+  };
+
+  const handleNameKeyDown = (event) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      handleSaveName();
+    }
+
+    if (event.key === "Escape") {
+      event.preventDefault();
+      handleCancelEdit();
+    }
+  };
 
   const handleLogout = async () => {
     try {
@@ -26,40 +89,70 @@ const Navbar = () => {
     <header role="banner">
       <nav
         aria-label="Main navigation"
-        className="bg-white border-b border-gray-200 flex items-center h-14 px-4 md:px-10"
+        className="flex h-14 items-center border-b border-gray-200 bg-white px-3 sm:px-4 md:px-10"
       >
-        <div className="text-gray-900 font-semibold flex items-center">
+        <div className="flex shrink-0 items-center font-semibold text-gray-900">
           <Link to="/projects" className="flex items-center gap-2">
-            <DataLoomLogo className="w-5 h-5" />
-            <span className="text-base">DataLoom</span>
+            <DataLoomLogo className="h-5 w-5 shrink-0" />
+            <span className="text-base font-semibold">DataLoom</span>
           </Link>
         </div>
 
-        <div className="ml-auto flex items-center gap-3 min-w-0">
-          {isWorkspacePage && (
-            <div
-              className="text-gray-700 font-medium text-base min-w-0 max-w-[50vw] md:max-w-md mr-2 truncate"
-              title={displayProjectName}
-            >
-              {displayProjectName}
-            </div>
-          )}
+        <div className="ml-auto flex min-w-0 items-center gap-2 sm:gap-3">
+          {isWorkspacePage &&
+            (isEditingName ? (
+              <div className="flex min-w-0 items-center gap-1">
+                <input
+                  type="text"
+                  value={editedName}
+                  onChange={(event) => setEditedName(event.target.value)}
+                  onKeyDown={handleNameKeyDown}
+                  className="h-9 w-[86px] min-w-0 rounded-md border border-gray-300 px-2 text-sm font-medium text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 sm:w-56 md:w-80"
+                  autoFocus
+                  disabled={savingName}
+                  aria-label="Project name"
+                />
+
+                <button
+                  type="button"
+                  onClick={handleSaveName}
+                  disabled={savingName}
+                  className="flex shrink-0 p-1 items-center justify-center rounded-md text-green-600 transition-colors hover:bg-green-50 disabled:cursor-not-allowed disabled:opacity-60"
+                  aria-label="Save project name"
+                >
+                  <LuCheck className="h-4 w-4" />
+                </button>
+
+                <button
+                  type="button"
+                  onClick={handleCancelEdit}
+                  disabled={savingName}
+                  className="flex shrink-0 p-1 items-center justify-center rounded-md text-gray-500 transition-colors hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-60"
+                  aria-label="Cancel rename"
+                >
+                  <LuX className="h-4 w-4 text-red-500" />
+                </button>
+              </div>
+            ) : (
+              <button
+                type="button"
+                onClick={handleStartEdit}
+                className="min-w-0 max-w-[92px] truncate rounded-md px-1.5 py-1 text-left text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 hover:text-gray-900 sm:max-w-[220px] sm:text-base md:max-w-md"
+                title={`${displayProjectName} — click to rename`}
+                aria-label="Rename project"
+              >
+                {displayProjectName}
+              </button>
+            ))}
 
           {user && (
-            <Link to={ROUTES.profile} className="flex items-center justify-center gap-2">
-              <span
-                className="hidden sm:inline text-sm text-gray-500 truncate max-w-[180px]"
-                title={user.email}
-              >
-                {user.email}
-              </span>
-
+            <Link to={ROUTES.profile} className="shrink-0">
               <div
                 title="Profile"
                 aria-label="Profile"
-                className="flex items-center justify-center w-9 h-9 rounded-2xl border border-gray-300 text-gray-600 hover:bg-gray-50 hover:text-gray-900 transition-colors"
+                className="flex h-9 w-9 items-center justify-center rounded-full border border-gray-300 text-gray-600 transition-colors hover:bg-gray-50 hover:text-gray-900"
               >
-                <LuCircleUserRound className="w-5 h-5" />
+                <LuCircleUserRound className="h-5 w-5" />
               </div>
             </Link>
           )}
@@ -67,9 +160,11 @@ const Navbar = () => {
           <button
             type="button"
             onClick={handleLogout}
-            className="bg-white border border-gray-300 rounded-md text-gray-700 text-sm py-1.5 px-4 hover:bg-gray-50 transition-colors duration-150"
+            className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md border border-gray-300 bg-white text-gray-700 transition-colors hover:bg-gray-50 sm:w-auto sm:px-4 sm:text-sm"
+            aria-label="Sign out"
           >
-            Sign out
+            <LuLogOut className="h-4 w-4 sm:hidden" />
+            <span className="hidden sm:inline">Sign out</span>
           </button>
         </div>
       </nav>

--- a/dataloom-frontend/src/api/projects.js
+++ b/dataloom-frontend/src/api/projects.js
@@ -118,3 +118,14 @@ export const deleteProject = async (projectId) => {
   const response = await client.delete(`/projects/${projectId}`);
   return response.data;
 };
+
+/**
+ * Rename a project.
+ * @param {string} projectId - The project ID.
+ * @param {string} name - The new project name.
+ * @returns {Promise<Object>} Updated project response.
+ */
+export const renameProject = async (projectId, name) => {
+  const response = await client.patch(`/projects/${projectId}/rename`, { name });
+  return response.data;
+};


### PR DESCRIPTION
## Description
There was previously no way to rename a project after creation. This PR adds the ability to rename a project via an inline edit UI in the navbar and a new backend endpoint to persist the change.

Fixes #375 

## Type of Change
- [x] New feature

## How Has This Been Tested?
- [x] Existing tests pass
- [x] New tests added
- [x] Manual testing

**Following scenarios were modified manually:**
- Renamed a project — name updates and persists on refresh
- Attempted to save an empty/whitespace-only name — rejected with validation error
- Cancel button discards changes without persisting

## Screen Recording

https://github.com/user-attachments/assets/777d68a2-09ac-448b-8595-d4bee844c2b0



## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally