### PR TITLE
fix: prevent logs panel overflow and refresh logs after transforms

### DIFF
--- a/dataloom-frontend/src/Components/MenuNavbar.jsx
+++ b/dataloom-frontend/src/Components/MenuNavbar.jsx
@@ -100,6 +100,18 @@ const MenuNavbar = ({ projectId }) => {
     if (showCheckpoints) fetchCheckpoints();
   }, [showLogs, showCheckpoints, fetchLogs, fetchCheckpoints]);
 
+  useEffect(() => {
+    const handleLogsRefresh = () => {
+      if (showLogs) fetchLogs();
+    };
+
+    window.addEventListener("project:logs-refresh", handleLogsRefresh);
+
+    return () => {
+      window.removeEventListener("project:logs-refresh", handleLogsRefresh);
+    };
+  }, [showLogs, fetchLogs]);
+
   const handleSave = () => {
     setIsInputOpen(true);
   };

--- a/dataloom-frontend/src/Components/history/LogsPanel.jsx
+++ b/dataloom-frontend/src/Components/history/LogsPanel.jsx
@@ -22,7 +22,7 @@ const LogsPanel = ({ logs, onClose }) => {
         </button>
       </div>
 
-      <div className="mt-4 overflow-x-auto">
+      <div className="mt-4 overflow-x-auto overflow-y-auto max-h-72">
         <table className="min-w-full bg-white rounded-lg overflow-hidden">
           <thead className="bg-gray-50">
             <tr>

--- a/dataloom-frontend/src/api/transforms.js
+++ b/dataloom-frontend/src/api/transforms.js
@@ -12,6 +12,7 @@ import client from "./client";
  */
 export const transformProject = async (projectId, transformationInput) => {
   const response = await client.post(`/projects/${projectId}/transform`, transformationInput);
+  window.dispatchEvent(new CustomEvent("project:logs-refresh"));
   return response.data;
 };
 


### PR DESCRIPTION
## Description

Fixes the Logs panel UX issues by:

- Adding a fixed maximum height with internal scrolling to prevent the panel from pushing the data table out of view when many log entries exist.
- Refreshing logs automatically after successful transformations so newly created log entries appear immediately without requiring a page refresh.

Instead of manually calling `fetchLogs()` in every transformation form, a centralized event-driven approach was implemented. The `transformProject()` API helper now emits a custom browser event after successful transformations, and the Logs panel listens for this event to refresh itself.

This approach was chosen because:

- It avoids duplicating refresh logic across every transformation form.
- Future transformation forms automatically inherit log-refresh behavior.
- It reduces maintenance overhead and prevents regressions when new transformations are added.
- It keeps logging concerns centralized rather than coupling them to individual UI components.

Fixes #378 

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

- [x] Existing tests pass
- [x] Manual testing

**Following scenarios were verified manually:**
- Logs panel remains scrollable when a large number of logs are present.
- New log entries appear immediately after successful transformations.
- Existing transformation workflows continue to function correctly.
- No page refresh is required for log updates.

## Screen Recording

https://github.com/user-attachments/assets/012285fd-86b3-4395-9712-abe0e083bd68



## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally
