### PR TITLE
fix: Melt (Unpivot) toolbar icon active state and form button placement

### DIFF
--- a/dataloom-frontend/src/Components/MenuNavbar.jsx
+++ b/dataloom-frontend/src/Components/MenuNavbar.jsx
@@ -355,6 +355,7 @@ const MenuNavbar = ({ projectId }) => {
           {
             label: "Melt (Unpivot)",
             icon: LuLayoutList,
+            formType: "MeltForm",
             onClick: () => handleMenuClick("MeltForm"),
           },
         ],
@@ -461,7 +462,15 @@ const MenuNavbar = ({ projectId }) => {
           projectId={projectId}
         />
       )}
-      {showMeltForm && <MeltForm onClose={() => setShowMeltForm(false)} projectId={projectId} />}
+      {showMeltForm && (
+        <MeltForm
+          onClose={() => {
+            setShowMeltForm(false);
+            setActiveForm(null);
+          }}
+          projectId={projectId}
+        />
+      )}
       {showCastDataTypeForm && (
         <CastDataTypeForm
           projectId={projectId}

--- a/dataloom-frontend/src/Components/forms/MeltForm.jsx
+++ b/dataloom-frontend/src/Components/forms/MeltForm.jsx
@@ -180,14 +180,12 @@ const MeltForm = ({ projectId, onClose }) => {
         </div>
 
         <div className="flex justify-between pt-2">
-          <div className="flex gap-2">
-            <Button type="submit" disabled={loading}>
-              {loading ? "Processing..." : "Apply Melt"}
-            </Button>
-            <Button type="button" variant="secondary" onClick={onClose}>
-              Cancel
-            </Button>
-          </div>
+          <Button type="submit" disabled={loading}>
+            {loading ? "Processing..." : "Apply Melt"}
+          </Button>
+          <Button type="button" variant="secondary" onClick={onClose}>
+            Cancel
+          </Button>
         </div>
       </form>
       {result && (


### PR DESCRIPTION
## Description
Two small UI inconsistencies in the Melt (Unpivot) feature compared to every other transform form:

1. The toolbar icon did not highlight blue when active — `MeltForm`'s entry in `MenuNavbar.jsx` was missing the `formType` key that drives the `isActive` check used by every other toolbar item.
2. The Cancel button sat immediately next to Apply instead of being right-aligned — both buttons were wrapped in an inner `flex gap-2` div that defeated the outer `flex justify-between` layout used consistently in other forms.

Also fixed: `MeltForm`'s `onClose` handler wasn't resetting `activeForm` to `null` like every other form, which would have left the icon stuck in its active state after closing.

Fixes #386 

## Type of Change
- [x] Bug fix

## How Has This Been Tested?
- [x] Existing tests pass
- [x] Manual testing

**Verified the following scenarios manually:**
- Opened Melt form —> toolbar icon now highlights blue, matching other forms
- Closed Melt form —> icon correctly returns to inactive state
- Verified Cancel button is now right-aligned, separated from Apply

## Screen Recording

https://github.com/user-attachments/assets/65eb2bb8-c63f-4e70-a7aa-9e8b9700d852



## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally