### PR TITLE
Feat/select component

### DIFF
--- a/dataloom-frontend/src/Components/ExportModal.tsx
+++ b/dataloom-frontend/src/Components/ExportModal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, type CSSProperties, type FormEvent } from "react";
 import Modal from "./common/Modal";
 import Button from "./common/Button";
+import Select from "./common/Select";
 import { exportProject } from "../api";
 
 type FormatDef = {
@@ -247,17 +248,7 @@ export default function ExportModal({
               {/* Encoding (secondary — quiet dropdown) */}
               <label className="block">
                 <span className="mb-1.5 block text-xs text-gray-500">Encoding</span>
-                <select
-                  value={encoding}
-                  onChange={(e) => setEncoding(e.target.value)}
-                  className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-800 transition-colors focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/25"
-                >
-                  {ENCODINGS.map((enc) => (
-                    <option key={enc.value} value={enc.value}>
-                      {enc.label}
-                    </option>
-                  ))}
-                </select>
+                <Select value={encoding} onChange={setEncoding} options={ENCODINGS} />
               </label>
             </div>
           ) : (

--- a/dataloom-frontend/src/Components/common/ColumnSelect.tsx
+++ b/dataloom-frontend/src/Components/common/ColumnSelect.tsx
@@ -149,6 +149,7 @@ const ColumnSelect = ({
         aria-expanded={open}
         aria-required={required}
         onClick={toggle}
+        onKeyDown={handleKeyDown}
         className="flex items-center justify-between gap-2 border border-gray-300 rounded-md px-3 py-2 w-full bg-white text-left text-gray-900 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed"
       >
         <span className="flex items-center min-w-0">

--- a/dataloom-frontend/src/Components/common/Select.tsx
+++ b/dataloom-frontend/src/Components/common/Select.tsx
@@ -1,0 +1,170 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+
+export interface SelectOption {
+  value: string;
+  label: string;
+}
+
+interface SelectProps {
+  value: string;
+  onChange: (value: string) => void;
+  options: SelectOption[];
+  placeholder?: string;
+  id?: string;
+  disabled?: boolean;
+  className?: string;
+  "data-testid"?: string;
+}
+
+/**
+ * Generic styled dropdown. A trigger button opens an animated popover with a
+ * keyboard-navigable list of options. Shares the look and motion of ColumnSelect
+ * but takes a plain {value,label}[] list — used for the app's short, curated
+ * dropdowns (aggregation functions, sort order, target types, etc.).
+ */
+const Select = ({
+  value,
+  onChange,
+  options,
+  placeholder = "Select...",
+  id,
+  disabled = false,
+  className = "",
+  "data-testid": dataTestId,
+}: SelectProps) => {
+  const [open, setOpen] = useState(false);
+  // Kept mounted while the close animation plays, then unmounted on animationend.
+  const [mounted, setMounted] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+
+  const selectedLabel = useMemo(
+    () => options.find((opt) => opt.value === value)?.label,
+    [options, value],
+  );
+
+  // Fallback unmount in case animationend never fires (jsdom, reduced motion).
+  useEffect(() => {
+    if (!mounted || open) return;
+    const t = setTimeout(() => {
+      setMounted(false);
+      setActiveIndex(0);
+    }, 200);
+    return () => clearTimeout(t);
+  }, [mounted, open]);
+
+  // Close on outside click; highlight the current value on open.
+  useEffect(() => {
+    if (!open) return;
+    const handleClick = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClick);
+    const current = options.findIndex((opt) => opt.value === value);
+    setActiveIndex(current >= 0 ? current : 0);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [open, options, value]);
+
+  // Keep the keyboard-highlighted option scrolled into view.
+  useEffect(() => {
+    const el = listRef.current?.children[activeIndex] as HTMLElement | undefined;
+    el?.scrollIntoView?.({ block: "nearest" });
+  }, [activeIndex]);
+
+  const toggle = () => {
+    if (disabled) return;
+    if (open) {
+      setOpen(false);
+    } else {
+      setMounted(true);
+      setOpen(true);
+    }
+  };
+
+  const selectItem = (val: string) => {
+    onChange(val);
+    setOpen(false);
+  };
+
+  // After the close animation finishes, unmount and reset transient state.
+  const handleAnimationEnd = () => {
+    if (!open) {
+      setMounted(false);
+      setActiveIndex(0);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Escape") {
+      setOpen(false);
+    } else if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setActiveIndex((i) => Math.min(i + 1, options.length - 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setActiveIndex((i) => Math.max(i - 1, 0));
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      const item = options[activeIndex];
+      if (item) selectItem(item.value);
+    }
+  };
+
+  return (
+    <div ref={containerRef} className={`relative ${className || "w-full"}`}>
+      <button
+        type="button"
+        id={id}
+        data-testid={dataTestId}
+        disabled={disabled}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        onClick={toggle}
+        onKeyDown={handleKeyDown}
+        className="flex items-center justify-between gap-2 border border-gray-300 rounded-md px-3 py-2 w-full bg-white text-left text-gray-900 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        <span className={`truncate ${selectedLabel ? "text-gray-900" : "text-gray-400"}`}>
+          {selectedLabel || placeholder}
+        </span>
+        <svg
+          className={`w-4 h-4 text-gray-400 shrink-0 transition-transform ${open ? "rotate-180" : ""}`}
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+
+      {mounted && (
+        <div
+          data-state={open ? "open" : "closed"}
+          onAnimationEnd={handleAnimationEnd}
+          className="absolute z-20 mt-1 w-full bg-white border border-gray-300 rounded-md shadow-lg origin-top data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fill-mode-forwards data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0 data-[state=open]:zoom-in-95 data-[state=closed]:zoom-out-95 data-[state=open]:slide-in-from-top-2 data-[state=closed]:slide-out-to-top-2"
+        >
+          <ul ref={listRef} role="listbox" className="max-h-48 overflow-y-auto p-1">
+            {options.map((item, index) => (
+              <li
+                key={item.value}
+                role="option"
+                aria-selected={value === item.value}
+                onMouseEnter={() => setActiveIndex(index)}
+                onClick={() => selectItem(item.value)}
+                className={`px-2 py-1.5 rounded cursor-pointer text-sm ${
+                  index === activeIndex ? "bg-gray-200" : "hover:bg-gray-100"
+                } ${value === item.value ? "font-medium" : ""}`}
+              >
+                {item.label}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Select;

--- a/dataloom-frontend/src/Components/common/__tests__/Select.test.tsx
+++ b/dataloom-frontend/src/Components/common/__tests__/Select.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import Select from "../Select";
+
+const OPTIONS = [
+  { value: "sum", label: "Sum" },
+  { value: "mean", label: "Mean" },
+  { value: "count", label: "Count" },
+];
+
+const renderSelect = (props = {}) =>
+  render(<Select value="" onChange={vi.fn()} options={OPTIONS} {...props} />);
+
+describe("Select", () => {
+  it("shows the placeholder when no value matches", () => {
+    renderSelect({ placeholder: "Pick one..." });
+    expect(screen.getByText("Pick one...")).toBeInTheDocument();
+  });
+
+  it("shows the label of the selected value", () => {
+    renderSelect({ value: "mean" });
+    expect(screen.getByText("Mean")).toBeInTheDocument();
+  });
+
+  it("opens the popover and lists the options", () => {
+    renderSelect();
+    fireEvent.click(screen.getByRole("button"));
+    expect(screen.getAllByRole("option")).toHaveLength(3);
+  });
+
+  it("calls onChange with the value on selection", () => {
+    const onChange = vi.fn();
+    renderSelect({ onChange });
+    fireEvent.click(screen.getByRole("button"));
+    fireEvent.click(screen.getByText("Count"));
+    expect(onChange).toHaveBeenCalledWith("count");
+  });
+
+  it("selects the highlighted option with the keyboard", () => {
+    const onChange = vi.fn();
+    renderSelect({ onChange });
+    const button = screen.getByRole("button");
+    fireEvent.click(button);
+    fireEvent.keyDown(button, { key: "ArrowDown" });
+    fireEvent.keyDown(button, { key: "Enter" });
+    expect(onChange).toHaveBeenCalledWith("mean");
+  });
+
+  it("closes the popover on Escape", () => {
+    renderSelect();
+    const button = screen.getByRole("button");
+    fireEvent.click(button);
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+
+    fireEvent.keyDown(button, { key: "Escape" });
+    const panel = document.querySelector('[data-state="closed"]');
+    expect(panel).not.toBeNull();
+    fireEvent.animationEnd(panel as Element);
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+});

--- a/dataloom-frontend/src/Components/forms/AdvQueryFilterForm.jsx
+++ b/dataloom-frontend/src/Components/forms/AdvQueryFilterForm.jsx
@@ -62,8 +62,8 @@ const AdvQueryFilterForm = ({ projectId, onClose }) => {
             Cancel
           </Button>
         </div>
+        <FormErrorAlert message={error} />
       </form>
-      <FormErrorAlert message={error} />
       {result && <TransformResultPreview columns={result.columns} rows={result.rows} />}
     </div>
   );

--- a/dataloom-frontend/src/Components/forms/CastDataTypeForm.jsx
+++ b/dataloom-frontend/src/Components/forms/CastDataTypeForm.jsx
@@ -6,8 +6,17 @@ import { useToast } from "../../context/ToastContext";
 import useError from "../../hooks/useError";
 import FormErrorAlert from "../common/FormErrorAlert";
 import ColumnSelect from "../common/ColumnSelect";
+import Select from "../common/Select";
 import { useProjectContext } from "../../context/ProjectContext";
 import Button from "../common/Button";
+
+const TARGET_TYPES = [
+  { value: "string", label: "String" },
+  { value: "integer", label: "Integer" },
+  { value: "float", label: "Float" },
+  { value: "boolean", label: "Boolean" },
+  { value: "datetime", label: "DateTime" },
+];
 
 const CastDataTypeForm = ({ projectId, onClose }) => {
   const { showToast } = useToast();
@@ -66,17 +75,7 @@ const CastDataTypeForm = ({ projectId, onClose }) => {
 
           <div className="flex-1">
             <label className="block text-sm font-medium text-gray-700">Target Type:</label>
-            <select
-              value={targetType}
-              onChange={(e) => setTargetType(e.target.value)}
-              className="border border-gray-300 rounded-md w-full px-3 py-2 bg-white text-gray-900 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none"
-            >
-              <option value="string">String</option>
-              <option value="integer">Integer</option>
-              <option value="float">Float</option>
-              <option value="boolean">Boolean</option>
-              <option value="datetime">DateTime</option>
-            </select>
+            <Select value={targetType} onChange={setTargetType} options={TARGET_TYPES} />
           </div>
         </div>
 

--- a/dataloom-frontend/src/Components/forms/CastDataTypeForm.jsx
+++ b/dataloom-frontend/src/Components/forms/CastDataTypeForm.jsx
@@ -86,8 +86,8 @@ const CastDataTypeForm = ({ projectId, onClose }) => {
             Cancel
           </Button>
         </div>
+        <FormErrorAlert message={error} />
       </form>
-      <FormErrorAlert message={error} />
     </div>
   );
 };

--- a/dataloom-frontend/src/Components/forms/DropDuplicateForm.jsx
+++ b/dataloom-frontend/src/Components/forms/DropDuplicateForm.jsx
@@ -71,8 +71,8 @@ const DropDuplicateForm = ({ projectId, onClose }) => {
             Cancel
           </Button>
         </div>
+        <FormErrorAlert message={error} />
       </form>
-      <FormErrorAlert message={error} />
     </div>
   );
 };

--- a/dataloom-frontend/src/Components/forms/DropDuplicateForm.jsx
+++ b/dataloom-frontend/src/Components/forms/DropDuplicateForm.jsx
@@ -6,7 +6,13 @@ import useError from "../../hooks/useError";
 import FormErrorAlert from "../common/FormErrorAlert";
 import { useProjectContext } from "../../context/ProjectContext";
 import ColumnMultiSelect from "../common/ColumnMultiSelect";
+import Select from "../common/Select";
 import Button from "../common/Button";
+
+const KEEP_OPTIONS = [
+  { value: "first", label: "First" },
+  { value: "last", label: "Last" },
+];
 
 const DropDuplicateForm = ({ projectId, onClose }) => {
   const [columns, setColumns] = useState([]);
@@ -56,14 +62,7 @@ const DropDuplicateForm = ({ projectId, onClose }) => {
           </div>
           <div className="flex-1">
             <label className="block text-sm font-medium text-gray-700">Keep:</label>
-            <select
-              value={keep}
-              onChange={(e) => setKeep(e.target.value)}
-              className="border border-gray-300 rounded-md w-full px-3 py-2 bg-white text-gray-900 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none"
-            >
-              <option value="first">First</option>
-              <option value="last">Last</option>
-            </select>
+            <Select value={keep} onChange={setKeep} options={KEEP_OPTIONS} />
           </div>
         </div>
         <div className="flex justify-between">

--- a/dataloom-frontend/src/Components/forms/FillEmptyForm.tsx
+++ b/dataloom-frontend/src/Components/forms/FillEmptyForm.tsx
@@ -5,6 +5,7 @@ import { useToast } from "../../context/ToastContext";
 import useError from "../../hooks/useError";
 import FormErrorAlert from "../common/FormErrorAlert";
 import ColumnSelect from "../common/ColumnSelect";
+import Select from "../common/Select";
 
 const STRATEGIES = [
   { value: "custom", label: "Custom Value" },
@@ -77,17 +78,7 @@ const FillEmptyForm = ({ projectId, onClose }: { projectId: string; onClose: () 
 
         <div className="mb-4">
           <label className="block text-sm font-medium text-gray-700 mb-1">Strategy:</label>
-          <select
-            value={strategy}
-            onChange={(e) => setStrategy(e.target.value)}
-            className="border border-gray-300 rounded-md w-full px-3 py-2 bg-white text-gray-900"
-          >
-            {STRATEGIES.map((strategyOption) => (
-              <option key={strategyOption.value} value={strategyOption.value}>
-                {strategyOption.label}
-              </option>
-            ))}
-          </select>
+          <Select value={strategy} onChange={setStrategy} options={STRATEGIES} />
         </div>
 
         {strategy === "custom" && (

--- a/dataloom-frontend/src/Components/forms/FilterForm.jsx
+++ b/dataloom-frontend/src/Components/forms/FilterForm.jsx
@@ -111,8 +111,8 @@ const FilterForm = ({ projectId, onClose }) => {
             Cancel
           </Button>
         </div>
+        <FormErrorAlert message={error} />
       </form>
-      <FormErrorAlert message={error} />
       {result && <TransformResultPreview columns={result.columns} rows={result.rows} />}
     </div>
   );

--- a/dataloom-frontend/src/Components/forms/FilterForm.jsx
+++ b/dataloom-frontend/src/Components/forms/FilterForm.jsx
@@ -6,8 +6,19 @@ import TransformResultPreview from "./TransformResultPreview";
 import useError from "../../hooks/useError";
 import FormErrorAlert from "../common/FormErrorAlert";
 import ColumnSelect from "../common/ColumnSelect";
+import Select from "../common/Select";
 import { useProjectContext } from "../../context/ProjectContext";
 import Button from "../common/Button";
+
+const CONDITIONS = [
+  { value: "=", label: "=" },
+  { value: "!=", label: "!= (not equal)" },
+  { value: ">", label: ">" },
+  { value: "<", label: "<" },
+  { value: ">=", label: ">=" },
+  { value: "<=", label: "<=" },
+  { value: "contains", label: "contains" },
+];
 
 const FilterForm = ({ projectId, onClose }) => {
   const [filterParams, setFilterParams] = useState({
@@ -73,21 +84,11 @@ const FilterForm = ({ projectId, onClose }) => {
           </div>
           <div className="w-full sm:w-1/3 mb-2 pl-2">
             <label className="block mb-1 text-sm font-medium text-gray-700">Condition:</label>
-            <select
-              name="condition"
+            <Select
               value={filterParams.condition}
-              onChange={handleInputChange}
-              className="border border-gray-300 rounded-md px-3 py-2 w-full bg-white text-gray-900 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none"
-              required
-            >
-              <option value="=">=</option>
-              <option value="!=">!= (not equal)</option>
-              <option value=">">&gt;</option>
-              <option value="<">&lt;</option>
-              <option value=">=">&gt;=</option>
-              <option value="<=">&lt;=</option>
-              <option value="contains">contains</option>
-            </select>
+              onChange={(value) => setFilterParams((p) => ({ ...p, condition: value }))}
+              options={CONDITIONS}
+            />
           </div>
           <div className="w-full sm:w-1/3 mb-2 pl-2">
             <label className="block mb-1 text-sm font-medium text-gray-700">Value:</label>

--- a/dataloom-frontend/src/Components/forms/GroupByForm.jsx
+++ b/dataloom-frontend/src/Components/forms/GroupByForm.jsx
@@ -8,7 +8,17 @@ import FormErrorAlert from "../common/FormErrorAlert";
 import { useProjectContext } from "../../context/ProjectContext";
 import ColumnSelect from "../common/ColumnSelect";
 import ColumnMultiSelect from "../common/ColumnMultiSelect";
+import Select from "../common/Select";
 import Button from "../common/Button";
+
+const AGG_FUNCTIONS = [
+  { value: "sum", label: "Sum" },
+  { value: "mean", label: "Mean" },
+  { value: "count", label: "Count" },
+  { value: "min", label: "Min" },
+  { value: "max", label: "Max" },
+  { value: "median", label: "Median" },
+];
 
 const GroupByForm = ({ projectId, onClose }) => {
   const { columns: availableColumns, updateData, refreshProject, pageSize } = useProjectContext();
@@ -77,18 +87,7 @@ const GroupByForm = ({ projectId, onClose }) => {
           </div>
           <div className="w-full sm:w-1/3 mb-2 pl-2">
             <label className="block mb-1 text-sm font-medium text-gray-700">Function:</label>
-            <select
-              value={aggFunction}
-              onChange={(e) => setAggFunction(e.target.value)}
-              className="border border-gray-300 rounded-md px-3 py-2 w-full bg-white text-gray-900 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none"
-            >
-              <option value="sum">Sum</option>
-              <option value="mean">Mean</option>
-              <option value="count">Count</option>
-              <option value="min">Min</option>
-              <option value="max">Max</option>
-              <option value="median">Median</option>
-            </select>
+            <Select value={aggFunction} onChange={setAggFunction} options={AGG_FUNCTIONS} />
           </div>
         </div>
         <div className="flex justify-between">

--- a/dataloom-frontend/src/Components/forms/GroupByForm.jsx
+++ b/dataloom-frontend/src/Components/forms/GroupByForm.jsx
@@ -90,8 +90,8 @@ const GroupByForm = ({ projectId, onClose }) => {
             Cancel
           </Button>
         </div>
+        <FormErrorAlert message={error} />
       </form>
-      <FormErrorAlert message={error} />
       {result && <TransformResultPreview columns={result.columns} rows={result.rows} />}
     </div>
   );

--- a/dataloom-frontend/src/Components/forms/GroupByForm.jsx
+++ b/dataloom-frontend/src/Components/forms/GroupByForm.jsx
@@ -10,15 +10,7 @@ import ColumnSelect from "../common/ColumnSelect";
 import ColumnMultiSelect from "../common/ColumnMultiSelect";
 import Select from "../common/Select";
 import Button from "../common/Button";
-
-const AGG_FUNCTIONS = [
-  { value: "sum", label: "Sum" },
-  { value: "mean", label: "Mean" },
-  { value: "count", label: "Count" },
-  { value: "min", label: "Min" },
-  { value: "max", label: "Max" },
-  { value: "median", label: "Median" },
-];
+import { AGG_FUNCTIONS } from "../../constants/aggregations";
 
 const GroupByForm = ({ projectId, onClose }) => {
   const { columns: availableColumns, updateData, refreshProject, pageSize } = useProjectContext();

--- a/dataloom-frontend/src/Components/forms/PivotTableForm.jsx
+++ b/dataloom-frontend/src/Components/forms/PivotTableForm.jsx
@@ -7,8 +7,17 @@ import useError from "../../hooks/useError";
 import FormErrorAlert from "../common/FormErrorAlert";
 import ColumnSelect from "../common/ColumnSelect";
 import ColumnMultiSelect from "../common/ColumnMultiSelect";
+import Select from "../common/Select";
 import { useProjectContext } from "../../context/ProjectContext";
 import Button from "../common/Button";
+
+const AGG_FUNCTIONS = [
+  { value: "sum", label: "Sum" },
+  { value: "mean", label: "Mean" },
+  { value: "count", label: "Count" },
+  { value: "min", label: "Min" },
+  { value: "max", label: "Max" },
+];
 
 const PivotTableForm = ({ projectId, onClose }) => {
   const [index, setIndex] = useState([]);
@@ -83,17 +92,7 @@ const PivotTableForm = ({ projectId, onClose }) => {
           </div>
           <div className="flex-1">
             <label className="block text-sm font-medium text-gray-700">Aggregation Function:</label>
-            <select
-              value={aggfun}
-              onChange={(e) => setAggfun(e.target.value)}
-              className="border border-gray-300 rounded-md w-full px-3 py-2 bg-white text-gray-900 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none"
-            >
-              <option value="sum">Sum</option>
-              <option value="mean">Mean</option>
-              <option value="count">Count</option>
-              <option value="min">Min</option>
-              <option value="max">Max</option>
-            </select>
+            <Select value={aggfun} onChange={setAggfun} options={AGG_FUNCTIONS} />
           </div>
         </div>
         <div className="flex justify-between">

--- a/dataloom-frontend/src/Components/forms/PivotTableForm.jsx
+++ b/dataloom-frontend/src/Components/forms/PivotTableForm.jsx
@@ -96,8 +96,8 @@ const PivotTableForm = ({ projectId, onClose }) => {
             Cancel
           </Button>
         </div>
+        <FormErrorAlert message={error} />
       </form>
-      <FormErrorAlert message={error} />
       {result && <TransformResultPreview columns={result.columns} rows={result.rows} />}
     </div>
   );

--- a/dataloom-frontend/src/Components/forms/PivotTableForm.jsx
+++ b/dataloom-frontend/src/Components/forms/PivotTableForm.jsx
@@ -10,14 +10,7 @@ import ColumnMultiSelect from "../common/ColumnMultiSelect";
 import Select from "../common/Select";
 import { useProjectContext } from "../../context/ProjectContext";
 import Button from "../common/Button";
-
-const AGG_FUNCTIONS = [
-  { value: "sum", label: "Sum" },
-  { value: "mean", label: "Mean" },
-  { value: "count", label: "Count" },
-  { value: "min", label: "Min" },
-  { value: "max", label: "Max" },
-];
+import { AGG_FUNCTIONS } from "../../constants/aggregations";
 
 const PivotTableForm = ({ projectId, onClose }) => {
   const [index, setIndex] = useState([]);

--- a/dataloom-frontend/src/Components/forms/SampleRowsForm.jsx
+++ b/dataloom-frontend/src/Components/forms/SampleRowsForm.jsx
@@ -101,8 +101,8 @@ const SampleRowsForm = ({ projectId, onClose }) => {
             Cancel
           </Button>
         </div>
+        <FormErrorAlert message={error} />
       </form>
-      <FormErrorAlert message={error} />
       {result && <TransformResultPreview columns={result.columns} rows={result.rows} />}
     </div>
   );

--- a/dataloom-frontend/src/Components/forms/SortForm.jsx
+++ b/dataloom-frontend/src/Components/forms/SortForm.jsx
@@ -6,8 +6,14 @@ import TransformResultPreview from "./TransformResultPreview";
 import useError from "../../hooks/useError";
 import FormErrorAlert from "../common/FormErrorAlert";
 import ColumnSelect from "../common/ColumnSelect";
+import Select from "../common/Select";
 import { useProjectContext } from "../../context/ProjectContext";
 import Button from "../common/Button";
+
+const ORDER_OPTIONS = [
+  { value: "true", label: "Ascending" },
+  { value: "false", label: "Descending" },
+];
 
 /**
  * SortForm component for multi-column sorting.
@@ -125,14 +131,12 @@ const SortForm = ({ projectId, onClose }) => {
                   data-testid={index === 0 ? "sort-column" : undefined}
                 />
               </div>
-              <select
-                value={criterion.ascending}
-                onChange={(e) => updateCriterionOrder(criterion.id, e.target.value === "true")}
-                className="border border-gray-300 rounded-md px-3 py-2 bg-white text-gray-900 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none text-sm w-32"
-              >
-                <option value="true">Ascending</option>
-                <option value="false">Descending</option>
-              </select>
+              <Select
+                value={String(criterion.ascending)}
+                onChange={(value) => updateCriterionOrder(criterion.id, value === "true")}
+                options={ORDER_OPTIONS}
+                className="w-32 shrink-0"
+              />
               <div className="flex gap-1">
                 <button
                   type="button"

--- a/dataloom-frontend/src/Components/forms/SortForm.jsx
+++ b/dataloom-frontend/src/Components/forms/SortForm.jsx
@@ -207,8 +207,8 @@ const SortForm = ({ projectId, onClose }) => {
             Cancel
           </Button>
         </div>
+        <FormErrorAlert message={error} />
       </form>
-      <FormErrorAlert message={error} />
       {result && <TransformResultPreview columns={result.columns} rows={result.rows} />}
     </div>
   );

--- a/dataloom-frontend/src/Components/forms/StringReplaceForm.jsx
+++ b/dataloom-frontend/src/Components/forms/StringReplaceForm.jsx
@@ -104,8 +104,8 @@ const StringReplaceForm = ({ projectId, onClose }) => {
             Cancel
           </Button>
         </div>
+        <FormErrorAlert message={error} />
       </form>
-      <FormErrorAlert message={error} />
     </div>
   );
 };

--- a/dataloom-frontend/src/Components/forms/TrimWhitespaceForm.jsx
+++ b/dataloom-frontend/src/Components/forms/TrimWhitespaceForm.jsx
@@ -76,8 +76,8 @@ const TrimWhitespaceForm = ({ projectId, onClose }) => {
             Cancel
           </Button>
         </div>
+        <FormErrorAlert message={error} />
       </form>
-      <FormErrorAlert message={error} />
     </div>
   );
 };

--- a/dataloom-frontend/src/constants/aggregations.ts
+++ b/dataloom-frontend/src/constants/aggregations.ts
@@ -1,0 +1,11 @@
+import type { SelectOption } from "../Components/common/Select";
+
+/** Aggregation functions shared by the Group By and Pivot Table forms. */
+export const AGG_FUNCTIONS: SelectOption[] = [
+  { value: "sum", label: "Sum" },
+  { value: "mean", label: "Mean" },
+  { value: "count", label: "Count" },
+  { value: "min", label: "Min" },
+  { value: "max", label: "Max" },
+  { value: "median", label: "Median" },
+];


### PR DESCRIPTION
## Description

- add Select, a generic styled single-select sharing ColumnSelect's look, animation, and keyboard navigation but taking a plain {value,label}[] list
- replace native <select> elements in the filter, sort, pivot, group by, cast, drop duplicate, fill empty, and export forms
- add tests covering placeholder, selection, keyboard navigation, and escape-to-close

Fixes #388

## Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

- [X] Existing tests pass
- [X] New tests added
- [X] Manual testing

## Screenshots

## Checklist

- [X] My code follows the project's style guidelines
- [X] I have performed a self-review
- [X] I have added/updated documentation as needed
- [X] My changes generate no new warnings
- [X] Tests pass locally