### PR TITLE
feat(pagination): add first/last navigation and page jump input

### DIFF
--- a/dataloom-frontend/src/Components/Table.jsx
+++ b/dataloom-frontend/src/Components/Table.jsx
@@ -16,6 +16,7 @@ import InputDialog from "./common/InputDialog";
 import Toast from "./common/Toast";
 import DtypeBadge from "./common/DtypeBadge";
 import PropTypes from "prop-types";
+import { useToast } from "../context/ToastContext";
 
 const MenuButton = ({ children, onClick }) => (
   <button
@@ -488,62 +489,58 @@ export function TablePagination({
   onPageSizeChange,
 }) {
   const [pageSizeOpen, setPageSizeOpen] = useState(false);
-  const [pageInput, setPageInput] = useState("");
+  const [pageInput, setPageInput] = useState(String(page));
   const pageInputRef = useRef(null);
   const pageSizeOptions = [10, 25, 50, 100];
+  const { showToast } = useToast();
+
+  const prevPageRef = useRef(page);
+  if (prevPageRef.current !== page) {
+    prevPageRef.current = page;
+    setPageInput(String(page));
+  }
 
   const handleFirst = () => {
     if (page !== 1) onPageChange(1);
   };
-
   const handlePrevious = () => {
     if (page > 1) onPageChange(page - 1);
   };
-
   const handleNext = () => {
     if (page < totalPages) onPageChange(page + 1);
   };
-
   const handleLast = () => {
     if (page !== totalPages) onPageChange(totalPages);
   };
 
-  const goToInputPage = () => {
+  const commitPageInput = () => {
     const input = pageInputRef.current;
-
     if (input && !input.reportValidity()) {
+      showToast("Invalid page number", "error");
+      setPageInput(String(page));
       return;
     }
-
-    const trimmed = pageInput.trim();
-    if (!trimmed) return;
-
-    const parsed = Number(trimmed);
-    const clamped = Math.min(Math.max(parsed, 1), totalPages);
-    onPageChange(clamped);
-    setPageInput("");
+    const parsed = Number(pageInput);
+    if (parsed !== page) onPageChange(parsed);
   };
 
   const handlePageInputKeyDown = (e) => {
     if (e.key === "Enter") {
       e.preventDefault();
-      goToInputPage();
+      commitPageInput();
+    }
+    if (e.key === "Escape") {
+      setPageInput(String(page));
     }
   };
 
   return (
     <div className="flex flex-col gap-3 px-4 py-3 bg-white sm:flex-row sm:items-center sm:justify-between sm:px-8">
-      {/* Info section */}
+      {/* Left: Total Rows + Page Size */}
       <div className="flex flex-wrap items-center gap-x-6 gap-y-2 text-sm text-gray-600">
         <div className="flex items-center gap-2">
           <span className="text-gray-500">Total Rows:</span>
           <span className="text-gray-900">{totalRows}</span>
-        </div>
-        <div className="flex items-center gap-2">
-          <span className="text-gray-500">Page:</span>
-          <span className="text-gray-900">
-            {page} of {totalPages}
-          </span>
         </div>
         <div className="relative flex items-center gap-2">
           <span className="text-gray-500">Page Size:</span>
@@ -554,7 +551,6 @@ export function TablePagination({
             >
               {pageSize}
             </button>
-
             {pageSizeOpen && (
               <div className="absolute bottom-full z-10 mb-1 min-w-[60px] rounded-lg border-2 border-gray-300 bg-white shadow-lg">
                 {pageSizeOptions.map((size) => (
@@ -575,6 +571,7 @@ export function TablePagination({
         </div>
       </div>
 
+      {/* Right: nav buttons + Page X of Y */}
       <div className="flex flex-wrap items-center justify-center gap-2 sm:flex-nowrap sm:justify-end">
         <button
           onClick={handleFirst}
@@ -593,7 +590,9 @@ export function TablePagination({
           <ChevronLeft className="h-5 w-5 text-gray-700" />
         </button>
 
-        <div className="flex items-center gap-1.5">
+        {/* Page X of Y — X always editable */}
+        <div className="flex items-center gap-1.5 text-sm text-gray-600 select-none">
+          <span className="text-gray-500">Page</span>
           <input
             ref={pageInputRef}
             type="number"
@@ -603,17 +602,12 @@ export function TablePagination({
             value={pageInput}
             onChange={(e) => setPageInput(e.target.value)}
             onKeyDown={handlePageInputKeyDown}
-            placeholder={String(page)}
+            onBlur={commitPageInput}
             title={`Enter a page between 1 and ${totalPages}`}
-            className="h-[34px] w-16 rounded-md border-2 border-gray-300 px-2 text-center text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
-            aria-label="Go to page"
+            className="h-7 w-14 rounded-md border-2 border-gray-300 px-1.5 text-center text-sm text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+            aria-label="Current page"
           />
-          <button
-            onClick={goToInputPage}
-            className="h-[34px] rounded-md border-2 border-gray-300 px-3 text-sm text-gray-700 transition-colors hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-blue-500"
-          >
-            Go
-          </button>
+          <span className="text-gray-500">of {totalPages}</span>
         </div>
 
         <button

--- a/dataloom-frontend/src/Components/Table.jsx
+++ b/dataloom-frontend/src/Components/Table.jsx
@@ -1,7 +1,7 @@
 import ContextMenu from "./ContextMenu";
 import { useContextMenu } from "../hooks/useContextMenu";
-import { useState, useEffect, useMemo } from "react";
-import { ChevronLeft, ChevronRight } from "lucide-react";
+import { useState, useEffect, useMemo, useRef } from "react";
+import { ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight } from "lucide-react";
 import { transformProject } from "../api";
 import { useProjectContext } from "../context/ProjectContext";
 import {
@@ -488,23 +488,53 @@ export function TablePagination({
   onPageSizeChange,
 }) {
   const [pageSizeOpen, setPageSizeOpen] = useState(false);
+  const [pageInput, setPageInput] = useState("");
+  const pageInputRef = useRef(null);
   const pageSizeOptions = [10, 25, 50, 100];
 
+  const handleFirst = () => {
+    if (page !== 1) onPageChange(1);
+  };
+
   const handlePrevious = () => {
-    if (page > 1) {
-      onPageChange(page - 1);
-    }
+    if (page > 1) onPageChange(page - 1);
   };
 
   const handleNext = () => {
-    if (page < totalPages) {
-      onPageChange(page + 1);
+    if (page < totalPages) onPageChange(page + 1);
+  };
+
+  const handleLast = () => {
+    if (page !== totalPages) onPageChange(totalPages);
+  };
+
+  const goToInputPage = () => {
+    const input = pageInputRef.current;
+
+    if (input && !input.reportValidity()) {
+      return;
+    }
+
+    const trimmed = pageInput.trim();
+    if (!trimmed) return;
+
+    const parsed = Number(trimmed);
+    const clamped = Math.min(Math.max(parsed, 1), totalPages);
+    onPageChange(clamped);
+    setPageInput("");
+  };
+
+  const handlePageInputKeyDown = (e) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      goToInputPage();
     }
   };
 
   return (
-    <div className="flex items-center justify-between px-8 py-3 bg-white">
-      <div className="flex items-center gap-6 text-sm text-gray-600">
+    <div className="flex flex-col gap-3 px-4 py-3 bg-white sm:flex-row sm:items-center sm:justify-between sm:px-8">
+      {/* Info section */}
+      <div className="flex flex-wrap items-center gap-x-6 gap-y-2 text-sm text-gray-600">
         <div className="flex items-center gap-2">
           <span className="text-gray-500">Total Rows:</span>
           <span className="text-gray-900">{totalRows}</span>
@@ -515,18 +545,18 @@ export function TablePagination({
             {page} of {totalPages}
           </span>
         </div>
-        <div className="flex items-center gap-2 relative">
+        <div className="relative flex items-center gap-2">
           <span className="text-gray-500">Page Size:</span>
           <div className="relative inline-block">
             <button
               onClick={() => setPageSizeOpen(!pageSizeOpen)}
-              className="border-2 border-gray-300 rounded-md px-4 py-1 text-sm min-w-[40px] text-center focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="min-w-[40px] rounded-md border-2 border-gray-300 px-4 py-1 text-center text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
             >
               {pageSize}
             </button>
 
             {pageSizeOpen && (
-              <div className="absolute bottom-full mb-1 min-w-[60px] bg-white border-2 border-gray-300 rounded-lg shadow-lg z-10">
+              <div className="absolute bottom-full z-10 mb-1 min-w-[60px] rounded-lg border-2 border-gray-300 bg-white shadow-lg">
                 {pageSizeOptions.map((size) => (
                   <div
                     key={size}
@@ -534,7 +564,7 @@ export function TablePagination({
                       onPageSizeChange(size);
                       setPageSizeOpen(false);
                     }}
-                    className="px-4 py-2 text-sm hover:bg-blue-50 hover:text-blue-700 cursor-pointer rounded-md"
+                    className="cursor-pointer rounded-md px-4 py-2 text-sm hover:bg-blue-50 hover:text-blue-700"
                   >
                     {size}
                   </div>
@@ -545,22 +575,62 @@ export function TablePagination({
         </div>
       </div>
 
-      <div className="flex items-center gap-2">
+      <div className="flex flex-wrap items-center justify-center gap-2 sm:flex-nowrap sm:justify-end">
+        <button
+          onClick={handleFirst}
+          disabled={page === 1}
+          className="rounded-md border-2 border-gray-300 p-1.5 transition-colors hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-40"
+          aria-label="First page"
+        >
+          <ChevronsLeft className="h-5 w-5 text-gray-700" />
+        </button>
         <button
           onClick={handlePrevious}
           disabled={page === 1}
-          className="p-1.5 border-2 border-gray-300 rounded-md hover:bg-blue-50 disabled:opacity-40 disabled:cursor-not-allowed transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500"
+          className="rounded-md border-2 border-gray-300 p-1.5 transition-colors hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-40"
           aria-label="Previous page"
         >
-          <ChevronLeft className="w-5 h-5 text-gray-700" />
+          <ChevronLeft className="h-5 w-5 text-gray-700" />
         </button>
+
+        <div className="flex items-center gap-1.5">
+          <input
+            ref={pageInputRef}
+            type="number"
+            min={1}
+            max={totalPages}
+            step={1}
+            value={pageInput}
+            onChange={(e) => setPageInput(e.target.value)}
+            onKeyDown={handlePageInputKeyDown}
+            placeholder={String(page)}
+            title={`Enter a page between 1 and ${totalPages}`}
+            className="h-[34px] w-16 rounded-md border-2 border-gray-300 px-2 text-center text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+            aria-label="Go to page"
+          />
+          <button
+            onClick={goToInputPage}
+            className="h-[34px] rounded-md border-2 border-gray-300 px-3 text-sm text-gray-700 transition-colors hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          >
+            Go
+          </button>
+        </div>
+
         <button
           onClick={handleNext}
           disabled={page === totalPages}
-          className="p-1.5 border-2 border-gray-300 rounded-md hover:bg-blue-50 disabled:opacity-40 disabled:cursor-not-allowed transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500"
+          className="rounded-md border-2 border-gray-300 p-1.5 transition-colors hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-40"
           aria-label="Next page"
         >
-          <ChevronRight className="w-5 h-5 text-gray-700" />
+          <ChevronRight className="h-5 w-5 text-gray-700" />
+        </button>
+        <button
+          onClick={handleLast}
+          disabled={page === totalPages}
+          className="rounded-md border-2 border-gray-300 p-1.5 transition-colors hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-40"
+          aria-label="Last page"
+        >
+          <ChevronsRight className="h-5 w-5 text-gray-700" />
         </button>
       </div>
     </div>

--- a/dataloom-frontend/src/test/Table.columnOrder.test.jsx
+++ b/dataloom-frontend/src/test/Table.columnOrder.test.jsx
@@ -4,6 +4,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import Table from "../Components/Table";
 import { transformProject } from "../api";
+import { ToastProvider } from "../context/ToastContext";
 
 vi.mock("../api", () => ({
   transformProject: vi.fn(() =>
@@ -45,11 +46,18 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
+const renderTable = () =>
+  render(
+    <ToastProvider>
+      <Table projectId="test-id" />
+    </ToastProvider>,
+  );
+
 describe("Table — column reorder behavior", () => {
   it("renders columns in default order", () => {
     mockContext.columnOrder = [0, 1, 2];
 
-    render(<Table projectId="test-id" />);
+    renderTable();
 
     const headers = screen.getAllByRole("columnheader");
 
@@ -61,7 +69,7 @@ describe("Table — column reorder behavior", () => {
   it("renders columns in reordered sequence [2, 0, 1]", () => {
     mockContext.columnOrder = [2, 0, 1];
 
-    render(<Table projectId="test-id" />);
+    renderTable();
 
     const headers = screen.getAllByRole("columnheader");
 
@@ -73,7 +81,7 @@ describe("Table — column reorder behavior", () => {
   it("falls back to default order when columnOrder length mismatches", () => {
     mockContext.columnOrder = [0, 1];
 
-    render(<Table projectId="test-id" />);
+    renderTable();
 
     const headers = screen.getAllByRole("columnheader");
 
@@ -85,7 +93,7 @@ describe("Table — column reorder behavior", () => {
   it("calls setColumnOrder when columns are reordered via drag and drop", async () => {
     mockContext.columnOrder = [0, 1, 2];
 
-    render(<Table projectId="test-id" />);
+    renderTable();
 
     const buttons = screen.getAllByRole("button");
 
@@ -112,7 +120,7 @@ describe("Table — column reorder behavior", () => {
 
     mockContext.columnOrder = [2, 0, 1];
 
-    render(<Table projectId="test-id" />);
+    renderTable();
 
     const cells = screen.getAllByText("New York");
 


### PR DESCRIPTION
## Description
Adds First/Last page navigation buttons and a direct page-jump input to `TablePagination`, modeled after OpenRefine-style pagination. Previously only Previous/Next were available, which made navigating large result sets (e.g. hundreds of pages) tedious. Also makes the pagination bar responsive for smaller viewports.

Fixes #390 

## Type of Change
- [x] New feature

## How Has This Been Tested?
- [x] Manual testing

Manually verified:
- First/Last buttons navigate correctly and disable at boundaries (page 1 / last page)
- Page jump input accepts valid page numbers and navigates via both the **Go** button and `Enter` key
- Invalid input (`0`, negative numbers, values greater than total pages, non-integers) triggers the native browser validation warning via `reportValidity()` and does not call `onPageChange`
- Input clears after a successful jump
- Layout checked at mobile (`<640px`), tablet, and desktop widths — info row and nav row stack correctly on small screens and sit inline from `sm:` up

## Screen Recording

https://github.com/user-attachments/assets/5507150c-3e3f-45ea-b96c-d60b2a14bbc6



## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally