### PR TITLE
feat: add structured JSON logging with request correlation

### DIFF
--- a/dataloom-backend/app/main.py
+++ b/dataloom-backend/app/main.py
@@ -79,11 +79,13 @@ async def add_request_id(request: Request, call_next):
     response.headers["X-Request-ID"] = rid
 
     logger.info(
-        "request complete (method=%s path=%s status=%d duration_ms=%.2f)",
-        request.method,
-        request.url.path,
-        response.status_code,
-        duration_ms,
+        "request complete",
+        extra={
+            "method": request.method,
+            "path": request.url.path,
+            "status_code": response.status_code,
+            "duration_ms": duration_ms,
+        },
     )
     return response
 

--- a/dataloom-backend/app/main.py
+++ b/dataloom-backend/app/main.py
@@ -3,6 +3,8 @@
 Configures middleware, exception handlers, and mounts all API routers.
 """
 
+import time
+import uuid
 from contextlib import asynccontextmanager
 from pathlib import Path
 
@@ -15,7 +17,7 @@ from app.config import get_settings
 from app.database import verify_database_connection
 from app.exceptions import AppException, app_exception_handler
 from app.services.transformation_service import TransformationError
-from app.utils.logging import get_logger, setup_logging
+from app.utils.logging import get_logger, request_id_var, setup_logging
 
 logger = get_logger(__name__)
 
@@ -56,6 +58,34 @@ app.add_middleware(
     allow_headers=["*"],
     expose_headers=["Content-Disposition"],
 )
+
+
+@app.middleware("http")
+async def add_request_id(request: Request, call_next):
+    """Attach a correlation ID (request_id) to every request.
+
+    Reads the ``X-Request-ID`` header from the client when present so that
+    downstream consumers can correlate their own tracing IDs; otherwise
+    generates a new UUID hex string.  The ID is set on a ``ContextVar`` that
+    propagates to all log entries emitted during the request lifecycle.
+    """
+    rid = (request.headers.get("X-Request-ID") or "").strip() or uuid.uuid4().hex
+    request_id_var.set(rid)
+
+    start = time.perf_counter()
+    response = await call_next(request)
+    duration_ms = round((time.perf_counter() - start) * 1000, 2)
+
+    response.headers["X-Request-ID"] = rid
+
+    logger.info(
+        "request complete (method=%s path=%s status=%d duration_ms=%.2f)",
+        request.method,
+        request.url.path,
+        response.status_code,
+        duration_ms,
+    )
+    return response
 
 
 @app.exception_handler(TransformationError)

--- a/dataloom-backend/app/utils/logging.py
+++ b/dataloom-backend/app/utils/logging.py
@@ -14,14 +14,43 @@ from datetime import UTC, datetime
 
 request_id_var: ContextVar[str] = ContextVar("request_id", default="")
 
+_STANDARD_ATTRS = frozenset(
+    {
+        "args",
+        "asctime",
+        "created",
+        "exc_info",
+        "exc_text",
+        "filename",
+        "funcName",
+        "levelname",
+        "levelno",
+        "lineno",
+        "message",
+        "module",
+        "msecs",
+        "msg",
+        "name",
+        "pathname",
+        "process",
+        "processName",
+        "relativeCreated",
+        "stack_info",
+        "thread",
+        "threadName",
+    }
+)
+
 
 class JSONFormatter(logging.Formatter):
     """Format log records as JSON lines.
 
     The output always contains ``timestamp``, ``level``, ``logger``, and
     ``message`` keys.  If a ``request_id`` is set on the current execution
-    context via ``request_id_var`` it is included.  Exception tracebacks
-    are serialised under an ``exception`` key when present.
+    context via ``request_id_var`` it is included.  Any extra keyword
+    arguments passed via ``logging.Logger.*`` calls are surfaced as
+    top-level JSON keys.  Exception tracebacks are serialised under an
+    ``exception`` key when present.
     """
 
     def format(self, record: logging.LogRecord) -> str:
@@ -35,6 +64,10 @@ class JSONFormatter(logging.Formatter):
         rid = request_id_var.get()
         if rid:
             log_entry["request_id"] = rid
+
+        for key, value in record.__dict__.items():
+            if key not in _STANDARD_ATTRS:
+                log_entry[key] = value
 
         if record.exc_info and record.exc_info[0]:
             log_entry["exception"] = self.formatException(record.exc_info)

--- a/dataloom-backend/app/utils/logging.py
+++ b/dataloom-backend/app/utils/logging.py
@@ -1,45 +1,80 @@
 """Logging configuration for the DataLoom backend.
 
-Provides setup_logging() to configure the root logger and get_logger() to
-obtain named loggers for use across the application.
+Provides structured JSON logging with request correlation support.
+Every ``app.*`` module logger emits JSON lines to stdout, with an optional
+``request_id`` field correlated across all log entries within an HTTP request
+via a ``contextvars.ContextVar``.
 """
 
+import json
 import logging
 import sys
+from contextvars import ContextVar
+from datetime import UTC, datetime
+
+request_id_var: ContextVar[str] = ContextVar("request_id", default="")
+
+
+class JSONFormatter(logging.Formatter):
+    """Format log records as JSON lines.
+
+    The output always contains ``timestamp``, ``level``, ``logger``, and
+    ``message`` keys.  If a ``request_id`` is set on the current execution
+    context via ``request_id_var`` it is included.  Exception tracebacks
+    are serialised under an ``exception`` key when present.
+    """
+
+    def format(self, record: logging.LogRecord) -> str:
+        log_entry = {
+            "timestamp": datetime.fromtimestamp(record.created, tz=UTC).isoformat(),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+
+        rid = request_id_var.get()
+        if rid:
+            log_entry["request_id"] = rid
+
+        if record.exc_info and record.exc_info[0]:
+            log_entry["exception"] = self.formatException(record.exc_info)
+
+        return json.dumps(log_entry, ensure_ascii=False, default=str)
 
 
 def setup_logging(debug: bool = False) -> None:
-    """Configure the root logger with a console handler and formatter.
+    """Configure the ``app`` logger with JSON output.
+
+    Uses ``app`` as the parent logger so that all ``app.*`` module loggers
+    produce structured JSON lines.  Propagation is disabled to avoid
+    duplicate output when uvicorn (or any other framework) has already
+    configured the root logger.
 
     Args:
         debug: If True, set log level to DEBUG. Otherwise, use INFO.
     """
     level = logging.DEBUG if debug else logging.INFO
 
-    formatter = logging.Formatter(
-        fmt="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
-        datefmt="%Y-%m-%d %H:%M:%S",
-    )
-
     handler = logging.StreamHandler(sys.stdout)
     handler.setLevel(level)
-    handler.setFormatter(formatter)
+    handler.setFormatter(JSONFormatter())
 
-    root_logger = logging.getLogger()
-    root_logger.setLevel(level)
+    app_logger = logging.getLogger("app")
+    app_logger.setLevel(level)
 
-    # Avoid adding duplicate handlers on repeated calls
-    if not root_logger.handlers:
-        root_logger.addHandler(handler)
+    if not app_logger.handlers:
+        app_logger.addHandler(handler)
+
+    app_logger.propagate = False
 
 
 def get_logger(name: str) -> logging.Logger:
     """Return a named logger.
 
     Args:
-        name: The logger name, typically __name__ of the calling module.
+        name: The logger name, typically ``__name__`` of the calling module.
 
     Returns:
-        A logging.Logger instance.
+        A :class:`logging.Logger` instance.
     """
     return logging.getLogger(name)


### PR DESCRIPTION
## Summary

Replace the plain-text root-logger handler with a JSON formatter on the `app` logger so that all `app.*` module loggers emit machine-parseable JSON lines. Add a `request_id` context variable and a FastAPI middleware that correlates every log entry emitted during an HTTP request under a single UUID.

## Key changes

- **`JSONFormatter`** — stdlib-`logging` `Formatter` subclass that serialises each record as a JSON object with `timestamp`, `level`, `logger`, and `message` keys, plus an optional `request_id` from the execution context and an `exception` key for tracebacks.
- **`request_id_var`** — a `contextvars.ContextVar` that carries the correlation ID across async boundaries within the same request.
- **`setup_logging()`** — now configures the `app` logger with the JSON handler and sets `propagate=False` to avoid duplicate output when uvicorn has already installed a root-level handler.
- **`add_request_id` middleware** — reads or generates a request ID, sets it on the context var, measures request duration, and echoes the ID back in the `X-Request-ID` response header.
- **Zero new runtime dependencies** — uses only Python stdlib `logging`, `contextvars`, `json`, `uuid`, and `time`.

## Verification

- All 458 existing backend tests pass (no regressions).
- Ruff lint + format pass clean.
- Zero new dependencies added.
- Two files changed (+82, -17).
- Startup/shutdown logs (outside any HTTP request) correctly omit the `request_id` field.
