### PR TITLE
feat: revamp layout - add tabs and sidepanel

### DIFF
--- a/dataloom-frontend/src/Components/DataScreen.jsx
+++ b/dataloom-frontend/src/Components/DataScreen.jsx
@@ -1,14 +1,73 @@
 import { useParams } from "react-router-dom";
-import { useState, useEffect } from "react";
+import { useEffect } from "react";
+import PropTypes from "prop-types";
 import { useProjectContext } from "../context/ProjectContext";
+import { WorkspaceTabsProvider, useWorkspaceTabs } from "../context/WorkspaceTabsContext";
+import { PanelProvider } from "../context/PanelContext";
+import { HistoryRefreshProvider } from "../context/HistoryRefreshContext";
+import { ColumnProfilesProvider } from "../context/ColumnProfilesContext";
+import { getTabComponent } from "./workspace/TabRegistry";
+// Each feature module self-registers its tabs, panels, and menu items.
+import { DATASET_TAB } from "./workspace/features/dataset";
+import "./workspace/features/transforms";
+import "./workspace/features/history";
+import "./workspace/features/profiling";
+import WorkspaceTabBar from "./workspace/WorkspaceTabBar";
+import RightPanel from "./workspace/RightPanel";
 import MenuNavbar from "./MenuNavbar";
-import Table from "./Table";
+
+function WorkspaceContent({ projectId }) {
+  const { activeTab, openTab } = useWorkspaceTabs();
+
+  const renderActiveTab = () => {
+    if (!activeTab) {
+      return (
+        <div className="flex flex-1 flex-col items-center justify-center gap-3 text-center">
+          <p className="text-sm text-gray-500">No table open.</p>
+          <button
+            type="button"
+            onClick={() => openTab(DATASET_TAB)}
+            className="rounded-md bg-blue-500 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-600"
+          >
+            Open DataSet
+          </button>
+        </div>
+      );
+    }
+
+    // Every tab type — dataset, logs, checkpoints — resolves through the registry.
+    const TabComponent = getTabComponent(activeTab.type);
+    if (!TabComponent) {
+      return (
+        <div className="flex flex-1 items-center justify-center text-sm text-gray-500">
+          Unknown tab type: {activeTab.type}
+        </div>
+      );
+    }
+    return <TabComponent {...(activeTab.props ?? {})} tab={activeTab} />;
+  };
+
+  return (
+    <>
+      <MenuNavbar projectId={projectId} />
+      <div className="flex min-h-0 flex-1 overflow-hidden">
+        <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+          <WorkspaceTabBar onAddTab={() => openTab(DATASET_TAB)} />
+          <div className="flex min-h-0 flex-1 flex-col overflow-hidden">{renderActiveTab()}</div>
+        </div>
+        <RightPanel projectId={projectId} />
+      </div>
+    </>
+  );
+}
+
+WorkspaceContent.propTypes = {
+  projectId: PropTypes.string,
+};
 
 export default function DataScreen() {
   const { projectId } = useParams();
   const { setProjectInfo, refreshProject } = useProjectContext();
-  const [tableData, setTableData] = useState(null);
-  const [showColumnProfiles, setShowColumnProfiles] = useState(false);
 
   useEffect(() => {
     if (projectId) {
@@ -17,19 +76,17 @@ export default function DataScreen() {
     }
   }, [projectId, setProjectInfo, refreshProject]);
 
-  const handleTransform = (data) => {
-    setTableData(data);
-  };
-
   return (
-    <div className="flex flex-col flex-1 min-h-0 overflow-hidden">
-      <MenuNavbar
-        onTransform={handleTransform}
-        projectId={projectId}
-        columnProfilesActive={showColumnProfiles}
-        onToggleColumnProfiles={() => setShowColumnProfiles((v) => !v)}
-      />
-      <Table projectId={projectId} data={tableData} showColumnProfiles={showColumnProfiles} />
+    <div className="flex flex-col h-full overflow-hidden">
+      <WorkspaceTabsProvider projectId={projectId} initialTabs={[DATASET_TAB]}>
+        <PanelProvider>
+          <HistoryRefreshProvider>
+            <ColumnProfilesProvider>
+              <WorkspaceContent projectId={projectId} />
+            </ColumnProfilesProvider>
+          </HistoryRefreshProvider>
+        </PanelProvider>
+      </WorkspaceTabsProvider>
     </div>
   );
 }

--- a/dataloom-frontend/src/Components/MenuNavbar.jsx
+++ b/dataloom-frontend/src/Components/MenuNavbar.jsx
@@ -1,144 +1,58 @@
-import { useState, useEffect, useCallback } from "react";
-import FilterForm from "./forms/FilterForm";
-import SortForm from "./forms/SortForm";
-import DropDuplicateForm from "./forms/DropDuplicateForm";
-import AdvQueryFilterForm from "./forms/AdvQueryFilterForm";
-import PivotTableForm from "./forms/PivotTableForm";
-import MeltForm from "./forms/MeltForm";
-import CastDataTypeForm from "./forms/CastDataTypeForm";
-import TrimWhitespaceForm from "./forms/TrimWhitespaceForm";
-import GroupByForm from "./forms/GroupByForm";
-import StringReplaceForm from "./forms/StringReplaceForm";
-import LogsPanel from "./history/LogsPanel";
-import CheckpointsPanel from "./history/CheckpointsPanel";
-import DatasetSummaryPanel from "./profiling/DatasetSummaryPanel";
-import useDatasetSummary from "../hooks/useDatasetSummary";
-import FillEmptyForm from "./forms/FillEmptyForm";
+import { useState } from "react";
 import InputDialog from "./common/InputDialog";
-import ConfirmDialog from "./common/ConfirmDialog";
 import ExportModal from "./ExportModal";
 import Toast from "./common/Toast";
-import {
-  saveProject,
-  getLogs,
-  getCheckpoints,
-  revertToCheckpoint,
-  undoLastTransformation,
-} from "../api";
+import { saveProject, undoLastTransformation } from "../api";
 import proptype from "prop-types";
-import SampleRowsForm from "./forms/SampleRowsForm";
-import { LuDice5 } from "react-icons/lu";
-import {
-  LuFilter,
-  LuArrowUpDown,
-  LuCopyMinus,
-  LuCode,
-  LuTable2,
-  LuSave,
-  LuHistory,
-  LuBookmark,
-  LuDownload,
-  LuRefreshCw,
-  LuScissors,
-  LuLayoutList,
-  LuGroup,
-  LuUndo2,
-  LuReplace,
-  LuEraser,
-  LuLayoutDashboard,
-  LuColumns3,
-} from "react-icons/lu";
+import { LuSave, LuDownload, LuUndo2, LuColumns3 } from "react-icons/lu";
 import { useProjectContext } from "../context/ProjectContext";
+import { usePanel } from "../context/PanelContext";
+import { useWorkspaceTabs } from "../context/WorkspaceTabsContext";
+import { useHistoryRefresh } from "../context/HistoryRefreshContext";
+import { useColumnProfilesView } from "../context/ColumnProfilesContext";
+import { DATASET_TAB } from "./workspace/DataSetTab";
+import { getFeatureMenu } from "./workspace/featureRegistry";
 
-const MenuNavbar = ({ projectId, columnProfilesActive, onToggleColumnProfiles }) => {
-  const [showGroupByForm, setShowGroupByForm] = useState(false);
-  const [showFilterForm, setShowFilterForm] = useState(false);
-  const [showSortForm, setShowSortForm] = useState(false);
-  const [showDropDuplicateForm, setShowDropDuplicateForm] = useState(false);
-  const [showAdvQueryFilterForm, setShowAdvQueryFilterForm] = useState(false);
-  const [showPivotTableForm, setShowPivotTableForm] = useState(false);
-  const [showLogs, setShowLogs] = useState(false);
-  const [showCheckpoints, setShowCheckpoints] = useState(false);
-  const [showCastDataTypeForm, setShowCastDataTypeForm] = useState(false);
-  const [showTrimWhitespaceForm, setShowTrimWhitespaceForm] = useState(false);
-  const [showMeltForm, setShowMeltForm] = useState(false);
-  const [showSampleRowsForm, setShowSampleRowsForm] = useState(false);
-  const [showExportModal, setShowExportModal] = useState(false);
-  const [showStringReplaceForm, setShowStringReplaceForm] = useState(false);
-  const [showFillEmptyForm, setShowFillEmptyForm] = useState(false);
-  const [showDatasetSummary, setShowDatasetSummary] = useState(false);
-  const [logs, setLogs] = useState([]);
-  const [checkpoints, setCheckpoints] = useState(null);
+// Ribbon skeleton: the top tabs and the group order within each. Features and the
+// core items below slot their entries into these buckets; layout stays stable.
+const RIBBON_LAYOUT = {
+  File: ["Save", "History"],
+  Data: ["Transform", "Query"],
+  Profiling: ["Profiling"],
+};
+
+const MenuNavbar = ({ projectId }) => {
   const [isInputOpen, setIsInputOpen] = useState(false);
-  const [confirmData, setConfirmData] = useState(null);
+  const [showExportModal, setShowExportModal] = useState(false);
   const [toast, setToast] = useState(null);
+  const [activeTab, setActiveTab] = useState("File");
 
-  const { updateData, refreshProject, pageSize, projectName, isPreviewMode, dataVersion } =
-    useProjectContext();
+  const { updateData, refreshProject, pageSize, projectName, isPreviewMode } = useProjectContext();
+  const { activePanel, togglePanel, closePanel } = usePanel();
+  const { openTab } = useWorkspaceTabs();
+  const { refreshLogs, refreshCheckpoints } = useHistoryRefresh();
+  const { showColumnProfiles, toggleColumnProfiles } = useColumnProfilesView();
 
-  const {
-    summary,
-    error: summaryError,
-    refetch: refetchSummary,
-  } = useDatasetSummary(projectId, showDatasetSummary, dataVersion);
-
-  const fetchLogs = useCallback(async () => {
-    try {
-      const logsResponse = await getLogs(projectId);
-      setLogs(logsResponse);
-    } catch (error) {
-      console.error("Error fetching logs:", error);
-    }
-  }, [projectId]);
-
-  const fetchCheckpoints = useCallback(async () => {
-    try {
-      const checkpointsResponse = await getCheckpoints(projectId);
-      if (Array.isArray(checkpointsResponse)) {
-        setCheckpoints(checkpointsResponse);
-      } else if (checkpointsResponse?.id) {
-        setCheckpoints([checkpointsResponse]);
-      } else {
-        setCheckpoints([]);
-      }
-    } catch (error) {
-      console.error("Error fetching checkpoints:", error);
-      setCheckpoints(null);
-    }
-  }, [projectId]);
-
-  useEffect(() => {
-    if (showLogs) fetchLogs();
-    if (showCheckpoints) fetchCheckpoints();
-  }, [showLogs, showCheckpoints, fetchLogs, fetchCheckpoints]);
-
-  useEffect(() => {
-    const handleLogsRefresh = () => {
-      if (showLogs) fetchLogs();
-    };
-
-    window.addEventListener("project:logs-refresh", handleLogsRefresh);
-
-    return () => {
-      window.removeEventListener("project:logs-refresh", handleLogsRefresh);
-    };
-  }, [showLogs, fetchLogs]);
-
-  const handleSave = () => {
-    setIsInputOpen(true);
+  // Column profiles render inside the DataSet tab, so focus it when turning
+  // them on (re-opens it if the tab was closed).
+  const handleToggleColumnProfiles = () => {
+    if (!showColumnProfiles) openTab(DATASET_TAB);
+    toggleColumnProfiles();
   };
+
+  const handleSave = () => setIsInputOpen(true);
 
   const handleSubmitCommit = async (message) => {
     if (!message || !message.trim()) {
       setToast({ message: "Commit message is required.", type: "error" });
       return;
     }
-
     setIsInputOpen(false);
-
     try {
       await saveProject(projectId, message);
-      await fetchCheckpoints();
+      // Saving creates a checkpoint and marks pending logs as applied.
+      refreshCheckpoints();
+      refreshLogs();
       setToast({ message: "Project saved successfully!", type: "success" });
     } catch {
       setToast({ message: "Failed to save project.", type: "error" });
@@ -148,12 +62,11 @@ const MenuNavbar = ({ projectId, columnProfilesActive, onToggleColumnProfiles })
   const handleUndo = async () => {
     try {
       await undoLastTransformation(projectId);
-      setShowFilterForm(false);
-      setShowSortForm(false);
-      setActiveForm(null);
+      closePanel();
       updateData([], [], { resetColumnOrder: false });
       await refreshProject(projectId, 1, pageSize);
-      await fetchLogs();
+      // Undo removes the last log entry.
+      refreshLogs();
       setToast({ message: "Last transformation undone!", type: "success" });
     } catch (error) {
       if (error.response?.status === 404) {
@@ -164,264 +77,61 @@ const MenuNavbar = ({ projectId, columnProfilesActive, onToggleColumnProfiles })
     }
   };
 
-  const handleRevert = (checkpointId) => {
-    setConfirmData({
-      message: "Are you sure you want to revert to this checkpoint?",
-      onConfirm: async () => {
-        try {
-          const response = await revertToCheckpoint(projectId, checkpointId);
-          updateData(response.columns, response.rows, {
-            dtypes: response.dtypes,
-            resetColumnOrder: false,
-          });
-          setToast({ message: "Project reverted successfully!", type: "success" });
-        } catch {
-          setToast({ message: "Failed to revert project.", type: "error" });
-        }
-        setConfirmData(null);
-      },
-    });
-  };
+  // Core ribbon items — the ones that need component-local state/handlers and so
+  // can't be declared as (declarative) feature menu items.
+  const coreItems = [
+    { ribbon: "File", group: "Save", order: 0, label: "Save", icon: LuSave, onClick: handleSave },
+    {
+      ribbon: "File",
+      group: "Save",
+      order: 1,
+      label: "Export",
+      icon: LuDownload,
+      onClick: () => setShowExportModal(true),
+    },
+    { ribbon: "File", group: "Save", order: 2, label: "Undo", icon: LuUndo2, onClick: handleUndo },
+    {
+      ribbon: "Profiling",
+      group: "Profiling",
+      order: 1,
+      label: "Column Profiles",
+      icon: LuColumns3,
+      onClick: handleToggleColumnProfiles,
+      active: showColumnProfiles,
+    },
+  ];
 
-  const [activeForm, setActiveForm] = useState(null);
+  // Feature-contributed items resolved against the workspace hooks.
+  const featureItems = getFeatureMenu().map((item) => ({
+    ribbon: item.ribbon,
+    group: item.group,
+    order: item.order,
+    label: item.label,
+    icon: item.icon,
+    onClick:
+      "openTab" in item.action
+        ? () => openTab(item.action.openTab)
+        : () => togglePanel(item.action.togglePanel),
+    disabled: item.disabledInPreview ? isPreviewMode : false,
+    active: item.activePanel ? activePanel === item.activePanel : false,
+  }));
 
-  const handleMenuClick = (formType) => {
-    // If clicking the same form that's already open, close it
-    if (activeForm === formType) {
-      setActiveForm(null);
-      setShowFilterForm(false);
-      setShowSortForm(false);
-      setShowDropDuplicateForm(false);
-      setShowAdvQueryFilterForm(false);
-      setShowPivotTableForm(false);
-      setShowCastDataTypeForm(false);
-      setShowTrimWhitespaceForm(false);
-      setShowMeltForm(false);
-      setShowLogs(false);
-      setShowCheckpoints(false);
-      setShowGroupByForm(false);
-      setShowFillEmptyForm(false);
-      setShowSampleRowsForm(false);
-      setShowDatasetSummary(false);
-      return;
-    }
+  const allItems = [...coreItems, ...featureItems];
 
-    setShowSampleRowsForm(false);
-    setShowFilterForm(false);
-    setShowSortForm(false);
-    setShowDropDuplicateForm(false);
-    setShowAdvQueryFilterForm(false);
-    setShowPivotTableForm(false);
-    setShowCastDataTypeForm(false);
-    setShowTrimWhitespaceForm(false);
-    setShowMeltForm(false);
-    setShowStringReplaceForm(false);
-    setShowLogs(false);
-    setShowCheckpoints(false);
-    setShowGroupByForm(false);
-    setShowFillEmptyForm(false);
-    setShowDatasetSummary(false);
-
-    setActiveForm(formType);
-
-    switch (formType) {
-      case "FilterForm":
-        setShowFilterForm(true);
-        break;
-      case "SortForm":
-        setShowSortForm(true);
-        break;
-      case "DropDuplicateForm":
-        setShowDropDuplicateForm(true);
-        break;
-      case "AdvQueryFilterForm":
-        setShowAdvQueryFilterForm(true);
-        break;
-      case "PivotTableForm":
-        setShowPivotTableForm(true);
-        break;
-      case "CastDataTypeForm":
-        setShowCastDataTypeForm(true);
-        break;
-      case "TrimWhitespaceForm":
-        setShowTrimWhitespaceForm(true);
-        break;
-      case "MeltForm":
-        setShowMeltForm(true);
-        break;
-      case "StringReplaceForm":
-        setShowStringReplaceForm(true);
-        break;
-      case "Logs":
-        setShowLogs(true);
-        break;
-      case "Checkpoints":
-        setShowCheckpoints(true);
-        break;
-      case "GroupByForm":
-        setShowGroupByForm(true);
-        break;
-      case "SampleRowsForm":
-        setShowSampleRowsForm(true);
-        break;
-      case "FillEmptyForm":
-        setShowFillEmptyForm(true);
-        break;
-      case "DatasetSummary":
-        setShowDatasetSummary(true);
-        break;
-
-      default:
-        break;
-    }
-  };
-
-  const [activeTab, setActiveTab] = useState("File");
-
-  const tabs = {
-    File: [
-      {
-        group: "Save",
-        items: [
-          { label: "Save", icon: LuSave, onClick: handleSave },
-          { label: "Export", icon: LuDownload, onClick: () => setShowExportModal(true) },
-          { label: "Undo", icon: LuUndo2, onClick: handleUndo },
-        ],
-      },
-      {
-        group: "History",
-        items: [
-          {
-            label: "Logs",
-            icon: LuHistory,
-            formType: "Logs",
-            onClick: () => handleMenuClick("Logs"),
-          },
-          {
-            label: "Checkpoints",
-            icon: LuBookmark,
-            formType: "Checkpoints",
-            onClick: () => handleMenuClick("Checkpoints"),
-          },
-        ],
-      },
-    ],
-    Data: [
-      {
-        group: "Transform",
-        items: [
-          {
-            label: "Filter",
-            icon: LuFilter,
-            formType: "FilterForm",
-            disabled: isPreviewMode,
-            onClick: () => handleMenuClick("FilterForm"),
-          },
-          {
-            label: "Sample",
-            icon: LuDice5,
-            formType: "SampleRowsForm",
-            disabled: isPreviewMode,
-            onClick: () => handleMenuClick("SampleRowsForm"),
-          },
-          {
-            label: "Sort",
-            icon: LuArrowUpDown,
-            formType: "SortForm",
-            disabled: isPreviewMode,
-            onClick: () => handleMenuClick("SortForm"),
-          },
-          {
-            label: "Drop Dup",
-            icon: LuCopyMinus,
-            formType: "DropDuplicateForm",
-            disabled: isPreviewMode,
-            onClick: () => handleMenuClick("DropDuplicateForm"),
-          },
-          {
-            label: "GroupBy",
-            icon: LuGroup,
-            formType: "GroupByForm",
-            disabled: isPreviewMode,
-            onClick: () => handleMenuClick("GroupByForm"),
-          },
-          {
-            label: "Cast Type",
-            icon: LuRefreshCw,
-            formType: "CastDataTypeForm",
-            disabled: isPreviewMode,
-            onClick: () => handleMenuClick("CastDataTypeForm"),
-          },
-          {
-            label: "Trim Space",
-            icon: LuScissors,
-            formType: "TrimWhitespaceForm",
-            disabled: isPreviewMode,
-            onClick: () => handleMenuClick("TrimWhitespaceForm"),
-          },
-          {
-            label: "Replace",
-            icon: LuReplace,
-            formType: "StringReplaceForm",
-            disabled: isPreviewMode,
-            onClick: () => handleMenuClick("StringReplaceForm"),
-          },
-          {
-            label: "Fill Empty",
-            icon: LuEraser,
-            formType: "FillEmptyForm",
-            disabled: isPreviewMode,
-            onClick: () => handleMenuClick("FillEmptyForm"),
-          },
-        ],
-      },
-      {
-        group: "Query",
-        items: [
-          {
-            label: "Adv Query",
-            icon: LuCode,
-            formType: "AdvQueryFilterForm",
-            disabled: isPreviewMode,
-            onClick: () => handleMenuClick("AdvQueryFilterForm"),
-          },
-          {
-            label: "Pivot Table",
-            icon: LuTable2,
-            formType: "PivotTableForm",
-            disabled: isPreviewMode,
-            onClick: () => handleMenuClick("PivotTableForm"),
-          },
-          {
-            label: "Melt (Unpivot)",
-            icon: LuLayoutList,
-            formType: "MeltForm",
-            disabled: isPreviewMode,
-            onClick: () => handleMenuClick("MeltForm"),
-          },
-        ],
-      },
-    ],
-    Profile: [
-      {
-        group: "Profile",
-        items: [
-          {
-            label: "Overview",
-            icon: LuLayoutDashboard,
-            formType: "DatasetSummary",
-            onClick: () => handleMenuClick("DatasetSummary"),
-          },
-          {
-            label: "Columns",
-            icon: LuColumns3,
-            active: columnProfilesActive,
-            onClick: onToggleColumnProfiles,
-          },
-        ],
-      },
-    ],
-  };
+  // Bucket items into the ribbon skeleton, dropping empty groups.
+  const tabs = Object.fromEntries(
+    Object.entries(RIBBON_LAYOUT).map(([ribbon, groups]) => [
+      ribbon,
+      groups
+        .map((group) => ({
+          group,
+          items: allItems
+            .filter((it) => it.ribbon === ribbon && it.group === group)
+            .sort((a, b) => a.order - b.order),
+        }))
+        .filter((section) => section.items.length > 0),
+    ]),
+  );
 
   return (
     <div className="bg-white border-b border-gray-200">
@@ -449,7 +159,7 @@ const MenuNavbar = ({ projectId, columnProfilesActive, onToggleColumnProfiles })
             <div className="flex flex-col items-center">
               <div className="flex items-center gap-1 flex-1">
                 {section.items.map((item) => {
-                  const isActive = item.formType ? activeForm === item.formType : !!item.active;
+                  const isActive = Boolean(item.active);
                   return (
                     <button
                       key={item.label}
@@ -472,154 +182,10 @@ const MenuNavbar = ({ projectId, columnProfilesActive, onToggleColumnProfiles })
                   );
                 })}
               </div>
-              <span className="text-[10px] text-gray-400 uppercase tracking-wider mt-0.5">
-                {section.group}
-              </span>
             </div>
           </div>
         ))}
       </div>
-
-      {showFilterForm && (
-        <FilterForm
-          onClose={() => {
-            setShowFilterForm(false);
-            setActiveForm(null);
-          }}
-          projectId={projectId}
-        />
-      )}
-      {showSortForm && (
-        <SortForm
-          onClose={() => {
-            setShowSortForm(false);
-            setActiveForm(null);
-          }}
-          projectId={projectId}
-        />
-      )}
-      {showDropDuplicateForm && (
-        <DropDuplicateForm
-          projectId={projectId}
-          onClose={() => {
-            setShowDropDuplicateForm(false);
-            setActiveForm(null);
-          }}
-        />
-      )}
-      {showAdvQueryFilterForm && (
-        <AdvQueryFilterForm
-          onClose={() => {
-            setShowAdvQueryFilterForm(false);
-            setActiveForm(null);
-          }}
-          projectId={projectId}
-        />
-      )}
-      {showPivotTableForm && (
-        <PivotTableForm
-          onClose={() => {
-            setShowPivotTableForm(false);
-            setActiveForm(null);
-          }}
-          projectId={projectId}
-        />
-      )}
-      {showMeltForm && (
-        <MeltForm
-          onClose={() => {
-            setShowMeltForm(false);
-            setActiveForm(null);
-          }}
-          projectId={projectId}
-        />
-      )}
-      {showCastDataTypeForm && (
-        <CastDataTypeForm
-          projectId={projectId}
-          onClose={() => {
-            setShowCastDataTypeForm(false);
-            setActiveForm(null);
-          }}
-        />
-      )}
-      {showTrimWhitespaceForm && (
-        <TrimWhitespaceForm
-          projectId={projectId}
-          onClose={() => {
-            setShowTrimWhitespaceForm(false);
-            setActiveForm(null);
-          }}
-        />
-      )}
-      {showStringReplaceForm && (
-        <StringReplaceForm
-          projectId={projectId}
-          onClose={() => {
-            setShowStringReplaceForm(false);
-            setActiveForm(null);
-          }}
-        />
-      )}
-      {showLogs && (
-        <LogsPanel
-          logs={logs}
-          onClose={() => {
-            setShowLogs(false);
-            setActiveForm(null);
-          }}
-        />
-      )}
-      {showCheckpoints && (
-        <CheckpointsPanel
-          projectId={projectId}
-          checkpoints={checkpoints}
-          onClose={() => {
-            setShowCheckpoints(false);
-            setActiveForm(null);
-          }}
-          onRevert={handleRevert}
-          onCheckpointDeleted={fetchCheckpoints}
-        />
-      )}
-      {showGroupByForm && (
-        <GroupByForm
-          projectId={projectId}
-          onClose={() => {
-            setShowGroupByForm(false);
-            setActiveForm(null);
-          }}
-        />
-      )}
-      {showFillEmptyForm && (
-        <FillEmptyForm
-          projectId={projectId}
-          onClose={() => {
-            setShowFillEmptyForm(false);
-            setActiveForm(null);
-          }}
-        />
-      )}
-      {showSampleRowsForm && (
-        <SampleRowsForm
-          projectId={projectId}
-          onClose={() => {
-            setShowSampleRowsForm(false);
-            setActiveForm(null);
-          }}
-        />
-      )}
-      {showDatasetSummary && (
-        <DatasetSummaryPanel
-          summary={summary}
-          error={summaryError}
-          onRetry={refetchSummary}
-          onClose={() => {
-            setShowDatasetSummary(false);
-            setActiveForm(null);
-          }}
-        />
-      )}
 
       <ExportModal
         isOpen={showExportModal}
@@ -637,13 +203,6 @@ const MenuNavbar = ({ projectId, columnProfilesActive, onToggleColumnProfiles })
         onCancel={() => setIsInputOpen(false)}
       />
 
-      <ConfirmDialog
-        isOpen={!!confirmData}
-        message={confirmData?.message}
-        onConfirm={confirmData?.onConfirm}
-        onCancel={() => setConfirmData(null)}
-      />
-
       {toast && (
         <div className="fixed bottom-4 right-4 z-50">
           <Toast message={toast.message} type={toast.type} onDismiss={() => setToast(null)} />
@@ -655,8 +214,6 @@ const MenuNavbar = ({ projectId, columnProfilesActive, onToggleColumnProfiles })
 
 MenuNavbar.propTypes = {
   projectId: proptype.string.isRequired,
-  columnProfilesActive: proptype.bool,
-  onToggleColumnProfiles: proptype.func,
 };
 
 export default MenuNavbar;

--- a/dataloom-frontend/src/Components/Table.tsx
+++ b/dataloom-frontend/src/Components/Table.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useMemo, useRef, type ReactNode, type KeyboardEven
 import { ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight } from "lucide-react";
 import { transformProject } from "../api";
 import { useProjectContext } from "../context/ProjectContext";
+import { useHistoryRefresh } from "../context/HistoryRefreshContext";
 import {
   ADD_COLUMN,
   ADD_ROW,
@@ -27,12 +28,6 @@ interface TransformResponse {
   columns: string[];
   rows: Array<Cell[] | Record<string, Cell>>;
   dtypes?: Record<string, string>;
-}
-
-/** Project data passed in directly, bypassing ProjectContext. */
-interface ExternalData {
-  columns: string[];
-  rows: Array<Record<string, Cell>>;
 }
 
 type ToastType = "success" | "error" | "info" | "warning";
@@ -104,11 +99,10 @@ function normalizeRows(rows: Array<Cell[] | Record<string, Cell>>): Cell[][] {
 
 interface TableProps {
   projectId: string;
-  data?: ExternalData;
   showColumnProfiles?: boolean;
 }
 
-const Table = ({ projectId, data: externalData, showColumnProfiles = false }: TableProps) => {
+const Table = ({ projectId, showColumnProfiles = false }: TableProps) => {
   const {
     columns: ctxColumns,
     rows: ctxRows,
@@ -124,6 +118,7 @@ const Table = ({ projectId, data: externalData, showColumnProfiles = false }: Ta
     setPaginationData,
     refreshProject,
   } = useProjectContext() as unknown as ProjectContextValue;
+  const { refreshLogs } = useHistoryRefresh();
   const [data, setData] = useState<Cell[][]>([]);
   const [columns, setColumns] = useState<string[]>([]);
   const [editingCell, setEditingCell] = useState<EditingCell | null>(null);
@@ -165,14 +160,6 @@ const Table = ({ projectId, data: externalData, showColumnProfiles = false }: Ta
     }
   }, [ctxColumns, ctxRows, page, pageSize, columnOrder, safeOrder]);
 
-  useEffect(() => {
-    if (externalData) {
-      const { columns, rows } = externalData;
-      setColumns(["S.No.", ...columns]);
-      setData(rows.map((row, index) => [index + 1, ...Object.values(row)]));
-    }
-  }, [externalData]);
-
   const updateTableData = (response: TransformResponse) => {
     const { columns, rows, dtypes: newDtypes } = response;
     setColumns(["S.No.", ...columns]);
@@ -180,6 +167,8 @@ const Table = ({ projectId, data: externalData, showColumnProfiles = false }: Ta
     // updateData resets the saved column order when the column count changes,
     // which covers add/delete column; rename and row ops keep the order.
     updateData(columns, normalizeRows(rows), { dtypes: newDtypes });
+    // Every Table transform is persisted, so refresh any open Logs tab.
+    refreshLogs();
   };
 
   const handleAddRow = async (index: number) => {
@@ -536,7 +525,7 @@ const Table = ({ projectId, data: externalData, showColumnProfiles = false }: Ta
         </div>
       </div>
 
-      <div className="mt-auto bg-white shadow-lg border-t border-gray-200 z-10">
+      <div className="mt-auto bg-white border-t border-gray-200 z-10">
         <TablePagination
           totalRows={totalRows}
           totalPages={totalPages}
@@ -669,24 +658,24 @@ export function TablePagination({
   };
 
   return (
-    <div className="flex flex-col gap-3 px-4 py-3 bg-white sm:flex-row sm:items-center sm:justify-between sm:px-8">
+    <div className="flex h-9 shrink-0 items-center justify-between gap-2 px-4 bg-white text-xs sm:px-6">
       {/* Left: Total Rows + Page Size */}
-      <div className="flex flex-wrap items-center gap-x-6 gap-y-2 text-sm text-gray-600">
-        <div className="flex items-center gap-2">
+      <div className="flex flex-wrap items-center gap-x-5 gap-y-1.5 text-gray-600">
+        <div className="flex items-center gap-1.5">
           <span className="text-gray-500">Total Rows:</span>
           <span className="text-gray-900">{totalRows}</span>
         </div>
-        <div className="relative flex items-center gap-2">
+        <div className="relative flex items-center gap-1.5">
           <span className="text-gray-500">Page Size:</span>
           <div className="relative inline-block">
             <button
               onClick={() => setPageSizeOpen(!pageSizeOpen)}
-              className="min-w-[40px] rounded-md border-2 border-gray-300 px-4 py-1 text-center text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="min-w-[34px] rounded border border-gray-300 px-2 py-0.5 text-center focus:outline-none focus:ring-1 focus:ring-blue-500"
             >
               {pageSize}
             </button>
             {pageSizeOpen && (
-              <div className="absolute bottom-full z-10 mb-1 min-w-[60px] rounded-lg border-2 border-gray-300 bg-white shadow-lg">
+              <div className="absolute bottom-full z-10 mb-1 min-w-[52px] rounded-md border border-gray-300 bg-white shadow-md">
                 {pageSizeOptions.map((size) => (
                   <div
                     key={size}
@@ -694,7 +683,7 @@ export function TablePagination({
                       onPageSizeChange(size);
                       setPageSizeOpen(false);
                     }}
-                    className="cursor-pointer rounded-md px-4 py-2 text-sm hover:bg-blue-50 hover:text-blue-700"
+                    className="cursor-pointer rounded px-3 py-1 hover:bg-blue-50 hover:text-blue-700"
                   >
                     {size}
                   </div>
@@ -706,26 +695,26 @@ export function TablePagination({
       </div>
 
       {/* Right: nav buttons + Page X of Y */}
-      <div className="flex flex-wrap items-center justify-center gap-2 sm:flex-nowrap sm:justify-end">
+      <div className="flex flex-wrap items-center justify-center gap-1.5 sm:flex-nowrap sm:justify-end">
         <button
           onClick={handleFirst}
           disabled={page === 1}
-          className="rounded-md border-2 border-gray-300 p-1.5 transition-colors hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-40"
+          className="rounded border border-gray-300 p-1 transition-colors hover:bg-blue-50 focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-40"
           aria-label="First page"
         >
-          <ChevronsLeft className="h-5 w-5 text-gray-700" />
+          <ChevronsLeft className="h-3.5 w-3.5 text-gray-700" />
         </button>
         <button
           onClick={handlePrevious}
           disabled={page === 1}
-          className="rounded-md border-2 border-gray-300 p-1.5 transition-colors hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-40"
+          className="rounded border border-gray-300 p-1 transition-colors hover:bg-blue-50 focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-40"
           aria-label="Previous page"
         >
-          <ChevronLeft className="h-5 w-5 text-gray-700" />
+          <ChevronLeft className="h-3.5 w-3.5 text-gray-700" />
         </button>
 
         {/* Page X of Y — X always editable */}
-        <div className="flex items-center gap-1.5 text-sm text-gray-600 select-none">
+        <div className="flex items-center gap-1 text-gray-600 select-none">
           <span className="text-gray-500">Page</span>
           <input
             ref={pageInputRef}
@@ -738,7 +727,7 @@ export function TablePagination({
             onKeyDown={handlePageInputKeyDown}
             onBlur={commitPageInput}
             title={`Enter a page between 1 and ${totalPages}`}
-            className="h-7 w-14 rounded-md border-2 border-gray-300 px-1.5 text-center text-sm text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+            className="h-6 w-11 rounded border border-gray-300 px-1 text-center text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
             aria-label="Current page"
           />
           <span className="text-gray-500">of {totalPages}</span>
@@ -747,18 +736,18 @@ export function TablePagination({
         <button
           onClick={handleNext}
           disabled={page === totalPages}
-          className="rounded-md border-2 border-gray-300 p-1.5 transition-colors hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-40"
+          className="rounded border border-gray-300 p-1 transition-colors hover:bg-blue-50 focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-40"
           aria-label="Next page"
         >
-          <ChevronRight className="h-5 w-5 text-gray-700" />
+          <ChevronRight className="h-3.5 w-3.5 text-gray-700" />
         </button>
         <button
           onClick={handleLast}
           disabled={page === totalPages}
-          className="rounded-md border-2 border-gray-300 p-1.5 transition-colors hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-40"
+          className="rounded border border-gray-300 p-1 transition-colors hover:bg-blue-50 focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-40"
           aria-label="Last page"
         >
-          <ChevronsRight className="h-5 w-5 text-gray-700" />
+          <ChevronsRight className="h-3.5 w-3.5 text-gray-700" />
         </button>
       </div>
     </div>

--- a/dataloom-frontend/src/Components/common/SidePanel.tsx
+++ b/dataloom-frontend/src/Components/common/SidePanel.tsx
@@ -1,0 +1,39 @@
+import { X } from "lucide-react";
+import type { ReactNode } from "react";
+
+interface SidePanelProps {
+  title: string;
+  onClose: () => void;
+  children: ReactNode;
+}
+
+/**
+ * Right-docked drawer for workspace forms and panels. Rendered as a flex sibling
+ * of the table so it pushes the table aside rather than overlaying it. Header
+ * shows the title + close button; the body scrolls vertically.
+ */
+const SidePanel = ({ title, onClose, children }: SidePanelProps) => {
+  return (
+    <aside
+      data-testid="side-panel"
+      aria-label={title}
+      className="flex w-96 shrink-0 flex-col border-l border-gray-200 bg-white"
+    >
+      <div className="flex items-center justify-between border-b bg-gray-50 border-gray-200 h-9 px-4">
+        <h3 className="text-sm font-semibold text-gray-900">{title}</h3>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close panel"
+          data-testid="side-panel-close"
+          className="flex h-7 w-7 items-center justify-center rounded-md text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-700"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+      <div className="flex-1 overflow-y-auto p-4">{children}</div>
+    </aside>
+  );
+};
+
+export default SidePanel;

--- a/dataloom-frontend/src/Components/forms/AdvQueryFilterForm.jsx
+++ b/dataloom-frontend/src/Components/forms/AdvQueryFilterForm.jsx
@@ -46,9 +46,8 @@ const AdvQueryFilterForm = ({ projectId, onClose }) => {
   };
 
   return (
-    <div className="p-4 border border-gray-200 rounded-lg bg-white">
+    <div>
       <form onSubmit={handleSubmit}>
-        <h3 className="font-semibold text-gray-900 mb-2">Advanced Query</h3>
         <div className="mb-2">
           <label className="block text-sm font-medium text-gray-700">Query:</label>
           <input

--- a/dataloom-frontend/src/Components/forms/CastDataTypeForm.jsx
+++ b/dataloom-frontend/src/Components/forms/CastDataTypeForm.jsx
@@ -8,6 +8,7 @@ import FormErrorAlert from "../common/FormErrorAlert";
 import ColumnSelect from "../common/ColumnSelect";
 import Select from "../common/Select";
 import { useProjectContext } from "../../context/ProjectContext";
+import { useHistoryRefresh } from "../../context/HistoryRefreshContext";
 import Button from "../common/Button";
 
 const TARGET_TYPES = [
@@ -25,6 +26,7 @@ const CastDataTypeForm = ({ projectId, onClose }) => {
   const [targetType, setTargetType] = useState("string");
   const { error, setError, clearError, handleError } = useError();
   const { updateData, refreshProject, pageSize } = useProjectContext();
+  const { refreshLogs } = useHistoryRefresh();
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -50,6 +52,7 @@ const CastDataTypeForm = ({ projectId, onClose }) => {
         resetColumnOrder: false,
       });
       await refreshProject(projectId, 1, pageSize);
+      refreshLogs();
       onClose();
     } catch (err) {
       console.error("Error casting data type:", err);
@@ -59,24 +62,20 @@ const CastDataTypeForm = ({ projectId, onClose }) => {
   };
 
   return (
-    <div className="p-4 border border-gray-200 rounded-lg bg-white">
+    <div>
       <form onSubmit={handleSubmit}>
-        <h3 className="font-semibold text-gray-900 mb-2">Cast Data Type</h3>
+        <div className="mb-3">
+          <label className="block text-sm font-medium text-gray-700">Column:</label>
+          <ColumnSelect
+            value={column}
+            onChange={(value) => setColumn(value)}
+            placeholder="Select column..."
+          />
+        </div>
 
-        <div className="flex space-x-2 mb-4">
-          <div className="flex-1">
-            <label className="block text-sm font-medium text-gray-700">Column:</label>
-            <ColumnSelect
-              value={column}
-              onChange={(value) => setColumn(value)}
-              placeholder="Select column..."
-            />
-          </div>
-
-          <div className="flex-1">
-            <label className="block text-sm font-medium text-gray-700">Target Type:</label>
-            <Select value={targetType} onChange={setTargetType} options={TARGET_TYPES} />
-          </div>
+        <div className="mb-4">
+          <label className="block text-sm font-medium text-gray-700">Target Type:</label>
+          <Select value={targetType} onChange={setTargetType} options={TARGET_TYPES} />
         </div>
 
         <div className="flex justify-between">

--- a/dataloom-frontend/src/Components/forms/DropDuplicateForm.jsx
+++ b/dataloom-frontend/src/Components/forms/DropDuplicateForm.jsx
@@ -63,18 +63,15 @@ const DropDuplicateForm = ({ projectId, onClose }) => {
   };
 
   return (
-    <div className="p-4 border border-gray-200 rounded-lg bg-white">
+    <div>
       <form onSubmit={handleSubmit}>
-        <h3 className="font-semibold text-gray-900 mb-2">Drop Duplicate</h3>
-        <div className="flex space-x-2 mb-4">
-          <div className="flex-1">
-            <label className="block text-sm font-medium text-gray-700">Columns:</label>
-            <ColumnMultiSelect value={columns} onChange={setColumns} required />
-          </div>
-          <div className="flex-1">
-            <label className="block text-sm font-medium text-gray-700">Keep:</label>
-            <Select value={keep} onChange={setKeep} options={KEEP_OPTIONS} />
-          </div>
+        <div className="mb-3">
+          <label className="block text-sm font-medium text-gray-700">Columns:</label>
+          <ColumnMultiSelect value={columns} onChange={setColumns} required />
+        </div>
+        <div className="mb-4">
+          <label className="block text-sm font-medium text-gray-700">Keep:</label>
+          <Select value={keep} onChange={setKeep} options={KEEP_OPTIONS} />
         </div>
         <div className="flex justify-between">
           <div className="flex gap-2">

--- a/dataloom-frontend/src/Components/forms/FillEmptyForm.tsx
+++ b/dataloom-frontend/src/Components/forms/FillEmptyForm.tsx
@@ -1,6 +1,7 @@
 import { useState, FormEvent } from "react";
 import { transformProject } from "../../api";
 import { useProjectContext } from "../../context/ProjectContext";
+import { useHistoryRefresh } from "../../context/HistoryRefreshContext";
 import { useToast } from "../../context/ToastContext";
 import useError from "../../hooks/useError";
 import FormErrorAlert from "../common/FormErrorAlert";
@@ -18,6 +19,7 @@ const STRATEGIES = [
 
 const FillEmptyForm = ({ projectId, onClose }: { projectId: string; onClose: () => void }) => {
   const { columns, refreshProject, pageSize } = useProjectContext();
+  const { refreshLogs } = useHistoryRefresh();
   const { showToast } = useToast();
   const { error, clearError, handleError } = useError();
 
@@ -50,6 +52,7 @@ const FillEmptyForm = ({ projectId, onClose }: { projectId: string; onClose: () 
       });
 
       await refreshProject(projectId, 1, pageSize);
+      refreshLogs();
       onClose();
     } catch (err) {
       handleError(err);
@@ -62,9 +65,8 @@ const FillEmptyForm = ({ projectId, onClose }: { projectId: string; onClose: () 
   };
 
   return (
-    <div className="p-4 border border-gray-200 rounded-lg bg-white">
+    <div>
       <form onSubmit={handleSubmit}>
-        <h3 className="font-semibold text-gray-900 mb-4">Fill Empty Cells</h3>
 
         <div className="mb-4">
           <label className="block text-sm font-medium text-gray-700 mb-1">Column:</label>

--- a/dataloom-frontend/src/Components/forms/FilterForm.jsx
+++ b/dataloom-frontend/src/Components/forms/FilterForm.jsx
@@ -80,40 +80,37 @@ const FilterForm = ({ projectId, onClose }) => {
   };
 
   return (
-    <div data-testid="filter-form" className="p-4 border border-gray-200 rounded-lg bg-white">
+    <div data-testid="filter-form">
       <form onSubmit={handleSubmit}>
-        <h3 className="font-semibold text-gray-900 mb-2">Filter Dataset</h3>
-        <div className="flex flex-wrap mb-4">
-          <div className="w-full sm:w-1/3 mb-2">
-            <label className="block mb-1 text-sm font-medium text-gray-700">Column:</label>
-            <ColumnSelect
-              name="column"
-              data-testid="filter-column"
-              value={filterParams.column}
-              onChange={(value) => setFilterParams((p) => ({ ...p, column: value }))}
-              placeholder="Select column to filter..."
-            />
-          </div>
-          <div className="w-full sm:w-1/3 mb-2 pl-2">
-            <label className="block mb-1 text-sm font-medium text-gray-700">Condition:</label>
-            <Select
-              value={filterParams.condition}
-              onChange={(value) => setFilterParams((p) => ({ ...p, condition: value }))}
-              options={CONDITIONS}
-            />
-          </div>
-          <div className="w-full sm:w-1/3 mb-2 pl-2">
-            <label className="block mb-1 text-sm font-medium text-gray-700">Value:</label>
-            <input
-              type="text"
-              name="value"
-              data-testid="filter-value"
-              value={filterParams.value}
-              onChange={handleInputChange}
-              className="border border-gray-300 rounded-md px-3 py-2 w-full bg-white text-gray-900 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none"
-              required
-            />
-          </div>
+        <div className="mb-3">
+          <label className="block mb-1 text-sm font-medium text-gray-700">Column:</label>
+          <ColumnSelect
+            name="column"
+            data-testid="filter-column"
+            value={filterParams.column}
+            onChange={(value) => setFilterParams((p) => ({ ...p, column: value }))}
+            placeholder="Select column to filter..."
+          />
+        </div>
+        <div className="mb-3">
+          <label className="block mb-1 text-sm font-medium text-gray-700">Condition:</label>
+          <Select
+            value={filterParams.condition}
+            onChange={(value) => setFilterParams((p) => ({ ...p, condition: value }))}
+            options={CONDITIONS}
+          />
+        </div>
+        <div className="mb-4">
+          <label className="block mb-1 text-sm font-medium text-gray-700">Value:</label>
+          <input
+            type="text"
+            name="value"
+            data-testid="filter-value"
+            value={filterParams.value}
+            onChange={handleInputChange}
+            className="border border-gray-300 rounded-md px-3 py-2 w-full bg-white text-gray-900 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none"
+            required
+          />
         </div>
         <div className="flex justify-between">
           <div className="flex gap-2">

--- a/dataloom-frontend/src/Components/forms/GroupByForm.jsx
+++ b/dataloom-frontend/src/Components/forms/GroupByForm.jsx
@@ -6,6 +6,7 @@ import TransformResultPreview from "./TransformResultPreview";
 import useError from "../../hooks/useError";
 import FormErrorAlert from "../common/FormErrorAlert";
 import { useProjectContext } from "../../context/ProjectContext";
+import { useHistoryRefresh } from "../../context/HistoryRefreshContext";
 import ColumnSelect from "../common/ColumnSelect";
 import ColumnMultiSelect from "../common/ColumnMultiSelect";
 import Select from "../common/Select";
@@ -14,6 +15,7 @@ import { AGG_FUNCTIONS } from "../../constants/aggregations";
 
 const GroupByForm = ({ projectId, onClose }) => {
   const { columns: availableColumns, updateData, refreshProject, pageSize } = useProjectContext();
+  const { refreshLogs } = useHistoryRefresh();
   const [selectedColumns, setSelectedColumns] = useState([]);
   const [aggColumn, setAggColumn] = useState("");
   const [aggFunction, setAggFunction] = useState("sum");
@@ -43,6 +45,7 @@ const GroupByForm = ({ projectId, onClose }) => {
         resetColumnOrder: false,
       });
       await refreshProject(projectId, 1, pageSize);
+      refreshLogs();
     } catch (err) {
       handleError(err);
     } finally {
@@ -51,36 +54,31 @@ const GroupByForm = ({ projectId, onClose }) => {
   };
 
   return (
-    <div className="p-4 border border-gray-200 rounded-lg bg-white">
+    <div>
       <form onSubmit={handleSubmit}>
-        <h3 className="font-semibold text-gray-900 mb-2">GroupBy Aggregation</h3>
-        <div className="flex flex-wrap mb-4">
-          <div className="w-full sm:w-1/3 mb-2">
-            <label className="block mb-1 text-sm font-medium text-gray-700">
-              Group By Columns:
-            </label>
-            <ColumnMultiSelect
-              value={selectedColumns}
-              onChange={setSelectedColumns}
-              options={availableColumns}
-              required
-            />
-          </div>
-          <div className="w-full sm:w-1/3 mb-2 pl-2">
-            <label className="block mb-1 text-sm font-medium text-gray-700">
-              Aggregation Column:
-            </label>
-            <ColumnSelect
-              value={aggColumn}
-              onChange={setAggColumn}
-              options={availableColumns.filter((col) => !selectedColumns.includes(col))}
-              required
-            />
-          </div>
-          <div className="w-full sm:w-1/3 mb-2 pl-2">
-            <label className="block mb-1 text-sm font-medium text-gray-700">Function:</label>
-            <Select value={aggFunction} onChange={setAggFunction} options={AGG_FUNCTIONS} />
-          </div>
+        <div className="mb-3">
+          <label className="block mb-1 text-sm font-medium text-gray-700">Group By Columns:</label>
+          <ColumnMultiSelect
+            value={selectedColumns}
+            onChange={setSelectedColumns}
+            options={availableColumns}
+            required
+          />
+        </div>
+        <div className="mb-3">
+          <label className="block mb-1 text-sm font-medium text-gray-700">
+            Aggregation Column:
+          </label>
+          <ColumnSelect
+            value={aggColumn}
+            onChange={setAggColumn}
+            options={availableColumns.filter((col) => !selectedColumns.includes(col))}
+            required
+          />
+        </div>
+        <div className="mb-4">
+          <label className="block mb-1 text-sm font-medium text-gray-700">Function:</label>
+          <Select value={aggFunction} onChange={setAggFunction} options={AGG_FUNCTIONS} />
         </div>
         <div className="flex justify-between">
           <Button type="submit" disabled={loading || selectedColumns.length === 0 || !aggColumn}>

--- a/dataloom-frontend/src/Components/forms/MeltForm.jsx
+++ b/dataloom-frontend/src/Components/forms/MeltForm.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import TransformResultPreview from "./TransformResultPreview";
 import { transformProject, getProjectDetails } from "../../api";
 import { useProjectContext } from "../../context/ProjectContext";
+import { useHistoryRefresh } from "../../context/HistoryRefreshContext";
 import ColumnMultiSelect from "../common/ColumnMultiSelect";
 import Button from "../common/Button";
 
@@ -16,6 +17,7 @@ const MeltForm = ({ projectId, onClose }) => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const { updateData, refreshProject, pageSize } = useProjectContext();
+  const { refreshLogs } = useHistoryRefresh();
 
   useEffect(() => {
     const fetchProjectDetails = async () => {
@@ -71,6 +73,7 @@ const MeltForm = ({ projectId, onClose }) => {
         resetColumnOrder: false,
       });
       await refreshProject(projectId, 1, pageSize);
+      refreshLogs();
     } catch (err) {
       setError(err.response?.data?.detail || err.message);
     } finally {
@@ -79,19 +82,15 @@ const MeltForm = ({ projectId, onClose }) => {
   };
 
   return (
-    <div className="p-4 border border-gray-200 rounded-lg bg-white shadow-sm overflow-hidden">
+    <div>
       <form onSubmit={handleSubmit} className="space-y-4">
-        <h3 className="font-semibold text-gray-900 flex items-center gap-2">
-          Melt (Unpivot) Dataset
-        </h3>
-
         {error && (
           <div className="bg-red-50 text-red-600 p-2 rounded text-sm border border-red-100">
             {typeof error === "string" ? error : JSON.stringify(error, null, 2)}
           </div>
         )}
 
-        <div className="grid grid-cols-2 gap-4">
+        <div className="grid grid-cols-1 gap-4">
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">
               ID Variables (Keep as columns):
@@ -111,7 +110,7 @@ const MeltForm = ({ projectId, onClose }) => {
           </div>
         </div>
 
-        <div className="grid grid-cols-2 gap-4">
+        <div className="grid grid-cols-1 gap-4">
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">Variable Name:</label>
             <input

--- a/dataloom-frontend/src/Components/forms/PivotTableForm.jsx
+++ b/dataloom-frontend/src/Components/forms/PivotTableForm.jsx
@@ -9,6 +9,7 @@ import ColumnSelect from "../common/ColumnSelect";
 import ColumnMultiSelect from "../common/ColumnMultiSelect";
 import Select from "../common/Select";
 import { useProjectContext } from "../../context/ProjectContext";
+import { useHistoryRefresh } from "../../context/HistoryRefreshContext";
 import Button from "../common/Button";
 import { AGG_FUNCTIONS } from "../../constants/aggregations";
 
@@ -21,6 +22,7 @@ const PivotTableForm = ({ projectId, onClose }) => {
   const [loading, setLoading] = useState(false);
   const { error, setError, clearError, handleError } = useError();
   const { updateData, refreshProject, pageSize } = useProjectContext();
+  const { refreshLogs } = useHistoryRefresh();
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -48,6 +50,7 @@ const PivotTableForm = ({ projectId, onClose }) => {
         resetColumnOrder: false,
       });
       await refreshProject(projectId, 1, pageSize);
+      refreshLogs();
     } catch (err) {
       console.error("Error applying pivot table:", err.message);
       handleError(err);
@@ -57,36 +60,31 @@ const PivotTableForm = ({ projectId, onClose }) => {
   };
 
   return (
-    <div className="p-4 border border-gray-200 rounded-lg bg-white">
+    <div>
       <form onSubmit={handleSubmit}>
-        <h3 className="font-semibold text-gray-900 mb-2">Pivot Table</h3>
-        <div className="flex space-x-2 mb-4">
-          <div className="flex-1">
-            <label className="block text-sm font-medium text-gray-700">Index:</label>
-            <ColumnMultiSelect value={index} onChange={setIndex} required />
-          </div>
-          <div className="flex-1">
-            <label className="block text-sm font-medium text-gray-700">Column:</label>
-            <ColumnSelect
-              value={column}
-              onChange={(value) => setColumn(value)}
-              placeholder="Select column..."
-            />
-          </div>
+        <div className="mb-3">
+          <label className="block text-sm font-medium text-gray-700">Index:</label>
+          <ColumnMultiSelect value={index} onChange={setIndex} required />
         </div>
-        <div className="flex space-x-2 mb-4">
-          <div className="flex-1">
-            <label className="block text-sm font-medium text-gray-700">Value:</label>
-            <ColumnSelect
-              value={value}
-              onChange={(value) => setValue(value)}
-              placeholder="Select column..."
-            />
-          </div>
-          <div className="flex-1">
-            <label className="block text-sm font-medium text-gray-700">Aggregation Function:</label>
-            <Select value={aggfun} onChange={setAggfun} options={AGG_FUNCTIONS} />
-          </div>
+        <div className="mb-3">
+          <label className="block text-sm font-medium text-gray-700">Column:</label>
+          <ColumnSelect
+            value={column}
+            onChange={(value) => setColumn(value)}
+            placeholder="Select column..."
+          />
+        </div>
+        <div className="mb-3">
+          <label className="block text-sm font-medium text-gray-700">Value:</label>
+          <ColumnSelect
+            value={value}
+            onChange={(value) => setValue(value)}
+            placeholder="Select column..."
+          />
+        </div>
+        <div className="mb-4">
+          <label className="block text-sm font-medium text-gray-700">Aggregation Function:</label>
+          <Select value={aggfun} onChange={setAggfun} options={AGG_FUNCTIONS} />
         </div>
         <div className="flex justify-between">
           <Button type="submit" disabled={loading}>

--- a/dataloom-frontend/src/Components/forms/SampleRowsForm.jsx
+++ b/dataloom-frontend/src/Components/forms/SampleRowsForm.jsx
@@ -72,38 +72,35 @@ const SampleRowsForm = ({ projectId, onClose }) => {
   };
 
   return (
-    <div className="p-4 border border-gray-200 rounded-lg bg-white">
+    <div>
       <form onSubmit={handleSubmit}>
-        <h3 className="font-semibold text-gray-900 mb-2">Sample Rows</h3>
-        <div className="flex flex-wrap mb-4">
-          <div className="w-full sm:w-1/2 mb-2">
-            <label className="block mb-1 text-sm font-medium text-gray-700">Sample Size:</label>
-            <input
-              type="number"
-              min="1"
-              step="1"
-              value={sampleSize}
-              onChange={(e) => setSampleSize(e.target.value)}
-              placeholder="e.g., 100"
-              className="border border-gray-300 rounded-md px-3 py-2 w-full bg-white text-gray-900 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none"
-              required
-            />
-          </div>
-          <div className="w-full sm:w-1/2 mb-2 pl-2">
-            <label className="block mb-1 text-sm font-medium text-gray-700">
-              Random Seed (Optional):
-            </label>
-            <input
-              type="number"
-              min="0"
-              max="4294967295"
-              step="1"
-              value={randomSeed}
-              onChange={(e) => setRandomSeed(e.target.value)}
-              placeholder="e.g., 42"
-              className="border border-gray-300 rounded-md px-3 py-2 w-full bg-white text-gray-900 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none"
-            />
-          </div>
+        <div className="mb-3">
+          <label className="block mb-1 text-sm font-medium text-gray-700">Sample Size:</label>
+          <input
+            type="number"
+            min="1"
+            step="1"
+            value={sampleSize}
+            onChange={(e) => setSampleSize(e.target.value)}
+            placeholder="e.g., 100"
+            className="border border-gray-300 rounded-md px-3 py-2 w-full bg-white text-gray-900 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none"
+            required
+          />
+        </div>
+        <div className="mb-4">
+          <label className="block mb-1 text-sm font-medium text-gray-700">
+            Random Seed (Optional):
+          </label>
+          <input
+            type="number"
+            min="0"
+            max="4294967295"
+            step="1"
+            value={randomSeed}
+            onChange={(e) => setRandomSeed(e.target.value)}
+            placeholder="e.g., 42"
+            className="border border-gray-300 rounded-md px-3 py-2 w-full bg-white text-gray-900 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none"
+          />
         </div>
         <div className="flex justify-between">
           <div className="flex gap-2">

--- a/dataloom-frontend/src/Components/forms/SortForm.jsx
+++ b/dataloom-frontend/src/Components/forms/SortForm.jsx
@@ -8,6 +8,7 @@ import FormErrorAlert from "../common/FormErrorAlert";
 import ColumnSelect from "../common/ColumnSelect";
 import Select from "../common/Select";
 import { useProjectContext } from "../../context/ProjectContext";
+import { useHistoryRefresh } from "../../context/HistoryRefreshContext";
 import Button from "../common/Button";
 
 const ORDER_OPTIONS = [
@@ -21,6 +22,7 @@ const ORDER_OPTIONS = [
  */
 const SortForm = ({ projectId, onClose }) => {
   const { updateData, refreshProject, pageSize } = useProjectContext();
+  const { refreshLogs } = useHistoryRefresh();
   const [criteria, setCriteria] = useState([{ id: 1, column: "", ascending: true }]);
   const [nextId, setNextId] = useState(2);
   const [result, setResult] = useState(null);
@@ -101,6 +103,7 @@ const SortForm = ({ projectId, onClose }) => {
         resetColumnOrder: false,
       });
       await refreshProject(projectId, 1, pageSize);
+      refreshLogs();
     } catch (err) {
       handleError(err);
     } finally {
@@ -109,9 +112,8 @@ const SortForm = ({ projectId, onClose }) => {
   };
 
   return (
-    <div data-testid="sort-form" className="p-4 border border-gray-200 rounded-lg bg-white">
+    <div data-testid="sort-form">
       <form onSubmit={handleSubmit}>
-        <h3 className="font-semibold text-gray-900 mb-2">Sort Dataset</h3>
         <p className="text-sm text-gray-600 mb-4">
           Add multiple sort criteria. Priority is determined by order (top = primary sort).
         </p>

--- a/dataloom-frontend/src/Components/forms/StringReplaceForm.jsx
+++ b/dataloom-frontend/src/Components/forms/StringReplaceForm.jsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import PropTypes from "prop-types";
 import { transformProject } from "../../api";
 import { useProjectContext } from "../../context/ProjectContext";
+import { useHistoryRefresh } from "../../context/HistoryRefreshContext";
 import { useToast } from "../../context/ToastContext";
 import { STRING_REPLACE } from "../../constants/operationTypes";
 import useError from "../../hooks/useError";
@@ -11,6 +12,7 @@ import Button from "../common/Button";
 
 const StringReplaceForm = ({ projectId, onClose }) => {
   const { updateData, refreshProject, pageSize } = useProjectContext();
+  const { refreshLogs } = useHistoryRefresh();
   const { showToast } = useToast();
 
   const [column, setColumn] = useState("");
@@ -43,6 +45,7 @@ const StringReplaceForm = ({ projectId, onClose }) => {
         resetColumnOrder: false,
       });
       await refreshProject(projectId, 1, pageSize);
+      refreshLogs();
       onClose();
     } catch (error) {
       console.error("Error replacing string:", error);
@@ -59,10 +62,8 @@ const StringReplaceForm = ({ projectId, onClose }) => {
   };
 
   return (
-    <div className="p-4 border border-gray-200 rounded-lg bg-white">
+    <div>
       <form onSubmit={handleSubmit}>
-        <h3 className="font-semibold text-gray-900 mb-2">Find & Replace</h3>
-
         <div className="mb-4">
           <label className="block text-sm font-medium text-gray-700">Column:</label>
           <ColumnSelect value={column} onChange={setColumn} required />

--- a/dataloom-frontend/src/Components/forms/TransformResultPreview.jsx
+++ b/dataloom-frontend/src/Components/forms/TransformResultPreview.jsx
@@ -25,7 +25,7 @@ const TransformResultPreview = ({ columns, rows }) => {
   return (
     <div
       data-testid="transform-preview"
-      className="mt-2 border border-gray-200 rounded-lg shadow-sm overflow-hidden bg-white"
+      className="mt-2 border border-gray-200 rounded-lg overflow-hidden bg-white"
     >
       <div className="overflow-x-auto overflow-y-auto max-h-72">
         <table data-testid="preview-table" className="min-w-full bg-white border-collapse">

--- a/dataloom-frontend/src/Components/forms/TrimWhitespaceForm.jsx
+++ b/dataloom-frontend/src/Components/forms/TrimWhitespaceForm.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import { transformProject } from "../../api";
 import { TRIM_WHITESPACE } from "../../constants/operationTypes";
 import { useProjectContext } from "../../context/ProjectContext";
+import { useHistoryRefresh } from "../../context/HistoryRefreshContext";
 import { useToast } from "../../context/ToastContext";
 import useError from "../../hooks/useError";
 import FormErrorAlert from "../common/FormErrorAlert";
@@ -11,6 +12,7 @@ import Button from "../common/Button";
 
 const TrimWhitespaceForm = ({ projectId, onClose }) => {
   const { columns, updateData, refreshProject, pageSize } = useProjectContext();
+  const { refreshLogs } = useHistoryRefresh();
   const { showToast } = useToast();
 
   const [column, setColumn] = useState("");
@@ -42,6 +44,7 @@ const TrimWhitespaceForm = ({ projectId, onClose }) => {
         resetColumnOrder: false,
       });
       await refreshProject(projectId, 1, pageSize);
+      refreshLogs();
       onClose();
     } catch (error) {
       console.error("Error trimming whitespace:", error);
@@ -53,10 +56,8 @@ const TrimWhitespaceForm = ({ projectId, onClose }) => {
   };
 
   return (
-    <div className="p-4 border border-gray-200 rounded-lg bg-white">
+    <div>
       <form onSubmit={handleSubmit}>
-        <h3 className="font-semibold text-gray-900 mb-2">Trim Whitespace</h3>
-
         <div className="mb-4">
           <label className="block text-sm font-medium text-gray-700">Column:</label>
           <ColumnSelect

--- a/dataloom-frontend/src/Components/history/CheckpointsPanel.jsx
+++ b/dataloom-frontend/src/Components/history/CheckpointsPanel.jsx
@@ -5,7 +5,7 @@ import Modal from "../common/Modal";
 import { useToast } from "../../context/ToastContext";
 import Button from "../common/Button";
 
-const CheckpointsPanel = ({ projectId, checkpoints, onClose, onRevert, onCheckpointDeleted }) => {
+const CheckpointsPanel = ({ projectId, checkpoints, onRevert, onCheckpointDeleted }) => {
   const [confirmDeleteId, setConfirmDeleteId] = useState(null);
   const { showToast } = useToast();
 
@@ -24,27 +24,8 @@ const CheckpointsPanel = ({ projectId, checkpoints, onClose, onRevert, onCheckpo
   };
 
   return (
-    <div
-      data-testid="checkpoints-panel"
-      className="p-4 bg-white border border-gray-200 rounded-lg shadow-sm mx-auto relative group"
-    >
-      <div className="flex items-center justify-between mb-4">
-        <h3 className="text-lg font-semibold text-gray-900">Checkpoints</h3>
-        <button
-          onClick={onClose}
-          className="text-gray-400 hover:text-gray-600 font-medium transition-opacity opacity-0 group-hover:opacity-100"
-          style={{
-            transition: "opacity 0.3s",
-            background: "transparent",
-            border: "none",
-            cursor: "pointer",
-          }}
-        >
-          Close
-        </button>
-      </div>
-
-      <div className="overflow-x-auto overflow-y-auto max-h-72">
+    <div data-testid="checkpoints-panel">
+      <div className="overflow-x-auto">
         <table className="min-w-full bg-white rounded-lg overflow-hidden">
           <thead className="bg-gray-50 sticky top-0">
             <tr>
@@ -127,7 +108,6 @@ CheckpointsPanel.propTypes = {
       created_at: PropTypes.string.isRequired,
     }),
   ),
-  onClose: PropTypes.func.isRequired,
   onRevert: PropTypes.func.isRequired,
   onCheckpointDeleted: PropTypes.func.isRequired,
 };

--- a/dataloom-frontend/src/Components/history/LogsPanel.jsx
+++ b/dataloom-frontend/src/Components/history/LogsPanel.jsx
@@ -1,28 +1,9 @@
 import PropTypes from "prop-types";
 
-const LogsPanel = ({ logs, onClose }) => {
+const LogsPanel = ({ logs }) => {
   return (
-    <div
-      data-testid="logs-panel"
-      className="p-4 bg-white border border-gray-200 rounded-lg shadow-sm mx-auto relative group"
-    >
-      <div className="flex items-center justify-between mb-4">
-        <h3 className="text-lg font-semibold text-gray-900">Logs</h3>
-        <button
-          onClick={onClose}
-          className="text-gray-400 hover:text-gray-600 font-medium transition-opacity opacity-0 group-hover:opacity-100"
-          style={{
-            transition: "opacity 0.3s",
-            background: "transparent",
-            border: "none",
-            cursor: "pointer",
-          }}
-        >
-          Close
-        </button>
-      </div>
-
-      <div className="mt-4 overflow-x-auto overflow-y-auto max-h-72">
+    <div data-testid="logs-panel">
+      <div className="overflow-x-auto">
         <table className="min-w-full bg-white rounded-lg overflow-hidden">
           <thead className="bg-gray-50">
             <tr>
@@ -79,7 +60,6 @@ LogsPanel.propTypes = {
       applied: PropTypes.bool.isRequired,
     }),
   ).isRequired,
-  onClose: PropTypes.func.isRequired,
 };
 
 export default LogsPanel;

--- a/dataloom-frontend/src/Components/workspace/DataSetTab.tsx
+++ b/dataloom-frontend/src/Components/workspace/DataSetTab.tsx
@@ -1,0 +1,28 @@
+import { useParams } from "react-router-dom";
+import { useColumnProfilesView } from "../../context/ColumnProfilesContext";
+import type { WorkspaceTab } from "../../context/WorkspaceTabsContext";
+import Table from "../Table";
+
+/**
+ * The pinned, built-in tab descriptor for the project's working table. Lives
+ * here next to the component so both DataScreen (initial tab, "+") and the
+ * Profiling menu (focusing the table) share one definition.
+ */
+export const DATASET_TAB: WorkspaceTab = {
+  id: "dataset",
+  title: "DataSet",
+  type: "dataset",
+  closeable: true,
+};
+
+/**
+ * DataSet tab — the built-in tab showing the project's working table. Reads
+ * `projectId` from the route like the other tab adapters, so it renders through
+ * the same registry seam rather than a special case in the workspace. The
+ * inline column-profile row is driven by the shared Profiling toggle.
+ */
+export function DataSetTab() {
+  const { projectId } = useParams() as { projectId: string };
+  const { showColumnProfiles } = useColumnProfilesView();
+  return <Table projectId={projectId} showColumnProfiles={showColumnProfiles} />;
+}

--- a/dataloom-frontend/src/Components/workspace/HistoryTabs.tsx
+++ b/dataloom-frontend/src/Components/workspace/HistoryTabs.tsx
@@ -1,0 +1,155 @@
+import { useState, useEffect, useCallback } from "react";
+import { useParams } from "react-router-dom";
+import { useProjectContext } from "../../context/ProjectContext";
+import { useHistoryRefresh, useHistoryRefreshTokens } from "../../context/HistoryRefreshContext";
+import { getLogs, getCheckpoints, revertToCheckpoint } from "../../api";
+import LogsPanel from "../history/LogsPanel";
+import CheckpointsPanel from "../history/CheckpointsPanel";
+import ConfirmDialog from "../common/ConfirmDialog";
+import Toast from "../common/Toast";
+
+interface LogEntry {
+  id: number;
+  action_type: string;
+  timestamp: string;
+  checkpoint_id?: string | null;
+  applied: boolean;
+}
+
+interface CheckpointEntry {
+  id: string;
+  message: string;
+  created_at: string;
+  [key: string]: unknown;
+}
+
+// revert/checkpoint API helpers are authored in JS (typed as Object); narrow
+// the response shapes this module reads.
+interface RevertResponse {
+  columns: string[];
+  rows: unknown[];
+  dtypes: Record<string, string>;
+}
+
+interface ToastState {
+  message: string;
+  type: "success" | "error" | "info" | "warning";
+}
+
+interface ConfirmData {
+  message: string;
+  onConfirm: () => void | Promise<void>;
+}
+
+// ProjectContext is authored in JS; narrow the one slice this module uses.
+type UpdateData = (
+  columns: string[],
+  rows: unknown[],
+  options?: { dtypes?: Record<string, string>; resetColumnOrder?: boolean },
+) => void;
+
+/** Logs tab — fetches the project's change log and refreshes on transform events. */
+export function LogsTab() {
+  const { projectId } = useParams() as { projectId: string };
+  const { logsToken } = useHistoryRefreshTokens();
+  const [logs, setLogs] = useState<LogEntry[]>([]);
+
+  const fetchLogs = useCallback(async () => {
+    try {
+      setLogs(await getLogs(projectId));
+    } catch (error) {
+      console.error("Error fetching logs:", error);
+    }
+  }, [projectId]);
+
+  // Refetch on mount and whenever a mutation bumps the logs token.
+  useEffect(() => {
+    fetchLogs();
+  }, [fetchLogs, logsToken]);
+
+  return (
+    <div className="flex-1 overflow-auto p-4">
+      <LogsPanel logs={logs} />
+    </div>
+  );
+}
+
+/** Checkpoints tab — lists checkpoints and handles revert/delete. */
+export function CheckpointsTab() {
+  const { projectId } = useParams() as { projectId: string };
+  const { updateData } = useProjectContext() as unknown as { updateData: UpdateData };
+  const { refreshLogs } = useHistoryRefresh();
+  const { checkpointsToken } = useHistoryRefreshTokens();
+  const [checkpoints, setCheckpoints] = useState<CheckpointEntry[] | null>(null);
+  const [confirmData, setConfirmData] = useState<ConfirmData | null>(null);
+  const [toast, setToast] = useState<ToastState | null>(null);
+
+  const fetchCheckpoints = useCallback(async () => {
+    try {
+      const response = (await getCheckpoints(projectId)) as
+        | CheckpointEntry
+        | CheckpointEntry[]
+        | null;
+      if (Array.isArray(response)) {
+        setCheckpoints(response);
+      } else if (response?.id) {
+        setCheckpoints([response]);
+      } else {
+        setCheckpoints([]);
+      }
+    } catch (error) {
+      console.error("Error fetching checkpoints:", error);
+      setCheckpoints(null);
+    }
+  }, [projectId]);
+
+  // Refetch on mount and whenever a save bumps the checkpoints token.
+  useEffect(() => {
+    fetchCheckpoints();
+  }, [fetchCheckpoints, checkpointsToken]);
+
+  const handleRevert = (checkpointId: string) => {
+    setConfirmData({
+      message: "Are you sure you want to revert to this checkpoint?",
+      onConfirm: async () => {
+        try {
+          const response = (await revertToCheckpoint(projectId, checkpointId)) as RevertResponse;
+          updateData(response.columns, response.rows, {
+            dtypes: response.dtypes,
+            resetColumnOrder: false,
+          });
+          // Reverting un-applies later logs, so refresh any open Logs tab.
+          refreshLogs();
+          setToast({ message: "Project reverted successfully!", type: "success" });
+        } catch {
+          setToast({ message: "Failed to revert project.", type: "error" });
+        }
+        setConfirmData(null);
+      },
+    });
+  };
+
+  return (
+    <div className="flex-1 overflow-auto p-4">
+      <CheckpointsPanel
+        projectId={projectId}
+        checkpoints={checkpoints}
+        onRevert={handleRevert}
+        onCheckpointDeleted={fetchCheckpoints}
+      />
+
+      <ConfirmDialog
+        isOpen={!!confirmData}
+        message={confirmData?.message ?? ""}
+        onConfirm={confirmData?.onConfirm ?? (() => {})}
+        onCancel={() => setConfirmData(null)}
+      />
+
+      {toast && (
+        <div className="fixed bottom-4 right-4 z-50">
+          <Toast message={toast.message} type={toast.type} onDismiss={() => setToast(null)} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dataloom-frontend/src/Components/workspace/RightPanel.jsx
+++ b/dataloom-frontend/src/Components/workspace/RightPanel.jsx
@@ -1,0 +1,29 @@
+import PropTypes from "prop-types";
+import { usePanel } from "../../context/PanelContext";
+import SidePanel from "../common/SidePanel";
+import { getPanel } from "./featureRegistry";
+
+/**
+ * Right-docked panel that renders the active feature panel (transform forms, the
+ * chart builder, …). The panel is resolved from the feature registry by the
+ * active panel name; each panel component takes { projectId, onClose }.
+ */
+const RightPanel = ({ projectId }) => {
+  const { activePanel, closePanel } = usePanel();
+
+  const panel = activePanel ? getPanel(activePanel) : undefined;
+  if (!panel) return null;
+
+  const { title, component: Component } = panel;
+  return (
+    <SidePanel title={title} onClose={closePanel}>
+      <Component projectId={projectId} onClose={closePanel} />
+    </SidePanel>
+  );
+};
+
+RightPanel.propTypes = {
+  projectId: PropTypes.string,
+};
+
+export default RightPanel;

--- a/dataloom-frontend/src/Components/workspace/SummaryTab.tsx
+++ b/dataloom-frontend/src/Components/workspace/SummaryTab.tsx
@@ -1,0 +1,30 @@
+import { useParams } from "react-router-dom";
+import { useWorkspaceTabs } from "../../context/WorkspaceTabsContext";
+import { useProjectContext } from "../../context/ProjectContext";
+import useDatasetSummary from "../../hooks/useDatasetSummary";
+import DatasetSummaryPanel from "../profiling/DatasetSummaryPanel";
+
+/**
+ * Summary tab — the dataset-wide overview (row/column counts, dtypes, memory).
+ * Re-homes the profiling overview into the workspace tab system: it fetches via
+ * useDatasetSummary (cached by dataVersion) and renders the same panel upstream
+ * docked above the table.
+ */
+export function SummaryTab() {
+  const { projectId } = useParams() as { projectId: string };
+  const { dataVersion } = useProjectContext() as unknown as { dataVersion: number };
+  const { closeTab } = useWorkspaceTabs();
+  // The tab only mounts while active, so it is always "enabled" when rendered.
+  const { summary, error, refetch } = useDatasetSummary(projectId, true, dataVersion);
+
+  return (
+    <div className="flex-1 overflow-auto p-4">
+      <DatasetSummaryPanel
+        summary={summary}
+        error={error}
+        onRetry={refetch}
+        onClose={() => closeTab("summary")}
+      />
+    </div>
+  );
+}

--- a/dataloom-frontend/src/Components/workspace/TabRegistry.ts
+++ b/dataloom-frontend/src/Components/workspace/TabRegistry.ts
@@ -1,0 +1,28 @@
+import type { ComponentType } from "react";
+import type { WorkspaceTab } from "../../context/WorkspaceTabsContext";
+
+/**
+ * Props every registered tab component receives. `tab` carries the tab metadata
+ * (including its `props` bag), and the bag is also spread on directly for
+ * convenience.
+ */
+export interface TabComponentProps {
+  tab: WorkspaceTab;
+  [key: string]: unknown;
+}
+
+const registry = new Map<string, ComponentType<TabComponentProps>>();
+
+/**
+ * Register a component to render tabs of a given `type`. This is the extension
+ * point for new tab kinds (e.g. moving a form or a profiling view into a tab):
+ * register the component under a type, then `openTab({ type, ... })`.
+ */
+export function registerTabType(type: string, component: ComponentType<TabComponentProps>): void {
+  registry.set(type, component);
+}
+
+/** Look up the component for a tab `type`, or `undefined` if none is registered. */
+export function getTabComponent(type: string): ComponentType<TabComponentProps> | undefined {
+  return registry.get(type);
+}

--- a/dataloom-frontend/src/Components/workspace/WorkspaceTabBar.tsx
+++ b/dataloom-frontend/src/Components/workspace/WorkspaceTabBar.tsx
@@ -1,0 +1,79 @@
+import { Plus, X } from "lucide-react";
+import { useWorkspaceTabs } from "../../context/WorkspaceTabsContext";
+
+interface WorkspaceTabBarProps {
+  /** When provided, renders a trailing "+" button that invokes this. */
+  onAddTab?: () => void;
+}
+
+/**
+ * VS Code–style tab strip for the project workspace. Reads open tabs from
+ * WorkspaceTabsContext; selecting a tab activates it and the × closes it.
+ */
+const WorkspaceTabBar = ({ onAddTab }: WorkspaceTabBarProps) => {
+  const { tabs, activeTabId, setActiveTab, closeTab } = useWorkspaceTabs();
+
+  return (
+    <div
+      role="tablist"
+      aria-label="Open tables"
+      className="flex h-9 shrink-0 items-stretch overflow-hidden border-b border-gray-200 bg-gray-50"
+    >
+      {tabs.map((tab) => {
+        const isActive = tab.id === activeTabId;
+        const closeable = tab.closeable ?? true;
+        return (
+          <div
+            key={tab.id}
+            role="tab"
+            aria-selected={isActive}
+            tabIndex={isActive ? 0 : -1}
+            onClick={() => setActiveTab(tab.id)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                setActiveTab(tab.id);
+              }
+            }}
+            data-testid={`workspace-tab-${tab.id}`}
+            className={`group flex shrink-0 cursor-pointer items-center gap-2 border-r border-gray-200 px-3 py-1.5 text-sm transition-colors ${
+              isActive
+                ? "-mb-px border-b-2 border-b-blue-500 bg-white font-medium text-blue-600"
+                : "text-gray-500 hover:bg-gray-100"
+            }`}
+          >
+            <span className="max-w-45 truncate">{tab.title}</span>
+            {closeable && (
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  closeTab(tab.id);
+                }}
+                aria-label={`Close ${tab.title}`}
+                data-testid={`workspace-tab-close-${tab.id}`}
+                className="flex h-4 w-4 items-center justify-center rounded text-gray-400 hover:bg-gray-200 hover:text-gray-700"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            )}
+          </div>
+        );
+      })}
+
+      {onAddTab && (
+        <button
+          type="button"
+          onClick={onAddTab}
+          aria-label="New tab"
+          data-testid="workspace-tab-add"
+          className="flex shrink-0 items-center px-2 text-gray-400 hover:bg-gray-100 hover:text-gray-700"
+        >
+          <Plus className="h-4 w-4" />
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default WorkspaceTabBar;

--- a/dataloom-frontend/src/Components/workspace/featureRegistry.ts
+++ b/dataloom-frontend/src/Components/workspace/featureRegistry.ts
@@ -1,0 +1,87 @@
+import type { ComponentType } from "react";
+import type { IconType } from "react-icons";
+import type { WorkspaceTab } from "../../context/WorkspaceTabsContext";
+import { registerTabType, type TabComponentProps } from "./TabRegistry";
+
+/**
+ * Workspace Feature registry — the single seam for adding a workspace feature.
+ *
+ * A feature is a cohesive contributor of tabs, docked side panels, and ribbon
+ * menu items. It registers once (at import time, like registerTabType); the
+ * readers — DataScreen's tab area, RightPanel, and MenuNavbar — resolve against
+ * this registry instead of hardcoded lists. Adding a feature is then one adapter
+ * file plus its import, not edits smeared across four modules.
+ */
+
+/** Props every docked panel component receives from RightPanel. */
+export interface PanelProps {
+  projectId: string;
+  onClose: () => void;
+}
+
+/** A docked side-panel contribution (e.g. a transform form, the chart builder). */
+export interface FeaturePanel {
+  /** Stable key opened via PanelContext (e.g. "FilterForm"). */
+  name: string;
+  title: string;
+  component: ComponentType<PanelProps>;
+}
+
+/**
+ * What a menu item does when clicked. Declarative because the registry can't call
+ * hooks; MenuNavbar interprets it against useWorkspaceTabs / usePanel.
+ */
+export type MenuAction = { openTab: WorkspaceTab } | { togglePanel: string };
+
+/** A ribbon menu item contributed by a feature. */
+export interface FeatureMenuItem {
+  /** Top ribbon tab, e.g. "File" | "Data" | "Profiling". */
+  ribbon: string;
+  /** Group within the ribbon tab, e.g. "Transform". */
+  group: string;
+  /** Sort order within the group. */
+  order: number;
+  label: string;
+  icon: IconType;
+  action: MenuAction;
+  /** Disable while a transform preview is pending. */
+  disabledInPreview?: boolean;
+  /** Highlight the item while this panel is the active one. */
+  activePanel?: string;
+}
+
+/** A tab contribution: a tab type mapped to the component that renders it. */
+export interface FeatureTab {
+  type: string;
+  component: ComponentType<TabComponentProps>;
+}
+
+export interface WorkspaceFeature {
+  id: string;
+  tabs?: FeatureTab[];
+  panels?: FeaturePanel[];
+  menu?: FeatureMenuItem[];
+}
+
+const panels = new Map<string, FeaturePanel>();
+const menuItems: FeatureMenuItem[] = [];
+
+/**
+ * Register a workspace feature. Tabs are delegated to the existing TabRegistry so
+ * tab rendering is unchanged; panels and menu items are stored for the readers.
+ */
+export function registerFeature(feature: WorkspaceFeature): void {
+  feature.tabs?.forEach((tab) => registerTabType(tab.type, tab.component));
+  feature.panels?.forEach((panel) => panels.set(panel.name, panel));
+  feature.menu?.forEach((item) => menuItems.push(item));
+}
+
+/** Resolve the docked panel registered under `name`, or undefined. */
+export function getPanel(name: string): FeaturePanel | undefined {
+  return panels.get(name);
+}
+
+/** All feature-contributed menu items (unsorted; MenuNavbar buckets and sorts). */
+export function getFeatureMenu(): FeatureMenuItem[] {
+  return menuItems;
+}

--- a/dataloom-frontend/src/Components/workspace/features/dataset.tsx
+++ b/dataloom-frontend/src/Components/workspace/features/dataset.tsx
@@ -1,0 +1,14 @@
+import { DATASET_TAB, DataSetTab } from "../DataSetTab";
+import { registerFeature } from "../featureRegistry";
+
+/**
+ * DataSet feature — the built-in working-table tab. It has no ribbon menu item;
+ * it's opened by the tab bar "+" and focused by the Profiling column-profiles
+ * toggle. Re-exported here so DataScreen imports one feature module per feature.
+ */
+registerFeature({
+  id: "dataset",
+  tabs: [{ type: "dataset", component: DataSetTab }],
+});
+
+export { DATASET_TAB };

--- a/dataloom-frontend/src/Components/workspace/features/history.tsx
+++ b/dataloom-frontend/src/Components/workspace/features/history.tsx
@@ -1,0 +1,25 @@
+import { LuBookmark, LuHistory } from "react-icons/lu";
+import type { WorkspaceTab } from "../../../context/WorkspaceTabsContext";
+import { CheckpointsTab, LogsTab } from "../HistoryTabs";
+import { registerFeature } from "../featureRegistry";
+
+const LOGS_TAB: WorkspaceTab = { id: "logs", title: "Logs", type: "logs", closeable: true };
+const CHECKPOINTS_TAB: WorkspaceTab = {
+  id: "checkpoints",
+  title: "Checkpoints",
+  type: "checkpoints",
+  closeable: true,
+};
+
+/** History feature — the Logs and Checkpoints tabs and their File-ribbon menu. */
+registerFeature({
+  id: "history",
+  tabs: [
+    { type: "logs", component: LogsTab },
+    { type: "checkpoints", component: CheckpointsTab },
+  ],
+  menu: [
+    { ribbon: "File", group: "History", order: 0, label: "Logs", icon: LuHistory, action: { openTab: LOGS_TAB } },
+    { ribbon: "File", group: "History", order: 1, label: "Checkpoints", icon: LuBookmark, action: { openTab: CHECKPOINTS_TAB } },
+  ],
+});

--- a/dataloom-frontend/src/Components/workspace/features/profiling.tsx
+++ b/dataloom-frontend/src/Components/workspace/features/profiling.tsx
@@ -1,0 +1,19 @@
+import { LuLayoutDashboard } from "react-icons/lu";
+import type { WorkspaceTab } from "../../../context/WorkspaceTabsContext";
+import { SummaryTab } from "../SummaryTab";
+import { registerFeature } from "../featureRegistry";
+
+const SUMMARY_TAB: WorkspaceTab = { id: "summary", title: "Summary", type: "summary", closeable: true };
+
+/**
+ * Profiling feature — the dataset Summary tab and its Profiling-ribbon menu item.
+ * The "Column Profiles" toggle stays a core MenuNavbar item (it drives table state
+ * via a hook, not a declarative tab/panel action).
+ */
+registerFeature({
+  id: "profiling",
+  tabs: [{ type: "summary", component: SummaryTab }],
+  menu: [
+    { ribbon: "Profiling", group: "Profiling", order: 0, label: "Summary", icon: LuLayoutDashboard, action: { openTab: SUMMARY_TAB } },
+  ],
+});

--- a/dataloom-frontend/src/Components/workspace/features/transforms.tsx
+++ b/dataloom-frontend/src/Components/workspace/features/transforms.tsx
@@ -1,0 +1,67 @@
+import {
+  LuArrowUpDown,
+  LuCode,
+  LuCopyMinus,
+  LuDice5,
+  LuEraser,
+  LuFilter,
+  LuGroup,
+  LuLayoutList,
+  LuRefreshCw,
+  LuReplace,
+  LuScissors,
+  LuTable2,
+} from "react-icons/lu";
+import FilterForm from "../../forms/FilterForm";
+import SortForm from "../../forms/SortForm";
+import DropDuplicateForm from "../../forms/DropDuplicateForm";
+import AdvQueryFilterForm from "../../forms/AdvQueryFilterForm";
+import PivotTableForm from "../../forms/PivotTableForm";
+import MeltForm from "../../forms/MeltForm";
+import CastDataTypeForm from "../../forms/CastDataTypeForm";
+import TrimWhitespaceForm from "../../forms/TrimWhitespaceForm";
+import GroupByForm from "../../forms/GroupByForm";
+import StringReplaceForm from "../../forms/StringReplaceForm";
+import FillEmptyForm from "../../forms/FillEmptyForm";
+import SampleRowsForm from "../../forms/SampleRowsForm";
+import { registerFeature } from "../featureRegistry";
+
+/**
+ * Transforms feature — the docked transform forms and their Data-ribbon menu.
+ * Each form is both a panel (opened via togglePanel) and a menu item that toggles
+ * it; the menu label may differ from the panel title (e.g. "Drop Dup" vs "Drop
+ * Duplicates"), matching the pre-registry ribbon exactly.
+ */
+registerFeature({
+  id: "transforms",
+  panels: [
+    { name: "FilterForm", title: "Filter", component: FilterForm },
+    { name: "SampleRowsForm", title: "Sample", component: SampleRowsForm },
+    { name: "SortForm", title: "Sort", component: SortForm },
+    { name: "DropDuplicateForm", title: "Drop Duplicates", component: DropDuplicateForm },
+    { name: "GroupByForm", title: "Group By", component: GroupByForm },
+    { name: "CastDataTypeForm", title: "Cast Type", component: CastDataTypeForm },
+    { name: "TrimWhitespaceForm", title: "Trim Whitespace", component: TrimWhitespaceForm },
+    { name: "StringReplaceForm", title: "Replace", component: StringReplaceForm },
+    { name: "FillEmptyForm", title: "Fill Empty", component: FillEmptyForm },
+    { name: "AdvQueryFilterForm", title: "Advanced Query", component: AdvQueryFilterForm },
+    { name: "PivotTableForm", title: "Pivot Table", component: PivotTableForm },
+    { name: "MeltForm", title: "Melt (Unpivot)", component: MeltForm },
+  ],
+  menu: [
+    // Data ▸ Transform
+    { ribbon: "Data", group: "Transform", order: 0, label: "Filter", icon: LuFilter, action: { togglePanel: "FilterForm" }, disabledInPreview: true, activePanel: "FilterForm" },
+    { ribbon: "Data", group: "Transform", order: 1, label: "Sample", icon: LuDice5, action: { togglePanel: "SampleRowsForm" }, disabledInPreview: true, activePanel: "SampleRowsForm" },
+    { ribbon: "Data", group: "Transform", order: 2, label: "Sort", icon: LuArrowUpDown, action: { togglePanel: "SortForm" }, disabledInPreview: true, activePanel: "SortForm" },
+    { ribbon: "Data", group: "Transform", order: 3, label: "Drop Dup", icon: LuCopyMinus, action: { togglePanel: "DropDuplicateForm" }, disabledInPreview: true, activePanel: "DropDuplicateForm" },
+    { ribbon: "Data", group: "Transform", order: 4, label: "GroupBy", icon: LuGroup, action: { togglePanel: "GroupByForm" }, disabledInPreview: true, activePanel: "GroupByForm" },
+    { ribbon: "Data", group: "Transform", order: 5, label: "Cast Type", icon: LuRefreshCw, action: { togglePanel: "CastDataTypeForm" }, disabledInPreview: true, activePanel: "CastDataTypeForm" },
+    { ribbon: "Data", group: "Transform", order: 6, label: "Trim Space", icon: LuScissors, action: { togglePanel: "TrimWhitespaceForm" }, disabledInPreview: true, activePanel: "TrimWhitespaceForm" },
+    { ribbon: "Data", group: "Transform", order: 7, label: "Replace", icon: LuReplace, action: { togglePanel: "StringReplaceForm" }, disabledInPreview: true, activePanel: "StringReplaceForm" },
+    { ribbon: "Data", group: "Transform", order: 8, label: "Fill Empty", icon: LuEraser, action: { togglePanel: "FillEmptyForm" }, disabledInPreview: true, activePanel: "FillEmptyForm" },
+    // Data ▸ Query
+    { ribbon: "Data", group: "Query", order: 0, label: "Adv Query", icon: LuCode, action: { togglePanel: "AdvQueryFilterForm" }, disabledInPreview: true, activePanel: "AdvQueryFilterForm" },
+    { ribbon: "Data", group: "Query", order: 1, label: "Pivot Table", icon: LuTable2, action: { togglePanel: "PivotTableForm" }, disabledInPreview: true, activePanel: "PivotTableForm" },
+    { ribbon: "Data", group: "Query", order: 2, label: "Melt (Unpivot)", icon: LuLayoutList, action: { togglePanel: "MeltForm" }, disabledInPreview: true, activePanel: "MeltForm" },
+  ],
+});

--- a/dataloom-frontend/src/api/transforms.js
+++ b/dataloom-frontend/src/api/transforms.js
@@ -21,12 +21,6 @@ export const transformProject = async (
   const response = await client.post(`/projects/${projectId}/transform`, transformationInput, {
     params,
   });
-  // Notify the logs panel to refresh, but only for persisted transforms.
-  // Preview-mode transforms are not logged, so firing the event would cause
-  // a spurious refetch.
-  if (!preview) {
-    window.dispatchEvent(new CustomEvent("project:logs-refresh"));
-  }
   return response.data;
 };
 

--- a/dataloom-frontend/src/context/ColumnProfilesContext.tsx
+++ b/dataloom-frontend/src/context/ColumnProfilesContext.tsx
@@ -1,0 +1,38 @@
+import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from "react";
+
+interface ColumnProfilesContextValue {
+  /** Whether the DataSet table shows the inline per-column profile row. */
+  showColumnProfiles: boolean;
+  toggleColumnProfiles: () => void;
+}
+
+const ColumnProfilesContext = createContext<ColumnProfilesContextValue | null>(null);
+
+/**
+ * Access the column-profiles view toggle. Shared between the Profiling menu
+ * (which flips it) and the DataSet tab (which renders profiles when on), since
+ * the two live in different subtrees of the workspace.
+ *
+ * Distinct from the `useColumnProfiles` data-fetching hook — this only holds the
+ * show/hide flag. Must be used within a ColumnProfilesProvider.
+ */
+// eslint-disable-next-line react-refresh/only-export-components
+export function useColumnProfilesView(): ColumnProfilesContextValue {
+  const context = useContext(ColumnProfilesContext);
+  if (!context)
+    throw new Error("useColumnProfilesView must be used within a ColumnProfilesProvider");
+  return context;
+}
+
+/** Holds whether the DataSet table shows its inline column-profile row. */
+export function ColumnProfilesProvider({ children }: { children: ReactNode }) {
+  const [showColumnProfiles, setShowColumnProfiles] = useState(false);
+  const toggleColumnProfiles = useCallback(() => setShowColumnProfiles((v) => !v), []);
+
+  const value = useMemo<ColumnProfilesContextValue>(
+    () => ({ showColumnProfiles, toggleColumnProfiles }),
+    [showColumnProfiles, toggleColumnProfiles],
+  );
+
+  return <ColumnProfilesContext.Provider value={value}>{children}</ColumnProfilesContext.Provider>;
+}

--- a/dataloom-frontend/src/context/HistoryRefreshContext.tsx
+++ b/dataloom-frontend/src/context/HistoryRefreshContext.tsx
@@ -1,0 +1,77 @@
+import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from "react";
+
+interface HistoryRefreshActions {
+  /** Signal that an open Logs tab should refetch (after a transform, undo, save, or revert). */
+  refreshLogs: () => void;
+  /** Signal that an open Checkpoints tab should refetch (after a save). */
+  refreshCheckpoints: () => void;
+}
+
+interface HistoryRefreshTokens {
+  /** Bumps whenever the change log may have changed; consume in a fetch effect's deps. */
+  logsToken: number;
+  /** Bumps whenever the checkpoint list may have changed; consume in a fetch effect's deps. */
+  checkpointsToken: number;
+}
+
+// Two contexts so the (stable) refresh actions and the (changing) tokens are
+// subscribed to independently. Mutation sites only need the actions, so they
+// never re-render when a token bumps; only the Logs/Checkpoints tabs read the
+// tokens and refetch. See rerender-defer-reads.
+const HistoryRefreshActionsContext = createContext<HistoryRefreshActions | null>(null);
+const HistoryRefreshTokensContext = createContext<HistoryRefreshTokens | null>(null);
+
+/**
+ * Access the history-refresh actions. Mutation sites (forms, save/undo/revert)
+ * call `refreshLogs`/`refreshCheckpoints` to signal that history changed.
+ *
+ * Must be used within a HistoryRefreshProvider.
+ */
+// eslint-disable-next-line react-refresh/only-export-components
+export function useHistoryRefresh(): HistoryRefreshActions {
+  const context = useContext(HistoryRefreshActionsContext);
+  if (!context) throw new Error("useHistoryRefresh must be used within a HistoryRefreshProvider");
+  return context;
+}
+
+/**
+ * Access the history-refresh tokens. The Logs and Checkpoints tabs read the
+ * matching token to know when to refetch.
+ *
+ * Must be used within a HistoryRefreshProvider.
+ */
+// eslint-disable-next-line react-refresh/only-export-components
+export function useHistoryRefreshTokens(): HistoryRefreshTokens {
+  const context = useContext(HistoryRefreshTokensContext);
+  if (!context)
+    throw new Error("useHistoryRefreshTokens must be used within a HistoryRefreshProvider");
+  return context;
+}
+
+/** Holds the refresh tokens for the workspace's Logs and Checkpoints tabs. */
+export function HistoryRefreshProvider({ children }: { children: ReactNode }) {
+  const [logsToken, setLogsToken] = useState(0);
+  const [checkpointsToken, setCheckpointsToken] = useState(0);
+
+  const refreshLogs = useCallback(() => setLogsToken((n) => n + 1), []);
+  const refreshCheckpoints = useCallback(() => setCheckpointsToken((n) => n + 1), []);
+
+  // Stable for the lifetime of the provider, so action-only consumers never
+  // re-render in response to a token bump.
+  const actions = useMemo<HistoryRefreshActions>(
+    () => ({ refreshLogs, refreshCheckpoints }),
+    [refreshLogs, refreshCheckpoints],
+  );
+  const tokens = useMemo<HistoryRefreshTokens>(
+    () => ({ logsToken, checkpointsToken }),
+    [logsToken, checkpointsToken],
+  );
+
+  return (
+    <HistoryRefreshActionsContext.Provider value={actions}>
+      <HistoryRefreshTokensContext.Provider value={tokens}>
+        {children}
+      </HistoryRefreshTokensContext.Provider>
+    </HistoryRefreshActionsContext.Provider>
+  );
+}

--- a/dataloom-frontend/src/context/PanelContext.tsx
+++ b/dataloom-frontend/src/context/PanelContext.tsx
@@ -1,0 +1,39 @@
+import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from "react";
+
+interface PanelContextValue {
+  /** Name of the open side panel (e.g. "FilterForm", "Logs"), or null if none. */
+  activePanel: string | null;
+  openPanel: (name: string) => void;
+  closePanel: () => void;
+  /** Open the named panel, or close it if it is already the active one. */
+  togglePanel: (name: string) => void;
+}
+
+const PanelContext = createContext<PanelContextValue | null>(null);
+
+/** Access the workspace side-panel state. Must be used within a PanelProvider. */
+// eslint-disable-next-line react-refresh/only-export-components
+export function usePanel(): PanelContextValue {
+  const context = useContext(PanelContext);
+  if (!context) throw new Error("usePanel must be used within a PanelProvider");
+  return context;
+}
+
+/** Tracks which side panel (transform form, Logs, Checkpoints) is open in the workspace. */
+export function PanelProvider({ children }: { children: ReactNode }) {
+  const [activePanel, setActivePanel] = useState<string | null>(null);
+
+  const openPanel = useCallback((name: string) => setActivePanel(name), []);
+  const closePanel = useCallback(() => setActivePanel(null), []);
+  const togglePanel = useCallback(
+    (name: string) => setActivePanel((current) => (current === name ? null : name)),
+    [],
+  );
+
+  const value = useMemo<PanelContextValue>(
+    () => ({ activePanel, openPanel, closePanel, togglePanel }),
+    [activePanel, openPanel, closePanel, togglePanel],
+  );
+
+  return <PanelContext.Provider value={value}>{children}</PanelContext.Provider>;
+}

--- a/dataloom-frontend/src/context/WorkspaceTabsContext.tsx
+++ b/dataloom-frontend/src/context/WorkspaceTabsContext.tsx
@@ -1,0 +1,112 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+
+/** A single open tab in the workspace tab strip. */
+export interface WorkspaceTab {
+  /** Stable identifier; opening a tab with an existing id focuses it instead of duplicating. */
+  id: string;
+  /** Label shown in the tab strip. */
+  title: string;
+  /** Content kind, resolved to a component via the tab registry (except the built-in "dataset"). */
+  type: string;
+  /** Whether the tab shows a close (×) button. Defaults to true. */
+  closeable?: boolean;
+  /** Arbitrary props forwarded to the registered tab component. */
+  props?: Record<string, unknown>;
+}
+
+interface WorkspaceTabsContextValue {
+  tabs: WorkspaceTab[];
+  activeTabId: string | null;
+  activeTab: WorkspaceTab | null;
+  openTab: (tab: WorkspaceTab) => void;
+  closeTab: (id: string) => void;
+  setActiveTab: (id: string) => void;
+}
+
+const WorkspaceTabsContext = createContext<WorkspaceTabsContextValue | null>(null);
+
+/** Access the workspace tab strip state and actions. Must be used within a WorkspaceTabsProvider. */
+// eslint-disable-next-line react-refresh/only-export-components
+export function useWorkspaceTabs(): WorkspaceTabsContextValue {
+  const context = useContext(WorkspaceTabsContext);
+  if (!context) throw new Error("useWorkspaceTabs must be used within a WorkspaceTabsProvider");
+  return context;
+}
+
+interface WorkspaceTabsProviderProps {
+  /** The tabs the workspace starts with (e.g. the pinned DataSet tab). */
+  initialTabs: WorkspaceTab[];
+  /** Resetting this (e.g. on project navigation) restores the tabs to `initialTabs`. */
+  projectId?: string;
+  children: ReactNode;
+}
+
+/**
+ * Holds the in-memory tab strip for a single project workspace. Tabs reset to
+ * `initialTabs` whenever `projectId` changes, so navigating between workspaces
+ * starts fresh.
+ */
+export function WorkspaceTabsProvider({
+  initialTabs,
+  projectId,
+  children,
+}: WorkspaceTabsProviderProps) {
+  const [tabs, setTabs] = useState<WorkspaceTab[]>(initialTabs);
+  const [activeTabId, setActiveTabId] = useState<string | null>(initialTabs[0]?.id ?? null);
+
+  // Reset to the initial tabs when the workspace's project changes. Skip the
+  // first run so the initial state above isn't clobbered.
+  const initialTabsRef = useRef(initialTabs);
+  initialTabsRef.current = initialTabs;
+  const didMountRef = useRef(false);
+  useEffect(() => {
+    if (!didMountRef.current) {
+      didMountRef.current = true;
+      return;
+    }
+    setTabs(initialTabsRef.current);
+    setActiveTabId(initialTabsRef.current[0]?.id ?? null);
+  }, [projectId]);
+
+  const openTab = useCallback((tab: WorkspaceTab) => {
+    setTabs((prev) => (prev.some((t) => t.id === tab.id) ? prev : [...prev, tab]));
+    setActiveTabId(tab.id);
+  }, []);
+
+  const closeTab = useCallback((id: string) => {
+    setTabs((prev) => prev.filter((t) => t.id !== id));
+    setActiveTabId((currentActive) => {
+      if (currentActive !== id) return currentActive;
+      const index = tabs.findIndex((t) => t.id === id);
+      const remaining = tabs.filter((t) => t.id !== id);
+      // Activate the left neighbour, falling back to the right, else nothing.
+      const neighbour = remaining[index - 1] ?? remaining[index] ?? null;
+      return neighbour?.id ?? null;
+    });
+  }, [tabs]);
+
+  const setActiveTab = useCallback((id: string) => {
+    setActiveTabId(id);
+  }, []);
+
+  const activeTab = useMemo(
+    () => tabs.find((t) => t.id === activeTabId) ?? null,
+    [tabs, activeTabId],
+  );
+
+  const value = useMemo<WorkspaceTabsContextValue>(
+    () => ({ tabs, activeTabId, activeTab, openTab, closeTab, setActiveTab }),
+    [tabs, activeTabId, activeTab, openTab, closeTab, setActiveTab],
+  );
+
+  return <WorkspaceTabsContext.Provider value={value}>{children}</WorkspaceTabsContext.Provider>;
+}

--- a/dataloom-frontend/src/hooks/usePreviewSave.js
+++ b/dataloom-frontend/src/hooks/usePreviewSave.js
@@ -1,6 +1,7 @@
 import { useState, useCallback } from "react";
 import { transformProject } from "../api";
 import { useProjectContext } from "../context/ProjectContext";
+import { useHistoryRefresh } from "../context/HistoryRefreshContext";
 
 /**
  * Shared hook that encapsulates the Save-Changes logic used by every
@@ -11,6 +12,7 @@ import { useProjectContext } from "../context/ProjectContext";
  */
 const usePreviewSave = ({ clearError, handleError, onClose }) => {
   const { confirmPreview, refreshProject, pageSize, pendingTransform } = useProjectContext();
+  const { refreshLogs } = useHistoryRefresh();
   const [saving, setSaving] = useState(false);
 
   const handleSave = useCallback(async () => {
@@ -23,6 +25,8 @@ const usePreviewSave = ({ clearError, handleError, onClose }) => {
       });
       confirmPreview();
       await refreshProject(pendingTransform.projectId, 1, pageSize);
+      // Persisting the transform adds a log entry.
+      refreshLogs();
       onClose();
     } catch (err) {
       handleError(err);
@@ -37,6 +41,7 @@ const usePreviewSave = ({ clearError, handleError, onClose }) => {
     pageSize,
     onClose,
     handleError,
+    refreshLogs,
   ]);
 
   return { saving, handleSave };

--- a/dataloom-frontend/src/test/HistoryRefreshContext.test.tsx
+++ b/dataloom-frontend/src/test/HistoryRefreshContext.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import {
+  HistoryRefreshProvider,
+  useHistoryRefresh,
+  useHistoryRefreshTokens,
+} from "../context/HistoryRefreshContext";
+
+// Read actions and tokens together so a single renderHook exercises both contexts.
+const useBoth = () => ({ ...useHistoryRefresh(), ...useHistoryRefreshTokens() });
+
+describe("HistoryRefreshContext", () => {
+  it("starts with zeroed tokens", () => {
+    const { result } = renderHook(useBoth, { wrapper: HistoryRefreshProvider });
+    expect(result.current.logsToken).toBe(0);
+    expect(result.current.checkpointsToken).toBe(0);
+  });
+
+  it("refreshLogs bumps only the logs token", () => {
+    const { result } = renderHook(useBoth, { wrapper: HistoryRefreshProvider });
+    act(() => result.current.refreshLogs());
+    expect(result.current.logsToken).toBe(1);
+    expect(result.current.checkpointsToken).toBe(0);
+  });
+
+  it("refreshCheckpoints bumps only the checkpoints token", () => {
+    const { result } = renderHook(useBoth, { wrapper: HistoryRefreshProvider });
+    act(() => result.current.refreshCheckpoints());
+    expect(result.current.checkpointsToken).toBe(1);
+    expect(result.current.logsToken).toBe(0);
+  });
+});

--- a/dataloom-frontend/src/test/PanelContext.test.tsx
+++ b/dataloom-frontend/src/test/PanelContext.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { PanelProvider, usePanel } from "../context/PanelContext";
+
+describe("PanelContext", () => {
+  it("starts with no active panel", () => {
+    const { result } = renderHook(() => usePanel(), { wrapper: PanelProvider });
+    expect(result.current.activePanel).toBeNull();
+  });
+
+  it("openPanel sets the active panel", () => {
+    const { result } = renderHook(() => usePanel(), { wrapper: PanelProvider });
+    act(() => result.current.openPanel("FilterForm"));
+    expect(result.current.activePanel).toBe("FilterForm");
+  });
+
+  it("closePanel clears the active panel", () => {
+    const { result } = renderHook(() => usePanel(), { wrapper: PanelProvider });
+    act(() => result.current.openPanel("Logs"));
+    act(() => result.current.closePanel());
+    expect(result.current.activePanel).toBeNull();
+  });
+
+  it("togglePanel opens, then closes the same panel", () => {
+    const { result } = renderHook(() => usePanel(), { wrapper: PanelProvider });
+    act(() => result.current.togglePanel("SortForm"));
+    expect(result.current.activePanel).toBe("SortForm");
+    act(() => result.current.togglePanel("SortForm"));
+    expect(result.current.activePanel).toBeNull();
+  });
+
+  it("togglePanel switches directly between panels", () => {
+    const { result } = renderHook(() => usePanel(), { wrapper: PanelProvider });
+    act(() => result.current.togglePanel("FilterForm"));
+    act(() => result.current.togglePanel("Checkpoints"));
+    expect(result.current.activePanel).toBe("Checkpoints");
+  });
+});

--- a/dataloom-frontend/src/test/TabRegistry.test.ts
+++ b/dataloom-frontend/src/test/TabRegistry.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { getTabComponent } from "../Components/workspace/TabRegistry";
+// Importing the feature modules for their registration side effects is what wires
+// the tab types into the registry — the same imports DataScreen relies on.
+import "../Components/workspace/features/dataset";
+import "../Components/workspace/features/history";
+import "../Components/workspace/features/profiling";
+
+describe("TabRegistry", () => {
+  it("registers every built-in tab type on import", () => {
+    expect(getTabComponent("dataset")).toBeTypeOf("function");
+    expect(getTabComponent("logs")).toBeTypeOf("function");
+    expect(getTabComponent("checkpoints")).toBeTypeOf("function");
+    expect(getTabComponent("summary")).toBeTypeOf("function");
+  });
+
+  it("returns undefined for an unregistered type", () => {
+    expect(getTabComponent("nope")).toBeUndefined();
+  });
+});

--- a/dataloom-frontend/src/test/Table.columnOrder.test.jsx
+++ b/dataloom-frontend/src/test/Table.columnOrder.test.jsx
@@ -42,6 +42,10 @@ vi.mock("../context/ProjectContext", () => ({
   useProjectContext: () => mockContext,
 }));
 
+vi.mock("../context/HistoryRefreshContext", () => ({
+  useHistoryRefresh: () => ({ refreshLogs: vi.fn(), refreshCheckpoints: vi.fn() }),
+}));
+
 beforeEach(() => {
   vi.clearAllMocks();
 });

--- a/dataloom-frontend/src/test/TransformResultPreview.test.jsx
+++ b/dataloom-frontend/src/test/TransformResultPreview.test.jsx
@@ -25,6 +25,10 @@ vi.mock("../context/ProjectContext", () => ({
   useProjectContext: () => mockContext,
 }));
 
+vi.mock("../context/HistoryRefreshContext", () => ({
+  useHistoryRefresh: () => ({ refreshLogs: vi.fn(), refreshCheckpoints: vi.fn() }),
+}));
+
 beforeEach(() => {
   vi.clearAllMocks();
   mockContext.columnOrder = [0, 1, 2];

--- a/dataloom-frontend/src/test/WorkspaceTabBar.test.tsx
+++ b/dataloom-frontend/src/test/WorkspaceTabBar.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { WorkspaceTabsProvider, useWorkspaceTabs } from "../context/WorkspaceTabsContext";
+import WorkspaceTabBar from "../Components/workspace/WorkspaceTabBar";
+import type { ReactNode } from "react";
+
+const DATASET = { id: "dataset", title: "DataSet", type: "dataset", closeable: true };
+const PINNED = { id: "pinned", title: "Pinned", type: "x", closeable: false };
+
+// Surfaces the active tab id so tests can assert selection without reaching into internals.
+function ActiveProbe() {
+  const { activeTabId } = useWorkspaceTabs();
+  return <span data-testid="active-id">{activeTabId ?? "none"}</span>;
+}
+
+function renderBar(initialTabs: (typeof DATASET)[], children?: ReactNode) {
+  return render(
+    <WorkspaceTabsProvider projectId="p1" initialTabs={initialTabs}>
+      <WorkspaceTabBar />
+      <ActiveProbe />
+      {children}
+    </WorkspaceTabsProvider>,
+  );
+}
+
+describe("WorkspaceTabBar", () => {
+  it("renders a tab per entry", () => {
+    renderBar([DATASET, { id: "a", title: "Pivot", type: "x", closeable: true }]);
+    expect(screen.getByTestId("workspace-tab-dataset")).toBeInTheDocument();
+    expect(screen.getByTestId("workspace-tab-a")).toBeInTheDocument();
+  });
+
+  it("clicking a tab activates it", async () => {
+    const user = userEvent.setup();
+    renderBar([DATASET, { id: "a", title: "Pivot", type: "x", closeable: true }]);
+
+    await user.click(screen.getByTestId("workspace-tab-a"));
+
+    expect(screen.getByTestId("active-id")).toHaveTextContent("a");
+  });
+
+  it("clicking the close button removes the tab", async () => {
+    const user = userEvent.setup();
+    renderBar([DATASET, { id: "a", title: "Pivot", type: "x", closeable: true }]);
+
+    await user.click(screen.getByTestId("workspace-tab-close-a"));
+
+    expect(screen.queryByTestId("workspace-tab-a")).not.toBeInTheDocument();
+  });
+
+  it("omits the close button on non-closeable tabs", () => {
+    renderBar([PINNED]);
+    expect(screen.queryByTestId("workspace-tab-close-pinned")).not.toBeInTheDocument();
+  });
+});

--- a/dataloom-frontend/src/test/WorkspaceTabsContext.test.tsx
+++ b/dataloom-frontend/src/test/WorkspaceTabsContext.test.tsx
@@ -1,0 +1,128 @@
+import { describe, it, expect } from "vitest";
+import { renderHook, render, act } from "@testing-library/react";
+import {
+  WorkspaceTabsProvider,
+  useWorkspaceTabs,
+  type WorkspaceTab,
+} from "../context/WorkspaceTabsContext";
+import type { ReactNode } from "react";
+
+const DATASET = { id: "dataset", title: "DataSet", type: "dataset", closeable: true };
+
+function makeWrapper(projectId = "p1") {
+  return ({ children }: { children: ReactNode }) => (
+    <WorkspaceTabsProvider projectId={projectId} initialTabs={[DATASET]}>
+      {children}
+    </WorkspaceTabsProvider>
+  );
+}
+
+describe("WorkspaceTabsContext", () => {
+  it("starts with the initial tabs and activates the first", () => {
+    const { result } = renderHook(() => useWorkspaceTabs(), { wrapper: makeWrapper() });
+    expect(result.current.tabs).toHaveLength(1);
+    expect(result.current.activeTabId).toBe("dataset");
+  });
+
+  it("openTab appends a new tab and activates it", () => {
+    const { result } = renderHook(() => useWorkspaceTabs(), { wrapper: makeWrapper() });
+
+    act(() => {
+      result.current.openTab({ id: "pivot-1", title: "Pivot", type: "pivot" });
+    });
+
+    expect(result.current.tabs.map((t) => t.id)).toEqual(["dataset", "pivot-1"]);
+    expect(result.current.activeTabId).toBe("pivot-1");
+  });
+
+  it("openTab focuses an existing tab instead of duplicating", () => {
+    const { result } = renderHook(() => useWorkspaceTabs(), { wrapper: makeWrapper() });
+
+    act(() => {
+      result.current.openTab({ id: "pivot-1", title: "Pivot", type: "pivot" });
+    });
+    act(() => {
+      result.current.setActiveTab("dataset");
+    });
+    act(() => {
+      result.current.openTab({ id: "pivot-1", title: "Pivot", type: "pivot" });
+    });
+
+    expect(result.current.tabs).toHaveLength(2);
+    expect(result.current.activeTabId).toBe("pivot-1");
+  });
+
+  it("closing the active tab activates the left neighbour", () => {
+    const { result } = renderHook(() => useWorkspaceTabs(), { wrapper: makeWrapper() });
+
+    act(() => {
+      result.current.openTab({ id: "a", title: "A", type: "x" });
+    });
+    act(() => {
+      result.current.openTab({ id: "b", title: "B", type: "x" });
+    });
+    // tabs: [dataset, a, b], active "b"
+    act(() => {
+      result.current.closeTab("b");
+    });
+
+    expect(result.current.tabs.map((t) => t.id)).toEqual(["dataset", "a"]);
+    expect(result.current.activeTabId).toBe("a");
+  });
+
+  it("closing the last remaining tab leaves no active tab", () => {
+    const { result } = renderHook(() => useWorkspaceTabs(), { wrapper: makeWrapper() });
+
+    act(() => {
+      result.current.closeTab("dataset");
+    });
+
+    expect(result.current.tabs).toHaveLength(0);
+    expect(result.current.activeTabId).toBeNull();
+  });
+
+  it("closing a non-active tab keeps the active tab", () => {
+    const { result } = renderHook(() => useWorkspaceTabs(), { wrapper: makeWrapper() });
+
+    act(() => {
+      result.current.openTab({ id: "a", title: "A", type: "x" });
+    });
+    act(() => {
+      result.current.setActiveTab("dataset");
+    });
+    act(() => {
+      result.current.closeTab("a");
+    });
+
+    expect(result.current.activeTabId).toBe("dataset");
+  });
+
+  it("changing projectId resets tabs to the initial set", () => {
+    // renderHook's wrapper doesn't receive initialProps, so drive projectId
+    // through a real render + rerender and read state via a probe.
+    let api: ReturnType<typeof useWorkspaceTabs> | null = null;
+    function Probe() {
+      api = useWorkspaceTabs();
+      return null;
+    }
+    const tree = (projectId: string) => (
+      <WorkspaceTabsProvider projectId={projectId} initialTabs={[DATASET]}>
+        <Probe />
+      </WorkspaceTabsProvider>
+    );
+
+    const { rerender } = render(tree("p1"));
+
+    act(() => {
+      api!.openTab({ id: "a", title: "A", type: "x" });
+    });
+    expect(api!.tabs).toHaveLength(2);
+
+    act(() => {
+      rerender(tree("p2"));
+    });
+
+    expect(api!.tabs.map((t: WorkspaceTab) => t.id)).toEqual(["dataset"]);
+    expect(api!.activeTabId).toBe("dataset");
+  });
+});

--- a/e2e/checkpoints.spec.js
+++ b/e2e/checkpoints.spec.js
@@ -60,6 +60,10 @@ test.describe("Checkpoints", () => {
     await expect(
       page.getByText("Project reverted successfully!"),
     ).toBeVisible();
+
+    // The Checkpoints tab is active and the data table only renders on the
+    // DataSet tab, so switch back to it before asserting on the restored data.
+    await page.getByRole("tab", { name: "DataSet" }).click();
     await expect(table).not.toContainText("MODIFIED");
     // Verify the known original value was restored.
     await expect(targetCell).toContainText(expectedOriginalValue);


### PR DESCRIPTION
## Description

Revamps the workspace into a **tabbed layout with docked side panels**, and adds a
**feature registry** so new features slot in through one seam instead of edits
scattered across the codebase.

- **Tabs** — a VS Code-style workspace tab strip; every tab type (DataSet, Logs,
  Checkpoints, Summary) resolves through a tab registry.
- **Side panel** — transform forms and other feature panels dock in a right-side
  panel (`RightPanel`, via `PanelContext`) instead of floating.
- **Data profiling** re-homed into the workspace: a **Summary** tab and an inline
  **Column Profiles** toggle under a new Profiling menu.
- **History sync** — Logs/Checkpoints refresh via `HistoryRefreshContext`, split
  into stable actions vs. changing tokens so action-only callers don't re-render;
  refresh is dispatched from the component layer, keeping the API layer
  side-effect free.
- **Feature registry** — `registerFeature({ tabs, panels, menu })` lets a feature
  declare its tabs, docked panels, and ribbon menu in one self-registering adapter
  (`workspace/features/*`). Adding a feature is now one file + one import rather
  than edits across the tab registry, a panel map, the menu, and DataScreen — this
  is what delivers the "easy to add features" goal.

Fixes #398

## Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

- [X] Existing tests pass (129 Vitest tests, lint clean)
- [X] Tests updated (tab-registry test repointed to the feature adapters)
- [X] Manual testing

## Screenshots
<img width="1918" height="968" alt="image" src="https://github.com/user-attachments/assets/a371cbe4-2011-4cc3-b94f-23dad1774735" />

## Checklist

- [X] My code follows the project's style guidelines
- [X] I have performed a self-review
- [X] I have added/updated documentation as needed
- [X] My changes generate no new warnings
- [X] Tests pass locally
