### PR TITLE
feat: add rate limiting to auth endpoints with sliding-window counter

### DIFF
--- a/dataloom-backend/app/api/dependencies.py
+++ b/dataloom-backend/app/api/dependencies.py
@@ -1,15 +1,56 @@
 """Shared FastAPI dependencies for endpoint functions."""
 
+import math
+import threading
 import uuid
 
-from fastapi import Cookie, Depends, HTTPException
+from fastapi import Cookie, Depends, HTTPException, Request
 from sqlmodel import Session
 
 from app import database, models
+from app.config import get_settings
 from app.services import auth_service
 from app.utils.logging import get_logger
+from app.utils.rate_limiter import RateLimiter
 
 logger = get_logger(__name__)
+
+_limiter: RateLimiter | None = None
+_limiter_lock = threading.Lock()
+
+
+def rate_limit(
+    request: Request,
+) -> None:
+    """FastAPI dependency that rate-limits requests by the direct TCP client IP.
+
+    The client IP is always taken from ``request.client.host`` (the direct TCP
+    connection) and never from client-supplied headers.  Operators behind a
+    reverse proxy must strip or overwrite the peer IP at the proxy layer.
+
+    Returns 429 with a ``Retry-After`` header when the limit is exceeded.
+    """
+    settings = get_settings()
+    if not settings.rate_limit_enabled:
+        return
+
+    global _limiter
+    if _limiter is None:
+        with _limiter_lock:
+            if _limiter is None:
+                _limiter = RateLimiter(
+                    settings.rate_limit_max_requests,
+                    settings.rate_limit_window_seconds,
+                )
+
+    client_ip = request.client.host if request.client is not None else "unknown"
+    allowed, retry_after = _limiter.check(client_ip)
+    if not allowed:
+        raise HTTPException(
+            status_code=429,
+            detail=f"Too many requests. Try again in {math.ceil(retry_after)} seconds.",
+            headers={"Retry-After": str(math.ceil(retry_after))},
+        )
 
 
 def get_current_user(

--- a/dataloom-backend/app/api/endpoints/auth.py
+++ b/dataloom-backend/app/api/endpoints/auth.py
@@ -5,7 +5,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlmodel import Session
 
 from app import database, models, schemas
-from app.api.dependencies import get_current_user
+from app.api.dependencies import get_current_user, rate_limit
 from app.config import get_settings
 from app.services import auth_service
 from app.utils.logging import get_logger
@@ -32,7 +32,12 @@ def _set_auth_cookie(response: Response, token: str) -> None:
 
 
 @router.post("/signup", response_model=schemas.UserResponse, status_code=201)
-def signup(payload: schemas.SignupRequest, response: Response, db: Session = Depends(database.get_db)):
+def signup(
+    payload: schemas.SignupRequest,
+    response: Response,
+    db: Session = Depends(database.get_db),
+    _rate_limit: None = Depends(rate_limit),
+):
     """Register a new user and issue an auth cookie."""
     if auth_service.get_user_by_email(db, payload.email) is not None:
         raise HTTPException(status_code=409, detail="An account with this email already exists")
@@ -42,7 +47,12 @@ def signup(payload: schemas.SignupRequest, response: Response, db: Session = Dep
 
 
 @router.post("/signin", response_model=schemas.UserResponse)
-def signin(payload: schemas.SigninRequest, response: Response, db: Session = Depends(database.get_db)):
+def signin(
+    payload: schemas.SigninRequest,
+    response: Response,
+    db: Session = Depends(database.get_db),
+    _rate_limit: None = Depends(rate_limit),
+):
     """Authenticate an existing user and issue an auth cookie."""
     user = auth_service.authenticate_user(db, payload.email, payload.password)
     if user is None:
@@ -75,6 +85,7 @@ def me(current_user: models.User = Depends(get_current_user)):
 async def forgot_password(
     payload: schemas.ForgotPasswordRequest,
     db: Session = Depends(database.get_db),
+    _rate_limit: None = Depends(rate_limit),
 ):
     """Requests a password reset email."""
     settings = get_settings()
@@ -88,6 +99,7 @@ async def forgot_password(
 async def reset_password(
     payload: schemas.ResetPasswordRequest,
     db: Session = Depends(database.get_db),
+    _rate_limit: None = Depends(rate_limit),
 ):
     """Reset password using a valid reset token."""
     if len(payload.new_password) < 8:

--- a/dataloom-backend/app/config.py
+++ b/dataloom-backend/app/config.py
@@ -46,6 +46,9 @@ class Settings(BaseSettings):
     smtp_password: str = ""
     smtp_from_email: str = ""
     frontend_url: str = "http://localhost:3200"
+    rate_limit_enabled: bool = True
+    rate_limit_max_requests: int = 20
+    rate_limit_window_seconds: int = 300
 
     model_config = {
         "env_file": ".env",

--- a/dataloom-backend/app/utils/rate_limiter.py
+++ b/dataloom-backend/app/utils/rate_limiter.py
@@ -1,0 +1,90 @@
+"""Sliding-window rate limiter for auth endpoints.
+
+Uses only Python stdlib (collections.deque, threading, time) with no external
+dependencies.  The time function is injectable so tests can use a fake clock.
+"""
+
+import threading
+import time
+from collections import deque
+from collections.abc import Callable
+
+
+class RateLimiter:
+    """Sliding-window rate limiter keyed by an arbitrary string (e.g. client IP).
+
+    Thread-safe: all reads and writes to the internal store are guarded by a
+    ``threading.Lock``.  A periodic sweep removes stale keys so the store
+    cannot grow without bound under a rotating-key attack.
+    """
+
+    _SWEEP_INTERVAL = 500
+
+    def __init__(
+        self,
+        max_requests: int,
+        window_seconds: int,
+        time_func: Callable[[], float] | None = None,
+    ) -> None:
+        if max_requests < 1:
+            raise ValueError("max_requests must be >= 1")
+        if window_seconds < 1:
+            raise ValueError("window_seconds must be >= 1")
+
+        self.max_requests = max_requests
+        self.window_seconds = window_seconds
+        self._time = time_func or time.monotonic
+        self._store: dict[str, deque[float]] = {}
+        self._lock = threading.Lock()
+        self._ops = 0
+
+    def check(self, key: str) -> tuple[bool, float]:
+        """Record a request for *key* and return whether it is allowed.
+
+        Returns:
+            Tuple of ``(allowed, retry_after)``.  When ``allowed`` is ``False``
+            the caller should wait *retry_after* seconds before retrying.
+        """
+        now = self._time()
+        window_start = now - self.window_seconds
+
+        with self._lock:
+            self._ops += 1
+            if self._ops % self._SWEEP_INTERVAL == 0:
+                self._sweep(now)
+
+            dq = self._store.get(key)
+            if dq is None:
+                self._store[key] = deque([now])
+                return True, 0.0
+
+            # Prune entries whose window has elapsed.
+            while dq and dq[0] <= window_start:
+                dq.popleft()
+
+            if not dq:
+                self._store.pop(key, None)
+                self._store[key] = deque([now])
+                return True, 0.0
+
+            if len(dq) >= self.max_requests:
+                retry_after = dq[0] + self.window_seconds - now
+                return False, round(retry_after, 1)
+
+            dq.append(now)
+            return True, 0.0
+
+    def _sweep(self, now: float) -> None:
+        """Remove keys whose newest entry has fully left the window."""
+        cutoff = now - self.window_seconds
+        stale = [k for k, dq in self._store.items() if not dq or dq[-1] <= cutoff]
+        for k in stale:
+            del self._store[k]
+
+    def reset(self, key: str | None = None) -> None:
+        """Clear history for *key*, or all keys when *key* is ``None``."""
+        with self._lock:
+            if key is None:
+                self._store.clear()
+            else:
+                self._store.pop(key, None)

--- a/dataloom-backend/tests/conftest.py
+++ b/dataloom-backend/tests/conftest.py
@@ -11,6 +11,8 @@ os.environ.setdefault("SMTP_USERNAME", "test@example.com")
 os.environ.setdefault("SMTP_PASSWORD", "test-password")
 os.environ.setdefault("SMTP_FROM_EMAIL", "noreply@example.com")
 
+os.environ["RATE_LIMIT_ENABLED"] = "false"
+
 import pytest  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
 from sqlmodel import Session, SQLModel, create_engine  # noqa: E402

--- a/dataloom-backend/tests/test_auth.py
+++ b/dataloom-backend/tests/test_auth.py
@@ -348,3 +348,26 @@ class TestPasswordReset:
             json={"token": raw_token, "new_password": "short"},
         )
         assert response.status_code == 422
+
+
+def test_rate_limit_http_429(anon_client, monkeypatch):
+    from app.api import dependencies as deps
+    from app.config import get_settings
+    from app.utils.rate_limiter import RateLimiter
+
+    settings = get_settings()
+    monkeypatch.setattr(settings, "rate_limit_enabled", True)
+    fake_limiter = RateLimiter(max_requests=2, window_seconds=60)
+    monkeypatch.setattr(deps, "_limiter", fake_limiter)
+
+    r1 = anon_client.post("/auth/signup", json={"email": "rl-one@test.com", "password": "testpassword"})
+    assert r1.status_code != 429
+
+    r2 = anon_client.post("/auth/signup", json={"email": "rl-two@test.com", "password": "testpassword"})
+    assert r2.status_code != 429
+
+    r3 = anon_client.post("/auth/signup", json={"email": "rl-three@test.com", "password": "testpassword"})
+    assert r3.status_code == 429
+    assert "Retry-After" in r3.headers
+    retry_after = int(r3.headers["Retry-After"])
+    assert retry_after > 0

--- a/dataloom-backend/tests/test_rate_limiter.py
+++ b/dataloom-backend/tests/test_rate_limiter.py
@@ -1,0 +1,178 @@
+"""Unit tests for the sliding-window rate limiter."""
+
+import pytest
+
+from app.utils.rate_limiter import RateLimiter
+
+
+class TestSweep:
+    def test_sweep_removes_stale_keys(self):
+        clock = _FakeClock()
+        limiter = RateLimiter(max_requests=5, window_seconds=10, time_func=clock)
+
+        limiter.check("a")
+        limiter.check("b")
+        clock.advance(11.0)
+
+        for _ in range(limiter._SWEEP_INTERVAL):
+            limiter.check("c")
+            clock.advance(0.01)
+
+        assert "a" not in limiter._store
+        assert "b" not in limiter._store
+
+    def test_sweep_keeps_active_keys(self):
+        clock = _FakeClock()
+        limiter = RateLimiter(max_requests=5, window_seconds=10, time_func=clock)
+
+        for _ in range(limiter._SWEEP_INTERVAL + 5):
+            limiter.check("active")
+            clock.advance(0.01)
+
+        assert "active" in limiter._store
+
+    def test_remove_key_when_deque_empties(self):
+        clock = _FakeClock()
+        limiter = RateLimiter(max_requests=1, window_seconds=10, time_func=clock)
+
+        limiter.check("single")
+        assert "single" in limiter._store
+
+        clock.advance(11.0)
+        limiter.check("single")
+
+        # Key was removed and re-added; this verifies no stale empty deque
+        assert "single" in limiter._store
+        assert len(limiter._store["single"]) == 1
+
+
+class _FakeClock:
+    """Deterministic clock for testing sliding-window behaviour."""
+
+    def __init__(self, start: float = 0.0) -> None:
+        self._now = start
+
+    def advance(self, seconds: float) -> None:
+        self._now += seconds
+
+    def __call__(self) -> float:
+        return self._now
+
+
+class TestRateLimiter:
+    def test_allows_requests_under_limit(self):
+        clock = _FakeClock()
+        limiter = RateLimiter(max_requests=5, window_seconds=10, time_func=clock)
+
+        for _ in range(5):
+            allowed, retry_after = limiter.check("ip-1")
+            assert allowed
+            assert retry_after == 0.0
+            clock.advance(0.1)
+
+    def test_denies_request_at_limit(self):
+        limiter = RateLimiter(max_requests=3, window_seconds=10)
+
+        for _ in range(3):
+            limiter.check("ip-1")
+
+        allowed, retry_after = limiter.check("ip-1")
+        assert not allowed
+        assert retry_after > 0.0
+
+    def test_allows_request_from_different_key(self):
+        limiter = RateLimiter(max_requests=1, window_seconds=10)
+
+        limiter.check("ip-1")
+        allowed, _ = limiter.check("ip-2")
+        assert allowed
+
+    def test_window_expiry_resets_counter(self):
+        clock = _FakeClock()
+        limiter = RateLimiter(max_requests=2, window_seconds=10, time_func=clock)
+
+        limiter.check("ip-1")
+        limiter.check("ip-1")
+
+        allowed, _ = limiter.check("ip-1")
+        assert not allowed
+
+        clock.advance(10.0)
+
+        allowed, _ = limiter.check("ip-1")
+        assert allowed
+
+    def test_partial_window_slide(self):
+        clock = _FakeClock()
+        limiter = RateLimiter(max_requests=2, window_seconds=10, time_func=clock)
+
+        limiter.check("ip-1")
+        clock.advance(5.0)
+        limiter.check("ip-1")
+        assert not limiter.check("ip-1")[0]
+
+        clock.advance(5.0)
+
+        allowed, _ = limiter.check("ip-1")
+        assert allowed
+
+    def test_constructed_with_retry_after(self):
+        clock = _FakeClock()
+        limiter = RateLimiter(max_requests=2, window_seconds=10, time_func=clock)
+
+        limiter.check("ip-1")
+        limiter.check("ip-1")
+        _, retry_after = limiter.check("ip-1")
+
+        assert 9.0 <= retry_after <= 10.0
+
+    def test_reset_single_key(self):
+        limiter = RateLimiter(max_requests=1, window_seconds=10)
+        limiter.check("ip-1")
+        limiter.reset("ip-1")
+
+        allowed, _ = limiter.check("ip-1")
+        assert allowed
+
+    def test_reset_all_keys(self):
+        limiter = RateLimiter(max_requests=1, window_seconds=10)
+        limiter.check("ip-1")
+        limiter.check("ip-2")
+        limiter.reset()
+
+        assert limiter.check("ip-1")[0]
+        assert limiter.check("ip-2")[0]
+
+    def test_zero_or_negative_max_requests_rejected(self):
+        import re
+
+        match = "max_requests must be >= 1"
+        with pytest.raises(ValueError, match=re.escape(match)):
+            RateLimiter(max_requests=0, window_seconds=10)
+
+    def test_zero_or_negative_window_rejected(self):
+        import re
+
+        match = "window_seconds must be >= 1"
+        with pytest.raises(ValueError, match=re.escape(match)):
+            RateLimiter(max_requests=5, window_seconds=0)
+
+    def test_unknown_key_allowed(self):
+        limiter = RateLimiter(max_requests=5, window_seconds=10)
+        allowed, _ = limiter.check("never-seen")
+        assert allowed
+
+    def test_high_volume_does_not_deadlock(self):
+        import concurrent.futures
+
+        clock = _FakeClock()
+        limiter = RateLimiter(max_requests=100, window_seconds=60, time_func=clock)
+
+        def _hit(key: str) -> bool:
+            return limiter.check(key)[0]
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+            futures = [pool.submit(_hit, "shared") for _ in range(200)]
+            results = [f.result() for f in futures]
+
+        assert sum(results) == 100

--- a/dataloom-frontend/package-lock.json
+++ b/dataloom-frontend/package-lock.json
@@ -1190,9 +1190,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1207,9 +1204,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1224,9 +1218,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1241,9 +1232,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1258,9 +1246,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1275,9 +1260,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1292,9 +1274,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1309,9 +1288,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1326,9 +1302,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1343,9 +1316,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1360,9 +1330,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1377,9 +1344,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1394,9 +1358,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1627,9 +1588,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1647,9 +1605,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1667,9 +1622,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1687,9 +1639,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5063,9 +5012,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5087,9 +5033,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5111,9 +5054,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5135,9 +5075,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [


### PR DESCRIPTION
## Summary

Adds an in-memory sliding-window rate limiter to the four auth endpoints that accept credentials or tokens: `/auth/signin`, `/auth/signup`, `/auth/forgot-password`, and `/auth/reset-password`.

## Implementation

- **`app/utils/rate_limiter.py`** — `RateLimiter` class using `collections.deque` + `threading.Lock`. Default: 20 requests per 5-minute window per client IP. Time function is injectable for deterministic testing.
- **`app/api/dependencies.py`** — `rate_limit()` FastAPI dependency. Uses `request.client.host` (direct TCP connection, never client-supplied headers). Returns 429 with `Retry-After` header.
- **`app/config.py`** — Three new settings: `rate_limit_enabled`, `rate_limit_max_requests`, `rate_limit_window_seconds`.
- **`app/api/endpoints/auth.py`** — `Depends(rate_limit)` added to the four rate-limited endpoints.

## Testing

- 12 unit tests for the `RateLimiter` class: under-limit, at-limit, window expiry, partial slide, multiple keys, reset, invalid construction, and thread-safety (200 concurrent requests).
- 3 sweep tests verifying periodic key expiry prevents unbounded store growth.
- 1 integration test exercising the FastAPI dependency end-to-end (429 + Retry-After header).
- Existing test suite (474 tests) passes with `RATE_LIMIT_ENABLED=false` set in conftest.py.

## Design decisions

- Sliding-window counter (not fixed window) to avoid boundary bursts.
- Thread-safe via `threading.Lock` — single-process in-memory; production deployments behind multiple workers should substitute a shared store (Redis).
- 20 req / 5 min is conservative for interactive usage; tune via env vars.