### PR TITLE
feat: add data visualization (Charts feature)

### DIFF
--- a/dataloom-backend/app/api/dependencies.py
+++ b/dataloom-backend/app/api/dependencies.py
@@ -4,6 +4,7 @@ import math
 import threading
 import uuid
 
+import pandas as pd
 from fastapi import Cookie, Depends, HTTPException, Request
 from sqlmodel import Session
 
@@ -11,6 +12,7 @@ from app import database, models
 from app.config import get_settings
 from app.services import auth_service
 from app.utils.logging import get_logger
+from app.utils.pandas_helpers import read_table_safe
 from app.utils.rate_limiter import RateLimiter
 
 logger = get_logger(__name__)
@@ -107,3 +109,19 @@ def get_project_or_404(
     if project is None or project.owner_id != current_user.id:
         raise HTTPException(status_code=404, detail=f"Project with ID {project_id} not found")
     return project
+
+
+def load_project_df(project: models.Project) -> pd.DataFrame:
+    """Read a project's working copy, redacting any path from error details.
+
+    ``read_table_safe`` embeds the absolute file path in its 404/500 details;
+    surface a generic message to the client instead, matching the transform
+    endpoint's handling. Shared by the profiling and visualization endpoints.
+    """
+    try:
+        return read_table_safe(project.file_path)
+    except HTTPException as e:
+        if e.status_code == 404:
+            raise HTTPException(status_code=404, detail="Project data file not found") from e
+        logger.warning("Failed to read project file project_id=%s status=%s", project.project_id, e.status_code)
+        raise HTTPException(status_code=e.status_code, detail="Could not read project data") from e

--- a/dataloom-backend/app/api/endpoints/profiling.py
+++ b/dataloom-backend/app/api/endpoints/profiling.py
@@ -7,36 +7,13 @@ descriptive — quality assessment is out of scope here.
 
 import uuid
 
-import pandas as pd
 from fastapi import APIRouter, Depends, HTTPException, Query
 
 from app import models, schemas
-from app.api.dependencies import get_project_or_404
+from app.api.dependencies import get_project_or_404, load_project_df
 from app.services import profiling_service
-from app.utils.logging import get_logger
-from app.utils.pandas_helpers import read_table_safe
-
-logger = get_logger(__name__)
 
 router = APIRouter()
-
-
-def _load_project_df(project: models.Project) -> pd.DataFrame:
-    """Read the project's working copy, redacting any path from error details.
-
-    ``read_table_safe`` embeds the absolute file path in its 404/500 details;
-    surface a generic message to the client instead, matching the transform
-    endpoint's handling.
-    """
-    try:
-        return read_table_safe(project.file_path)
-    except HTTPException as e:
-        if e.status_code == 404:
-            raise HTTPException(status_code=404, detail="Project data file not found") from e
-        logger.warning(
-            "Failed to read project file for profiling project_id=%s status=%s", project.project_id, e.status_code
-        )
-        raise HTTPException(status_code=e.status_code, detail="Could not read project data") from e
 
 
 @router.get("/{project_id}/profile/summary", response_model=schemas.DatasetSummaryResponse)
@@ -45,7 +22,7 @@ async def get_dataset_summary(
     project: models.Project = Depends(get_project_or_404),
 ):
     """Return a top-level summary of the project's dataset."""
-    df = _load_project_df(project)
+    df = load_project_df(project)
     return profiling_service.dataset_summary(df)
 
 
@@ -62,7 +39,7 @@ async def get_column_profile(
     across servers and reverse proxies, which handle ``%2F`` in paths
     inconsistently.
     """
-    df = _load_project_df(project)
+    df = load_project_df(project)
     try:
         return profiling_service.column_profile(df, column_name)
     except KeyError as e:
@@ -80,7 +57,7 @@ async def get_all_column_profiles(
     client needs all columns (e.g. the column-profiles table view) so the
     working copy is read once rather than once per column.
     """
-    df = _load_project_df(project)
+    df = load_project_df(project)
     return profiling_service.all_column_profiles(df)
 
 
@@ -90,5 +67,5 @@ async def get_correlation_matrix(
     project: models.Project = Depends(get_project_or_404),
 ):
     """Return the pairwise Pearson correlation over numeric columns."""
-    df = _load_project_df(project)
+    df = load_project_df(project)
     return profiling_service.correlation_matrix(df)

--- a/dataloom-backend/app/api/endpoints/visualizations.py
+++ b/dataloom-backend/app/api/endpoints/visualizations.py
@@ -1,0 +1,90 @@
+"""Data visualization API endpoints.
+
+Two read-only routes over a project's current working copy: auto-suggested charts
+and a single configurable chart. Both return the self-describing ``ChartSpec``
+shape (see ``schemas.ChartSpec``) — the backend aggregates, the frontend renders.
+
+Column names are query parameters rather than path segments, matching the
+profiling endpoints, so names with slashes or other reserved characters route
+reliably across servers and proxies.
+"""
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from app import models, schemas
+from app.api.dependencies import get_project_or_404, load_project_df
+from app.services import visualization_service
+
+router = APIRouter()
+
+
+@router.get("/{project_id}/charts/suggest", response_model=schemas.ChartSuggestionsResponse)
+async def suggest_charts(
+    project_id: uuid.UUID,
+    project: models.Project = Depends(get_project_or_404),
+):
+    """Return up to three charts recommended from the dataset's column shapes."""
+    df = load_project_df(project)
+    return {"suggestions": visualization_service.suggest_charts(df)}
+
+
+@router.get("/{project_id}/charts", response_model=schemas.ChartSpec)
+async def get_chart(
+    project_id: uuid.UUID,
+    chart_type: schemas.ChartType = Query(..., description="The kind of chart to build"),
+    column: str | None = Query(None, description="Numeric column for a histogram"),
+    category: str | None = Query(None, description="Grouping column for a bar/pie chart"),
+    value: str | None = Query(None, description="Numeric value column for a bar/pie chart"),
+    x: str | None = Query(None, description="X-axis column for a line/area/scatter chart"),
+    y: list[str] = Query(default_factory=list, description="Y-axis column(s) for a line/area/scatter chart"),
+    color: str | None = Query(None, description="Optional color-grouping column for a scatter chart"),
+    agg: schemas.AggFunc = Query(schemas.AggFunc.sum, description="Aggregation for a bar chart"),
+    bins: int = Query(visualization_service.DEFAULT_BINS, description="Bucket count for a histogram"),
+    project: models.Project = Depends(get_project_or_404),
+):
+    """Build one chart from the project's dataset.
+
+    Required parameters depend on ``chart_type``: histogram needs ``column``;
+    bar/pie need ``category``; line/area/scatter need ``x`` and ``y``. Invalid
+    combinations (missing params, or a column whose dtype the chart can't use)
+    return 400; an unknown column returns 404.
+    """
+    df = load_project_df(project)
+    try:
+        return _dispatch(df, chart_type, column, category, value, x, y, color, agg, bins)
+    except KeyError as e:
+        raise HTTPException(status_code=404, detail=f"Column '{e.args[0]}' not found") from e
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
+
+def _dispatch(df, chart_type, column, category, value, x, y, color, agg, bins):
+    """Route a chart request to the matching service builder, validating params."""
+    if chart_type == schemas.ChartType.histogram:
+        if not column:
+            raise ValueError("histogram requires 'column'")
+        return visualization_service.build_histogram(df, column, bins)
+
+    if chart_type == schemas.ChartType.bar:
+        if not category:
+            raise ValueError("bar chart requires 'category'")
+        return visualization_service.build_bar_chart(df, category, value, agg.value)
+
+    if chart_type == schemas.ChartType.pie:
+        if not category:
+            raise ValueError("pie chart requires 'category'")
+        return visualization_service.build_pie_chart(df, category, value)
+
+    if chart_type in (schemas.ChartType.line, schemas.ChartType.area):
+        if not x or not y:
+            raise ValueError(f"{chart_type.value} chart requires 'x' and at least one 'y'")
+        if chart_type == schemas.ChartType.line:
+            return visualization_service.build_line_chart(df, x, y)
+        return visualization_service.build_area_chart(df, x, y)
+
+    # scatter
+    if not x or len(y) != 1:
+        raise ValueError("scatter chart requires 'x' and exactly one 'y'")
+    return visualization_service.build_scatter_plot(df, x, y[0], color)

--- a/dataloom-backend/app/main.py
+++ b/dataloom-backend/app/main.py
@@ -12,7 +12,7 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
-from app.api.endpoints import auth, profiling, projects, transformations, user_logs
+from app.api.endpoints import auth, profiling, projects, transformations, user_logs, visualizations
 from app.config import get_settings
 from app.database import verify_database_connection
 from app.exceptions import AppException, app_exception_handler
@@ -101,6 +101,7 @@ app.include_router(auth.router, prefix="/auth", tags=["auth"])
 app.include_router(projects.router, prefix="/projects", tags=["projects"])
 app.include_router(transformations.router, prefix="/projects", tags=["transformations"])
 app.include_router(profiling.router, prefix="/projects", tags=["profiling"])
+app.include_router(visualizations.router, prefix="/projects", tags=["visualizations"])
 app.include_router(user_logs.router, prefix="/logs", tags=["user_logs"])
 
 if __name__ == "__main__":

--- a/dataloom-backend/app/schemas.py
+++ b/dataloom-backend/app/schemas.py
@@ -75,6 +75,17 @@ class AggFunc(StrEnum):
     count = "count"
 
 
+class ChartType(StrEnum):
+    """Supported chart types. The frontend maps each to a renderer."""
+
+    histogram = "histogram"
+    bar = "bar"
+    line = "line"
+    area = "area"
+    scatter = "scatter"
+    pie = "pie"
+
+
 # --- Basic transformation parameter schemas ---
 
 
@@ -424,6 +435,54 @@ class CorrelationResponse(BaseModel):
 
     columns: list[str]
     matrix: list[list[float | None]]
+
+
+# --- Visualization response schemas ---
+#
+# One ChartSpec shape for every chart type: the backend computes aggregated data,
+# the frontend maps ``chart_type`` to a renderer. Adding a chart type needs only a
+# new builder + renderer case, no protocol change.
+
+
+class ChartPoint(BaseModel):
+    """A single (x, y) datum. x is a label, number, or ISO date; y is numeric."""
+
+    x: str | float | None
+    y: float | None
+
+
+class ChartSeries(BaseModel):
+    """A named set of points, optionally tinted with a color."""
+
+    name: str
+    data: list[ChartPoint]
+    color: str | None = None
+
+
+class ChartMeta(BaseModel):
+    """Honesty flags about how the data was reduced for rendering."""
+
+    sampled: bool | None = None
+    truncated: bool | None = None
+    total_rows: int | None = None
+    bins: int | None = None
+
+
+class ChartSpec(BaseModel):
+    """Self-describing chart payload rendered as-is by the frontend."""
+
+    chart_type: ChartType
+    title: str
+    x_label: str
+    y_label: str
+    series: list[ChartSeries]
+    meta: ChartMeta | None = None
+
+
+class ChartSuggestionsResponse(BaseModel):
+    """Auto-suggested charts based on the dataset's column shapes."""
+
+    suggestions: list[ChartSpec]
 
 
 # --- Other response schemas ---

--- a/dataloom-backend/app/services/visualization_service.py
+++ b/dataloom-backend/app/services/visualization_service.py
@@ -1,0 +1,387 @@
+"""Visualization service: chart data over a DataFrame.
+
+Pure functions, no side effects — each takes a DataFrame and returns a plain
+``ChartSpec`` dict; the endpoint layer handles I/O. This mirrors
+``profiling_service``'s style.
+
+Design principle (from the proposal): the backend computes *aggregated* chart
+data, the frontend renders it. No image generation here. Crucially, aggregation/
+binning/sampling happens server-side over the full working copy, so the wire
+payload stays small regardless of dataset size — the same chart request costs the
+same whether the dataset has 1k or 1M rows.
+
+Every builder returns the same ``ChartSpec`` shape so the frontend maps a single
+``chart_type`` field to a renderer; adding a chart type is one builder here plus
+one renderer case there, with no protocol change.
+
+Conventions:
+- Numeric output is JSON-safe: ``None`` in place of ``NaN``/``inf`` (reusing
+  ``profiling_service``'s helpers), so values survive FastAPI serialization.
+- A point's ``x`` is a category label (str), a rounded number, or an ISO date
+  string; ``y`` is always a JSON-safe number.
+"""
+
+from typing import Any
+
+import pandas as pd
+
+from app.services.profiling_service import _round, _safe_number
+from app.utils.pandas_helpers import map_dtype
+
+# Default histogram bucket count when the caller does not specify one.
+DEFAULT_BINS = 20
+# Hard bounds on histogram bins (a slider in the UI maps onto this range).
+MIN_BINS = 2
+MAX_BINS = 100
+# Scatter is sampled down to this many points before serializing.
+MAX_SCATTER_POINTS = 3000
+# Pie keeps this many slices; the rest collapse into a single "Other" slice.
+MAX_PIE_SLICES = 12
+# Bar keeps this many categories (highest values first); the rest are dropped.
+MAX_BAR_CATEGORIES = 30
+# Line/area downsample to this many points per series (evenly spaced).
+MAX_LINE_POINTS = 2000
+# A categorical column at or below this distinct-value count is "low cardinality".
+LOW_CARDINALITY_MAX = 25
+
+# Aggregation name (wire, matching schemas.AggFunc) → pandas Series/GroupBy method.
+AGG_FUNCS = {
+    "count": "size",
+    "sum": "sum",
+    "mean": "mean",
+    "median": "median",
+    "min": "min",
+    "max": "max",
+}
+
+NUMERIC_LABELS = ("int", "float")
+
+
+# --- internal helpers --------------------------------------------------------
+
+
+def _spec(
+    chart_type: str,
+    title: str,
+    x_label: str,
+    y_label: str,
+    series: list[dict[str, Any]],
+    meta: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Assemble a ChartSpec, dropping any None-valued meta keys."""
+    spec: dict[str, Any] = {
+        "chart_type": chart_type,
+        "title": title,
+        "x_label": x_label,
+        "y_label": y_label,
+        "series": series,
+    }
+    if meta:
+        cleaned = {k: v for k, v in meta.items() if v is not None}
+        if cleaned:
+            spec["meta"] = cleaned
+    return spec
+
+
+def _require_column(df: pd.DataFrame, column: str) -> None:
+    if column not in df.columns:
+        raise KeyError(column)
+
+
+def _require_numeric(df: pd.DataFrame, column: str) -> None:
+    """Raise ValueError if a column is not numeric (int/float)."""
+    if map_dtype(df[column].dtype) not in NUMERIC_LABELS:
+        raise ValueError(f"Column '{column}' is not numeric")
+
+
+def _fmt_edge(value: float) -> str:
+    """Format a histogram bin edge compactly (drop trailing ``.0``)."""
+    rounded = round(float(value), 2)
+    return str(int(rounded)) if rounded == int(rounded) else str(rounded)
+
+
+def _x_value(value: Any, label: str) -> Any:
+    """Coerce a point's x to a JSON-safe scalar based on its column dtype."""
+    if label == "datetime":
+        ts = pd.Timestamp(value)
+        return None if pd.isna(ts) else ts.isoformat()
+    if label in NUMERIC_LABELS:
+        return _round(value)
+    return str(value)
+
+
+# --- chart builders ----------------------------------------------------------
+
+
+def build_histogram(df: pd.DataFrame, column: str, bins: int = DEFAULT_BINS) -> dict[str, Any]:
+    """Bin a numeric column into a frequency distribution.
+
+    Returns a single ``count`` series whose points carry a ``"left–right"`` bin
+    label as x and the bin count as y. A constant column collapses to one bin.
+    """
+    _require_column(df, column)
+    _require_numeric(df, column)
+    bins = max(MIN_BINS, min(MAX_BINS, int(bins)))
+
+    series = pd.to_numeric(df[column], errors="coerce").dropna()
+    total = int(series.shape[0])
+    if total == 0:
+        return _spec("histogram", f"Distribution of {column}", column, "Count", [{"name": "count", "data": []}])
+
+    low, high = float(series.min()), float(series.max())
+    if low == high:
+        data = [{"x": _fmt_edge(low), "y": total}]
+        return _spec(
+            "histogram",
+            f"Distribution of {column}",
+            column,
+            "Count",
+            [{"name": "count", "data": data}],
+            {"bins": 1, "total_rows": total},
+        )
+
+    binned = pd.cut(series, bins=bins)
+    counts = binned.value_counts(sort=False)
+    data = [
+        {"x": f"{_fmt_edge(interval.left)}–{_fmt_edge(interval.right)}", "y": int(count)}
+        for interval, count in counts.items()
+    ]
+    return _spec(
+        "histogram",
+        f"Distribution of {column}",
+        column,
+        "Count",
+        [{"name": "count", "data": data}],
+        {"bins": bins, "total_rows": total},
+    )
+
+
+def build_bar_chart(
+    df: pd.DataFrame,
+    category_col: str,
+    value_col: str | None = None,
+    agg: str = "sum",
+) -> dict[str, Any]:
+    """Aggregate a numeric value over a categorical column.
+
+    With ``agg="count"`` the value column is ignored and rows-per-category are
+    counted. Categories are sorted by value descending and capped at
+    ``MAX_BAR_CATEGORIES`` (``meta.truncated`` flags the cut).
+    """
+    _require_column(df, category_col)
+    if agg not in AGG_FUNCS:
+        raise ValueError(f"Unsupported aggregation '{agg}'")
+
+    if agg == "count":
+        grouped = df.groupby(category_col, dropna=True).size()
+        y_label = "Count"
+    else:
+        if value_col is None:
+            raise ValueError("value_col is required for non-count aggregations")
+        _require_column(df, value_col)
+        _require_numeric(df, value_col)
+        values = pd.to_numeric(df[value_col], errors="coerce")
+        grouped = values.groupby(df[category_col], dropna=True).agg(AGG_FUNCS[agg])
+        y_label = f"{agg} of {value_col}"
+
+    grouped = grouped.sort_values(ascending=False)
+    truncated = grouped.shape[0] > MAX_BAR_CATEGORIES
+    grouped = grouped.head(MAX_BAR_CATEGORIES)
+
+    data = [{"x": str(label), "y": _safe_number(value)} for label, value in grouped.items()]
+    name = "count" if agg == "count" else f"{agg}({value_col})"
+    return _spec(
+        "bar",
+        f"{y_label} by {category_col}",
+        category_col,
+        y_label,
+        [{"name": name, "data": data}],
+        {"truncated": truncated or None},
+    )
+
+
+def _xy_series(df: pd.DataFrame, x_col: str, y_cols: list[str], chart_type: str) -> dict[str, Any]:
+    """Shared builder for line/area: one series per y column, sorted by x."""
+    _require_column(df, x_col)
+    if not y_cols:
+        raise ValueError("at least one y column is required")
+    for y in y_cols:
+        _require_column(df, y)
+        _require_numeric(df, y)
+
+    x_label = map_dtype(df[x_col].dtype)
+    frame = df[[x_col, *y_cols]].dropna(subset=[x_col]).sort_values(x_col)
+
+    sampled = False
+    if frame.shape[0] > MAX_LINE_POINTS:
+        step = frame.shape[0] // MAX_LINE_POINTS + 1
+        frame = frame.iloc[::step]
+        sampled = True
+
+    xs = [_x_value(v, x_label) for v in frame[x_col]]
+    series = [
+        {"name": y, "data": [{"x": x, "y": _safe_number(v)} for x, v in zip(xs, frame[y], strict=True)]} for y in y_cols
+    ]
+    title = f"{', '.join(y_cols)} over {x_col}"
+    return _spec(chart_type, title, x_col, ", ".join(y_cols), series, {"sampled": sampled or None})
+
+
+def build_line_chart(df: pd.DataFrame, x_col: str, y_cols: list[str]) -> dict[str, Any]:
+    """Plot one or more numeric series against an ordered (often datetime) x."""
+    return _xy_series(df, x_col, y_cols, "line")
+
+
+def build_area_chart(df: pd.DataFrame, x_col: str, y_cols: list[str]) -> dict[str, Any]:
+    """Area variant of :func:`build_line_chart` (same data, filled rendering)."""
+    return _xy_series(df, x_col, y_cols, "area")
+
+
+def build_scatter_plot(
+    df: pd.DataFrame,
+    x_col: str,
+    y_col: str,
+    color_col: str | None = None,
+    max_points: int = MAX_SCATTER_POINTS,
+) -> dict[str, Any]:
+    """Plot two numeric columns as a point cloud, optionally grouped by color.
+
+    Rows missing x or y are dropped. The cloud is randomly sampled down to
+    ``max_points`` (``meta.sampled`` flags it) so the payload stays bounded.
+    """
+    _require_column(df, x_col)
+    _require_column(df, y_col)
+    _require_numeric(df, x_col)
+    _require_numeric(df, y_col)
+
+    cols = [x_col, y_col] + ([color_col] if color_col else [])
+    if color_col:
+        _require_column(df, color_col)
+    frame = df[cols].dropna(subset=[x_col, y_col])
+
+    sampled = False
+    if frame.shape[0] > max_points:
+        frame = frame.sample(n=max_points, random_state=0)
+        sampled = True
+
+    if color_col:
+        series = []
+        for group_value, group in frame.groupby(color_col, dropna=True):
+            data = [{"x": _round(xv), "y": _round(yv)} for xv, yv in zip(group[x_col], group[y_col], strict=True)]
+            series.append({"name": str(group_value), "data": data})
+    else:
+        data = [{"x": _round(xv), "y": _round(yv)} for xv, yv in zip(frame[x_col], frame[y_col], strict=True)]
+        series = [{"name": f"{y_col} vs {x_col}", "data": data}]
+
+    return _spec("scatter", f"{y_col} vs {x_col}", x_col, y_col, series, {"sampled": sampled or None})
+
+
+def build_pie_chart(
+    df: pd.DataFrame,
+    labels_col: str,
+    values_col: str | None = None,
+    max_slices: int = MAX_PIE_SLICES,
+) -> dict[str, Any]:
+    """Show category proportions as a single-series set of slices.
+
+    With ``values_col`` omitted the slices are row counts per category; otherwise
+    they are the summed value per category. Slices beyond ``max_slices`` collapse
+    into a single ``"Other"`` slice (``meta.truncated`` flags it).
+    """
+    _require_column(df, labels_col)
+
+    if values_col is None:
+        counts = df[labels_col].value_counts(dropna=True)
+        y_label = "Count"
+    else:
+        _require_column(df, values_col)
+        _require_numeric(df, values_col)
+        values = pd.to_numeric(df[values_col], errors="coerce")
+        counts = values.groupby(df[labels_col], dropna=True).sum().sort_values(ascending=False)
+        y_label = f"Sum of {values_col}"
+
+    truncated = counts.shape[0] > max_slices
+    data = [{"x": str(label), "y": _safe_number(value)} for label, value in counts.head(max_slices).items()]
+    if truncated:
+        # Avoid colliding with a real category literally named "Other" (common in
+        # survey data): pick a label that isn't already a shown slice.
+        shown = {slice_["x"] for slice_ in data}
+        overflow_label = "Other"
+        while overflow_label in shown:
+            overflow_label += " "
+        other = _safe_number(counts.iloc[max_slices:].sum())
+        data.append({"x": overflow_label, "y": other})
+
+    return _spec(
+        "pie",
+        f"{y_label} by {labels_col}",
+        labels_col,
+        y_label,
+        [{"name": labels_col, "data": data}],
+        {"truncated": truncated or None},
+    )
+
+
+# --- auto-suggestions --------------------------------------------------------
+
+
+def _classify_columns(df: pd.DataFrame) -> dict[str, list[str]]:
+    """Group column names by chart-relevant kind."""
+    kinds: dict[str, list[str]] = {"numeric": [], "categorical": [], "datetime": [], "low_card": []}
+    for column in df.columns:
+        label = map_dtype(df[column].dtype)
+        name = str(column)
+        if label in NUMERIC_LABELS:
+            kinds["numeric"].append(name)
+        elif label == "datetime":
+            kinds["datetime"].append(name)
+        elif label in ("str", "bool"):
+            kinds["categorical"].append(name)
+            if df[column].nunique(dropna=True) <= LOW_CARDINALITY_MAX:
+                kinds["low_card"].append(name)
+    return kinds
+
+
+def _most_correlated_pair(df: pd.DataFrame, numeric: list[str]) -> tuple[str, str] | None:
+    """Return the numeric column pair with the largest |Pearson r|, if any."""
+    corr = df[numeric].corr(method="pearson").abs()
+    best: tuple[str, str] | None = None
+    best_r = -1.0
+    for i in range(len(numeric)):
+        for j in range(i + 1, len(numeric)):
+            r = corr.iat[i, j]
+            if pd.notna(r) and r > best_r:
+                best_r = float(r)
+                best = (numeric[i], numeric[j])
+    return best
+
+
+def suggest_charts(df: pd.DataFrame, limit: int = 3) -> list[dict[str, Any]]:
+    """Recommend up to ``limit`` charts from the dataset's column shapes.
+
+    The heuristic prefers, in order: a scatter of the two most-correlated numeric
+    columns, a line over any datetime column, a bar of a low-cardinality category
+    by a numeric value, a histogram of a numeric column, then a pie of a
+    low-cardinality category. Returns ready-to-render ChartSpecs.
+    """
+    kinds = _classify_columns(df)
+    numeric, datetime_cols, low_card = kinds["numeric"], kinds["datetime"], kinds["low_card"]
+    suggestions: list[dict[str, Any]] = []
+
+    if len(numeric) >= 2:
+        pair = _most_correlated_pair(df, numeric)
+        if pair:
+            suggestions.append(build_scatter_plot(df, pair[0], pair[1]))
+
+    if datetime_cols and numeric:
+        suggestions.append(build_line_chart(df, datetime_cols[0], [numeric[0]]))
+
+    if low_card and numeric:
+        suggestions.append(build_bar_chart(df, low_card[0], numeric[0], agg="sum"))
+
+    if numeric:
+        suggestions.append(build_histogram(df, numeric[0]))
+
+    if low_card:
+        suggestions.append(build_pie_chart(df, low_card[0]))
+
+    return suggestions[:limit]

--- a/dataloom-backend/tests/test_visualizations.py
+++ b/dataloom-backend/tests/test_visualizations.py
@@ -1,0 +1,284 @@
+"""Tests for the visualization service and endpoints."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from app.services import visualization_service as vs
+
+# --- Service: build_histogram ---
+
+
+class TestBuildHistogram:
+    def test_bins_count_to_total_rows(self):
+        spec = vs.build_histogram(pd.DataFrame({"v": list(range(100))}), "v", bins=10)
+        assert spec["chart_type"] == "histogram"
+        data = spec["series"][0]["data"]
+        assert len(data) == 10
+        assert sum(point["y"] for point in data) == 100
+        assert spec["meta"]["bins"] == 10
+        assert spec["meta"]["total_rows"] == 100
+
+    def test_constant_column_collapses_to_one_bin(self):
+        spec = vs.build_histogram(pd.DataFrame({"v": [5, 5, 5]}), "v")
+        data = spec["series"][0]["data"]
+        assert len(data) == 1
+        assert data[0]["y"] == 3
+        assert spec["meta"]["bins"] == 1
+
+    def test_all_null_column_yields_empty_series(self):
+        spec = vs.build_histogram(pd.DataFrame({"v": [None, None]}, dtype="float"), "v")
+        assert spec["series"][0]["data"] == []
+
+    def test_bins_are_clamped(self):
+        spec = vs.build_histogram(pd.DataFrame({"v": list(range(50))}), "v", bins=99999)
+        assert spec["meta"]["bins"] == vs.MAX_BINS
+
+    def test_non_numeric_column_raises(self):
+        with pytest.raises(ValueError, match="not numeric"):
+            vs.build_histogram(pd.DataFrame({"c": ["a", "b"]}), "c")
+
+
+# --- Service: build_bar_chart ---
+
+
+class TestBuildBarChart:
+    def test_sum_aggregation(self):
+        df = pd.DataFrame({"region": ["a", "b", "a"], "sales": [10, 5, 20]})
+        spec = vs.build_bar_chart(df, "region", "sales", agg="sum")
+        data = {point["x"]: point["y"] for point in spec["series"][0]["data"]}
+        assert data == {"a": 30.0, "b": 5.0}
+        # Sorted by value descending.
+        assert spec["series"][0]["data"][0]["x"] == "a"
+
+    def test_count_aggregation_ignores_value_col(self):
+        df = pd.DataFrame({"region": ["a", "b", "a"]})
+        spec = vs.build_bar_chart(df, "region", agg="count")
+        data = {point["x"]: point["y"] for point in spec["series"][0]["data"]}
+        assert data == {"a": 2.0, "b": 1.0}
+
+    def test_mean_aggregation(self):
+        df = pd.DataFrame({"region": ["a", "a", "b"], "sales": [10, 20, 7]})
+        spec = vs.build_bar_chart(df, "region", "sales", agg="mean")
+        data = {point["x"]: point["y"] for point in spec["series"][0]["data"]}
+        assert data == {"a": 15.0, "b": 7.0}
+
+    def test_high_cardinality_is_capped_and_flagged(self):
+        n = vs.MAX_BAR_CATEGORIES + 5
+        df = pd.DataFrame({"k": [f"c{i}" for i in range(n)], "v": [1] * n})
+        spec = vs.build_bar_chart(df, "k", "v", agg="sum")
+        assert len(spec["series"][0]["data"]) == vs.MAX_BAR_CATEGORIES
+        assert spec["meta"]["truncated"] is True
+
+    def test_non_count_without_value_raises(self):
+        with pytest.raises(ValueError, match="value_col is required"):
+            vs.build_bar_chart(pd.DataFrame({"k": ["a"]}), "k", agg="sum")
+
+    def test_unknown_aggregation_raises(self):
+        with pytest.raises(ValueError, match="Unsupported aggregation"):
+            vs.build_bar_chart(pd.DataFrame({"k": ["a"], "v": [1]}), "k", "v", agg="bogus")
+
+
+# --- Service: build_line_chart / build_area_chart ---
+
+
+class TestBuildLineChart:
+    def test_sorts_by_x_and_emits_iso_dates(self):
+        df = pd.DataFrame(
+            {
+                "day": pd.to_datetime(["2020-03-01", "2020-01-01", "2020-02-01"]),
+                "v": [3, 1, 2],
+            }
+        )
+        spec = vs.build_line_chart(df, "day", ["v"])
+        xs = [point["x"] for point in spec["series"][0]["data"]]
+        assert xs == sorted(xs)
+        assert xs[0].startswith("2020-01-01")
+
+    def test_multiple_y_columns_become_multiple_series(self):
+        df = pd.DataFrame({"x": [1, 2, 3], "a": [1, 2, 3], "b": [3, 2, 1]})
+        spec = vs.build_line_chart(df, "x", ["a", "b"])
+        assert [s["name"] for s in spec["series"]] == ["a", "b"]
+
+    def test_downsamples_large_input(self):
+        df = pd.DataFrame({"x": range(10000), "y": range(10000)})
+        spec = vs.build_line_chart(df, "x", ["y"])
+        assert len(spec["series"][0]["data"]) <= vs.MAX_LINE_POINTS
+        assert spec["meta"]["sampled"] is True
+
+    def test_area_chart_type(self):
+        spec = vs.build_area_chart(pd.DataFrame({"x": [1, 2], "y": [1, 2]}), "x", ["y"])
+        assert spec["chart_type"] == "area"
+
+    def test_no_y_columns_raises(self):
+        with pytest.raises(ValueError, match="at least one y"):
+            vs.build_line_chart(pd.DataFrame({"x": [1]}), "x", [])
+
+
+# --- Service: build_scatter_plot ---
+
+
+class TestBuildScatter:
+    def test_drops_rows_missing_x_or_y(self):
+        df = pd.DataFrame({"x": [1, None, 3], "y": [1, 2, None]})
+        spec = vs.build_scatter_plot(df, "x", "y")
+        assert len(spec["series"][0]["data"]) == 1
+
+    def test_color_col_splits_into_series(self):
+        df = pd.DataFrame({"x": [1, 2, 3], "y": [1, 2, 3], "g": ["a", "b", "a"]})
+        spec = vs.build_scatter_plot(df, "x", "y", color_col="g")
+        assert {s["name"] for s in spec["series"]} == {"a", "b"}
+
+    def test_samples_when_over_max_points(self):
+        df = pd.DataFrame({"x": range(5000), "y": range(5000)})
+        spec = vs.build_scatter_plot(df, "x", "y", max_points=1000)
+        assert len(spec["series"][0]["data"]) == 1000
+        assert spec["meta"]["sampled"] is True
+
+    def test_non_numeric_axis_raises(self):
+        with pytest.raises(ValueError, match="not numeric"):
+            vs.build_scatter_plot(pd.DataFrame({"x": ["a"], "y": [1]}), "x", "y")
+
+
+# --- Service: build_pie_chart ---
+
+
+class TestBuildPie:
+    def test_counts_by_default(self):
+        spec = vs.build_pie_chart(pd.DataFrame({"k": ["a", "a", "b"]}), "k")
+        data = {point["x"]: point["y"] for point in spec["series"][0]["data"]}
+        assert data == {"a": 2.0, "b": 1.0}
+
+    def test_sums_a_value_column(self):
+        df = pd.DataFrame({"k": ["a", "a", "b"], "v": [1, 2, 5]})
+        spec = vs.build_pie_chart(df, "k", "v")
+        data = {point["x"]: point["y"] for point in spec["series"][0]["data"]}
+        assert data == {"a": 3.0, "b": 5.0}
+
+    def test_collapses_overflow_into_other(self):
+        n = vs.MAX_PIE_SLICES + 4
+        df = pd.DataFrame({"k": [f"c{i}" for i in range(n)]})
+        spec = vs.build_pie_chart(df, "k")
+        labels = [point["x"] for point in spec["series"][0]["data"]]
+        assert labels[-1] == "Other"
+        assert len(labels) == vs.MAX_PIE_SLICES + 1
+        assert spec["meta"]["truncated"] is True
+
+
+# --- Service: suggest_charts ---
+
+
+class TestSuggestCharts:
+    def test_recommends_relevant_charts(self):
+        df = pd.DataFrame(
+            {
+                "day": pd.to_datetime(pd.date_range("2020-01-01", periods=6)),
+                "revenue": [1, 2, 3, 4, 5, 6],
+                "cost": [2, 4, 6, 8, 10, 12],
+                "region": ["a", "b", "a", "b", "a", "b"],
+            }
+        )
+        types = [spec["chart_type"] for spec in vs.suggest_charts(df)]
+        assert len(types) <= 3
+        # Two correlated numerics → scatter is the top suggestion.
+        assert types[0] == "scatter"
+
+    def test_empty_dataframe_suggests_nothing(self):
+        assert vs.suggest_charts(pd.DataFrame()) == []
+
+    def test_single_numeric_suggests_histogram(self):
+        types = [spec["chart_type"] for spec in vs.suggest_charts(pd.DataFrame({"v": [1, 2, 3, 4]}))]
+        assert "histogram" in types
+
+
+# --- JSON safety ---
+
+
+def test_charts_emit_no_nan_or_inf():
+    """Every numeric y must be JSON-safe (None, not NaN/inf)."""
+    df = pd.DataFrame({"k": ["a", "b"], "v": [np.inf, np.nan]})
+    spec = vs.build_bar_chart(df, "k", "v", agg="sum")
+    for point in spec["series"][0]["data"]:
+        if isinstance(point["y"], float):
+            assert np.isfinite(point["y"])
+
+
+# --- Endpoints ---
+
+
+@pytest.fixture
+def project_id(client, tmp_path):
+    """Upload a CSV with a datetime, numerics, and a low-card category."""
+    csv = tmp_path / "viz.csv"
+    csv.write_text(
+        "day,revenue,cost,region\n"
+        "2020-01-01,10,5,north\n"
+        "2020-01-02,20,8,south\n"
+        "2020-01-03,30,12,north\n"
+        "2020-01-04,40,15,south\n"
+    )
+    with open(csv, "rb") as f:
+        response = client.post(
+            "/projects/upload",
+            files={"file": ("viz.csv", f, "text/csv")},
+            data={"projectName": "Viz", "projectDescription": "fixture"},
+        )
+    assert response.status_code == 200, response.text
+    return response.json()["project_id"]
+
+
+class TestVisualizationEndpoints:
+    def test_suggest(self, client, project_id):
+        response = client.get(f"/projects/{project_id}/charts/suggest")
+        assert response.status_code == 200, response.text
+        suggestions = response.json()["suggestions"]
+        assert len(suggestions) >= 1
+        assert all("chart_type" in s for s in suggestions)
+
+    def test_histogram(self, client, project_id):
+        response = client.get(
+            f"/projects/{project_id}/charts",
+            params={"chart_type": "histogram", "column": "revenue", "bins": 4},
+        )
+        assert response.status_code == 200, response.text
+        assert response.json()["chart_type"] == "histogram"
+
+    def test_bar(self, client, project_id):
+        response = client.get(
+            f"/projects/{project_id}/charts",
+            params={"chart_type": "bar", "category": "region", "value": "revenue", "agg": "sum"},
+        )
+        assert response.status_code == 200, response.text
+        data = {p["x"]: p["y"] for p in response.json()["series"][0]["data"]}
+        assert data == {"north": 40.0, "south": 60.0}
+
+    def test_scatter(self, client, project_id):
+        response = client.get(
+            f"/projects/{project_id}/charts",
+            params={"chart_type": "scatter", "x": "revenue", "y": "cost"},
+        )
+        assert response.status_code == 200, response.text
+        assert response.json()["chart_type"] == "scatter"
+
+    def test_missing_required_param_returns_400(self, client, project_id):
+        response = client.get(f"/projects/{project_id}/charts", params={"chart_type": "histogram"})
+        assert response.status_code == 400
+        assert "requires" in response.json()["detail"].lower()
+
+    def test_non_numeric_histogram_returns_400(self, client, project_id):
+        response = client.get(
+            f"/projects/{project_id}/charts",
+            params={"chart_type": "histogram", "column": "region"},
+        )
+        assert response.status_code == 400
+
+    def test_unknown_column_returns_404(self, client, project_id):
+        response = client.get(
+            f"/projects/{project_id}/charts",
+            params={"chart_type": "histogram", "column": "nope"},
+        )
+        assert response.status_code == 404
+
+    def test_requires_auth(self, anon_client, project_id):
+        response = anon_client.get(f"/projects/{project_id}/charts/suggest")
+        assert response.status_code == 401

--- a/dataloom-frontend/package-lock.json
+++ b/dataloom-frontend/package-lock.json
@@ -14,7 +14,8 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-icons": "^5.2.1",
-        "react-router-dom": "^6.24.0"
+        "react-router-dom": "^6.24.0",
+        "recharts": "^3.9.1"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.3.1",
@@ -1082,6 +1083,32 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@remix-run/router": {
       "version": "1.23.3",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
@@ -1453,6 +1480,18 @@
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
       "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@tailwindcss/node": {
@@ -1889,6 +1928,69 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -1900,14 +2002,14 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.31",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
       "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -1923,6 +2025,12 @@
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.1",
@@ -2629,6 +2737,15 @@
         "node": "*"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2729,8 +2846,129 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/data-urls": {
       "version": "5.0.0",
@@ -2822,6 +3060,12 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/deep-eql": {
@@ -3235,6 +3479,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es-toolkit": {
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.49.0.tgz",
+      "integrity": "sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
+    },
     "node_modules/esbuild": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
@@ -3539,6 +3793,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/execa": {
       "version": "8.0.1",
@@ -4130,6 +4390,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "11.1.9",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.9.tgz",
+      "integrity": "sha512-sc/z0Cyti70bZa0ZU4sWfAElfovFb9Ni8tArJZLuklYWxegPiK3pDOql1Rq5H0FIRAW9LSQRG6OX4KqBldbhBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -4199,6 +4469,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-arguments": {
@@ -5953,8 +6232,30 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-redux": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -5998,6 +6299,36 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.9.1.tgz",
+      "integrity": "sha512-WMcwlXcB7l+BbxiEdyClkG+1sxrMHNZpzT577LEvU4+rXPd8oTAy1wXk72hnk2KOOmxuLvw3z5DtXT7HEAydtg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^11.1.8",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.2.0",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -6010,6 +6341,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -6061,6 +6407,12 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/reselect": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
+      "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
       "license": "MIT"
     },
     "node_modules/resolve": {
@@ -6733,6 +7085,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -6999,6 +7357,37 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/dataloom-frontend/package.json
+++ b/dataloom-frontend/package.json
@@ -21,12 +21,11 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^5.2.1",
-    "react-router-dom": "^6.24.0"
+    "react-router-dom": "^6.24.0",
+    "recharts": "^3.9.1"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.3.1",
-    "tailwindcss": "^4.3.1",
-    "tw-animate-css": "^1.4.0",
     "@testing-library/jest-dom": "^6.4.2",
     "@testing-library/react": "^14.2.1",
     "@testing-library/user-event": "^14.5.2",
@@ -41,6 +40,8 @@
     "jsdom": "^24.0.0",
     "postcss": "^8.4.38",
     "prettier": "^3.2.5",
+    "tailwindcss": "^4.3.1",
+    "tw-animate-css": "^1.4.0",
     "vite": "^5.2.0",
     "vitest": "^1.6.0"
   }

--- a/dataloom-frontend/src/Components/DataScreen.jsx
+++ b/dataloom-frontend/src/Components/DataScreen.jsx
@@ -6,12 +6,14 @@ import { WorkspaceTabsProvider, useWorkspaceTabs } from "../context/WorkspaceTab
 import { PanelProvider } from "../context/PanelContext";
 import { HistoryRefreshProvider } from "../context/HistoryRefreshContext";
 import { ColumnProfilesProvider } from "../context/ColumnProfilesContext";
+import { ChartViewProvider } from "../context/ChartViewContext";
 import { getTabComponent } from "./workspace/TabRegistry";
 // Each feature module self-registers its tabs, panels, and menu items.
 import { DATASET_TAB } from "./workspace/features/dataset";
 import "./workspace/features/transforms";
 import "./workspace/features/history";
 import "./workspace/features/profiling";
+import "./workspace/features/charts";
 import WorkspaceTabBar from "./workspace/WorkspaceTabBar";
 import RightPanel from "./workspace/RightPanel";
 import MenuNavbar from "./MenuNavbar";
@@ -82,7 +84,9 @@ export default function DataScreen() {
         <PanelProvider>
           <HistoryRefreshProvider>
             <ColumnProfilesProvider>
-              <WorkspaceContent projectId={projectId} />
+              <ChartViewProvider>
+                <WorkspaceContent projectId={projectId} />
+              </ChartViewProvider>
             </ColumnProfilesProvider>
           </HistoryRefreshProvider>
         </PanelProvider>

--- a/dataloom-frontend/src/Components/MenuNavbar.jsx
+++ b/dataloom-frontend/src/Components/MenuNavbar.jsx
@@ -28,7 +28,7 @@ const MenuNavbar = ({ projectId }) => {
   const [activeTab, setActiveTab] = useState("File");
 
   const { updateData, refreshProject, pageSize, projectName, isPreviewMode } = useProjectContext();
-  const { activePanel, togglePanel, closePanel } = usePanel();
+  const { activePanel, openPanel, togglePanel, closePanel } = usePanel();
   const { openTab } = useWorkspaceTabs();
   const { refreshLogs, refreshCheckpoints } = useHistoryRefresh();
   const { showColumnProfiles, toggleColumnProfiles } = useColumnProfilesView();
@@ -108,10 +108,12 @@ const MenuNavbar = ({ projectId }) => {
     order: item.order,
     label: item.label,
     icon: item.icon,
-    onClick:
-      "openTab" in item.action
-        ? () => openTab(item.action.openTab)
-        : () => togglePanel(item.action.togglePanel),
+    onClick: () => {
+      const { openTab: tab, openPanel: panel, togglePanel: toggle } = item.action;
+      if (tab) openTab(tab);
+      if (panel) openPanel(panel);
+      if (toggle) togglePanel(toggle);
+    },
     disabled: item.disabledInPreview ? isPreviewMode : false,
     active: item.activePanel ? activePanel === item.activePanel : false,
   }));

--- a/dataloom-frontend/src/Components/common/Select.tsx
+++ b/dataloom-frontend/src/Components/common/Select.tsx
@@ -143,7 +143,7 @@ const Select = ({
         <div
           data-state={open ? "open" : "closed"}
           onAnimationEnd={handleAnimationEnd}
-          className="absolute z-20 mt-1 w-full bg-white border border-gray-300 rounded-md shadow-lg origin-top data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fill-mode-forwards data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0 data-[state=open]:zoom-in-95 data-[state=closed]:zoom-out-95 data-[state=open]:slide-in-from-top-2 data-[state=closed]:slide-out-to-top-2"
+          className="absolute z-50 mt-1 w-full bg-white border border-gray-300 rounded-md shadow-lg origin-top data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fill-mode-forwards data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0 data-[state=open]:zoom-in-95 data-[state=closed]:zoom-out-95 data-[state=open]:slide-in-from-top-2 data-[state=closed]:slide-out-to-top-2"
         >
           <ul ref={listRef} role="listbox" className="max-h-48 overflow-y-auto p-1">
             {options.map((item, index) => (

--- a/dataloom-frontend/src/Components/profiling/CorrelationHeatmap.tsx
+++ b/dataloom-frontend/src/Components/profiling/CorrelationHeatmap.tsx
@@ -1,0 +1,358 @@
+import { useMemo, useState } from "react";
+import type { Correlation } from "../../api/profiling";
+
+interface CorrelationHeatmapProps {
+  correlation: Correlation | null;
+  /** True when the correlation fetch failed; takes precedence over loading. */
+  error?: boolean;
+  onRetry?: () => void;
+}
+
+const NEGATIVE: [number, number, number] = [37, 99, 235]; // blue-600
+const POSITIVE: [number, number, number] = [220, 38, 38]; // red-600
+
+/**
+ * Diverging Pearson scale: −1 → blue, 0 → white, +1 → red. The mix factor is
+ * |value|, so the colour saturates toward the extremes and washes out near zero.
+ */
+function cellColor(value: number): string {
+  const magnitude = Math.min(Math.abs(value), 1);
+  const [r, g, b] = value < 0 ? NEGATIVE : POSITIVE;
+  const mix = (channel: number) => Math.round(255 + (channel - 255) * magnitude);
+  return `rgb(${mix(r)}, ${mix(g)}, ${mix(b)})`;
+}
+
+/** Strong cells need light text to stay legible against the saturated fill. */
+function textColor(value: number): string {
+  return Math.abs(value) > 0.55 ? "#ffffff" : "#374151"; // gray-700
+}
+
+/** Colour the bare value text by magnitude so near-zero numbers read as muted. */
+function valueTextColor(value: number): string {
+  if (Math.abs(value) < 0.2) return "#6b7280"; // gray-500
+  return value < 0 ? "#2563eb" : "#dc2626";
+}
+
+/** Round to 2 decimals and drop trailing zeros; null → "—". */
+function fmt(value: number | null): string {
+  if (value == null) return "—";
+  return Number(value.toFixed(2)).toString();
+}
+
+/** Plain-language strength + direction for a correlation coefficient. */
+function describe(value: number): string {
+  const magnitude = Math.abs(value);
+  const direction = value > 0 ? "positive" : "negative";
+  if (magnitude >= 0.7) return `strong ${direction}`;
+  if (magnitude >= 0.4) return `moderate ${direction}`;
+  if (magnitude >= 0.2) return `weak ${direction}`;
+  return "negligible";
+}
+
+interface Pair {
+  a: string;
+  b: string;
+  r: number;
+}
+
+/**
+ * Reduce the raw correlation payload to the parts worth showing: the columns
+ * that actually have variance (a constant/all-null numeric column correlates to
+ * NaN with everything, including itself), the sub-matrix over them, and the
+ * pairwise list ranked by |r|. Dead columns are surfaced separately rather than
+ * filling the grid with em dashes.
+ */
+function useDerived(correlation: Correlation | null) {
+  return useMemo(() => {
+    const columns = correlation?.columns ?? [];
+    const matrix = correlation?.matrix ?? [];
+
+    const activeColumns: string[] = [];
+    const activeIdx: number[] = [];
+    const excludedColumns: string[] = [];
+    columns.forEach((col, i) => {
+      // A self-correlation only exists when the column has variance.
+      if (matrix[i]?.[i] != null) {
+        activeColumns.push(col);
+        activeIdx.push(i);
+      } else {
+        excludedColumns.push(col);
+      }
+    });
+
+    const subMatrix: (number | null)[][] = activeIdx.map((i) =>
+      activeIdx.map((j) => matrix[i]?.[j] ?? null),
+    );
+
+    const pairs: Pair[] = [];
+    for (let i = 0; i < activeColumns.length; i++) {
+      const row = subMatrix[i];
+      const a = activeColumns[i];
+      if (!row || a === undefined) continue;
+      for (let j = 0; j < i; j++) {
+        const r = row[j];
+        const b = activeColumns[j];
+        if (r != null && b !== undefined) pairs.push({ a, b, r });
+      }
+    }
+    pairs.sort((p, q) => Math.abs(q.r) - Math.abs(p.r));
+
+    return { activeColumns, excludedColumns, subMatrix, pairs };
+  }, [correlation]);
+}
+
+function ExcludedNote({ columns }: { columns: string[] }) {
+  if (columns.length === 0) return null;
+  const noun = columns.length === 1 ? "column" : "columns";
+  return (
+    <p data-testid="excluded-note" className="mb-3 text-xs text-gray-400">
+      {columns.length} numeric {noun} excluded (no variance): {columns.join(", ")}
+    </p>
+  );
+}
+
+/** Ranked list of the strongest pairwise relationships — the insight-first view. */
+function HighlightsView({ pairs }: { pairs: Pair[] }) {
+  if (pairs.length === 0) {
+    return <p className="py-4 text-center text-sm text-gray-500">No correlations to rank.</p>;
+  }
+
+  const strongest = pairs[0];
+  const negligible = strongest != null && Math.abs(strongest.r) < 0.2;
+
+  return (
+    <div>
+      <p className="mb-2 text-xs text-gray-500">
+        Strongest linear relationships between numeric columns (Pearson, −1 to +1).
+        {negligible && " No strong correlations in this dataset — the strongest are shown below."}
+      </p>
+      <ul data-testid="highlights-list" className="divide-y divide-gray-100">
+        {pairs.slice(0, 10).map(({ a, b, r }) => (
+          <li key={`${a}|${b}`} className="flex items-center gap-3 py-2">
+            <span
+              className="h-4 w-4 shrink-0 rounded border border-gray-200"
+              style={{ background: cellColor(r) }}
+            />
+            <span className="truncate text-sm text-gray-700">
+              <span className="font-medium">{a}</span>
+              <span className="mx-1.5 text-gray-400">↔</span>
+              <span className="font-medium">{b}</span>
+            </span>
+            <span
+              className="ml-auto tabular-nums text-sm font-semibold"
+              style={{ color: valueTextColor(r) }}
+            >
+              {fmt(r)}
+            </span>
+            <span className="w-28 text-right text-xs text-gray-400">{describe(r)}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+/**
+ * Cleaned-up grid: lower triangle only (the matrix is symmetric), a muted
+ * identity diagonal instead of a screaming red one, a colour legend, and a
+ * crosshair that names the hovered pair in a readable caption.
+ */
+function MatrixView({ columns, subMatrix }: { columns: string[]; subMatrix: (number | null)[][] }) {
+  const [hovered, setHovered] = useState<{ row: number; col: number } | null>(null);
+  const hoveredValue = hovered != null ? (subMatrix[hovered.row]?.[hovered.col] ?? null) : null;
+
+  return (
+    <div>
+      <div className="mb-3 flex items-center gap-2 text-xs text-gray-500">
+        <span>−1</span>
+        <span
+          className="h-2 w-32 rounded"
+          style={{
+            background: `linear-gradient(to right, rgb(${NEGATIVE.join(",")}), #ffffff, rgb(${POSITIVE.join(",")}))`,
+          }}
+        />
+        <span>+1</span>
+        <span className="ml-1">blue = negative, red = positive</span>
+      </div>
+
+      <div className="mb-1 h-5 text-xs text-gray-600" data-testid="matrix-caption">
+        {hovered != null && hoveredValue != null && (
+          <>
+            <span className="font-medium">{columns[hovered.row]}</span>
+            <span className="mx-1 text-gray-400">↔</span>
+            <span className="font-medium">{columns[hovered.col]}</span>
+            {": "}
+            <span className="font-semibold">{fmt(hoveredValue)}</span>{" "}
+            <span className="text-gray-400">({describe(hoveredValue)})</span>
+          </>
+        )}
+      </div>
+
+      <div className="overflow-x-auto">
+        <table
+          className="border-collapse text-xs"
+          data-testid="correlation-table"
+          onMouseLeave={() => setHovered(null)}
+        >
+          <thead>
+            <tr>
+              <th className="sticky left-0 z-10 bg-white" />
+              {columns.map((col, j) => (
+                <th
+                  key={col}
+                  className={`px-2 py-1 align-bottom font-medium ${
+                    hovered?.col === j ? "text-gray-900" : "text-gray-500"
+                  }`}
+                  title={col}
+                >
+                  <span className="block max-w-[5rem] truncate">{col}</span>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {columns.map((rowCol, i) => {
+              const row = subMatrix[i] ?? [];
+              return (
+                <tr key={rowCol}>
+                  <th
+                    className={`sticky left-0 z-10 bg-white py-1 pr-2 text-right font-medium whitespace-nowrap ${
+                      hovered?.row === i ? "text-gray-900" : "text-gray-500"
+                    }`}
+                    title={rowCol}
+                  >
+                    <span className="block max-w-[8rem] truncate">{rowCol}</span>
+                  </th>
+                  {columns.map((colCol, j) => {
+                    // Upper triangle is the mirror image — leave it blank.
+                    if (j > i) {
+                      return <td key={colCol} className="border border-white" />;
+                    }
+                    // Identity diagonal: present but deliberately muted.
+                    if (j === i) {
+                      return (
+                        <td
+                          key={colCol}
+                          className="border border-white bg-gray-50 px-2 py-1 text-center text-gray-300"
+                        >
+                          1
+                        </td>
+                      );
+                    }
+                    const value = row[j] ?? null;
+                    const isHover = hovered?.row === i && hovered?.col === j;
+                    return (
+                      <td
+                        key={colCol}
+                        onMouseEnter={() => setHovered({ row: i, col: j })}
+                        className={`cursor-default border border-white px-2 py-1 text-center tabular-nums ${
+                          isHover ? "ring-2 ring-inset ring-gray-900/50" : ""
+                        }`}
+                        style={
+                          value == null
+                            ? { background: "#f3f4f6", color: "#9ca3af" }
+                            : { background: cellColor(value), color: textColor(value) }
+                        }
+                        title={`${rowCol} × ${colCol}: ${fmt(value)}`}
+                      >
+                        {fmt(value)}
+                      </td>
+                    );
+                  })}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function ViewToggle({
+  view,
+  onChange,
+}: {
+  view: "highlights" | "matrix";
+  onChange: (view: "highlights" | "matrix") => void;
+}) {
+  const base = "px-3 py-1 text-xs font-medium rounded-md transition-colors";
+  return (
+    <div className="inline-flex rounded-lg bg-gray-100 p-0.5">
+      <button
+        type="button"
+        onClick={() => onChange("highlights")}
+        className={`${base} ${view === "highlights" ? "bg-white text-gray-900 shadow-sm" : "text-gray-500 hover:text-gray-700"}`}
+      >
+        Highlights
+      </button>
+      <button
+        type="button"
+        onClick={() => onChange("matrix")}
+        className={`${base} ${view === "matrix" ? "bg-white text-gray-900 shadow-sm" : "text-gray-500 hover:text-gray-700"}`}
+      >
+        Matrix
+      </button>
+    </div>
+  );
+}
+
+/**
+ * Pairwise Pearson correlation over the dataset's numeric columns. Embedded in
+ * the Charts tab as one of the visualizations. Defaults to the full
+ * lower-triangular heatmap grid (what "heatmap" implies); a "Highlights" toggle
+ * shows a ranked list of the strongest pairs for a quick read.
+ */
+export default function CorrelationHeatmap({
+  correlation,
+  error = false,
+  onRetry,
+}: CorrelationHeatmapProps) {
+  const [view, setView] = useState<"highlights" | "matrix">("matrix");
+  const { activeColumns, excludedColumns, subMatrix, pairs } = useDerived(correlation);
+
+  const ready = !error && correlation != null && activeColumns.length >= 2;
+
+  return (
+    <div data-testid="correlation-heatmap-panel" className="relative">
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <h4 className="text-sm font-medium text-gray-700">Correlation</h4>
+        {ready && <ViewToggle view={view} onChange={setView} />}
+      </div>
+
+      {error ? (
+        <div className="py-4 text-center text-sm text-gray-500">
+          <p>Couldn’t load the correlation matrix.</p>
+          {onRetry && (
+            <button
+              type="button"
+              onClick={onRetry}
+              className="mt-2 font-medium text-blue-600 hover:text-blue-800"
+              style={{ background: "transparent", border: "none", cursor: "pointer" }}
+            >
+              Retry
+            </button>
+          )}
+        </div>
+      ) : !correlation ? (
+        <div className="py-4 text-center text-sm text-gray-500">Loading correlation…</div>
+      ) : activeColumns.length < 2 ? (
+        <>
+          <ExcludedNote columns={excludedColumns} />
+          <div className="py-4 text-center text-sm text-gray-500">
+            Correlation needs at least two numeric columns with variance.
+          </div>
+        </>
+      ) : (
+        <>
+          <ExcludedNote columns={excludedColumns} />
+          {view === "highlights" ? (
+            <HighlightsView pairs={pairs} />
+          ) : (
+            <MatrixView columns={activeColumns} subMatrix={subMatrix} />
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/dataloom-frontend/src/Components/profiling/__tests__/CorrelationHeatmap.test.tsx
+++ b/dataloom-frontend/src/Components/profiling/__tests__/CorrelationHeatmap.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import CorrelationHeatmap from "../CorrelationHeatmap";
+
+/** Two correlated columns plus a third constant column (null diagonal). */
+const withDeadColumn = {
+  columns: ["a", "b", "dead"],
+  matrix: [
+    [1, 0.5, null],
+    [0.5, 1, null],
+    [null, null, null],
+  ],
+};
+
+describe("CorrelationHeatmap", () => {
+  it("shows a loading state while the correlation is null", () => {
+    render(<CorrelationHeatmap correlation={null} />);
+    expect(screen.getByText("Loading correlation…")).toBeInTheDocument();
+  });
+
+  it("shows a retry affordance on error", () => {
+    const onRetry = vi.fn();
+    render(<CorrelationHeatmap correlation={null} error onRetry={onRetry} />);
+
+    fireEvent.click(screen.getByText("Retry"));
+    expect(onRetry).toHaveBeenCalledOnce();
+  });
+
+  it("prompts for more numeric columns when fewer than two have variance", () => {
+    render(
+      <CorrelationHeatmap correlation={{ columns: ["a"], matrix: [[1]] }} />,
+    );
+    expect(screen.getByText(/at least two numeric columns/i)).toBeInTheDocument();
+    expect(screen.queryByTestId("highlights-list")).not.toBeInTheDocument();
+  });
+
+  it("defaults to the lower-triangular matrix grid", () => {
+    render(<CorrelationHeatmap correlation={withDeadColumn} />);
+
+    const table = screen.getByTestId("correlation-table");
+    expect(within(table).getByText("0.5")).toBeInTheDocument();
+    // The ranked highlights list is hidden until the user toggles to it.
+    expect(screen.queryByTestId("highlights-list")).not.toBeInTheDocument();
+  });
+
+  it("shows a ranked highlights list with strength labels when toggled", () => {
+    render(<CorrelationHeatmap correlation={withDeadColumn} />);
+
+    fireEvent.click(screen.getByText("Highlights"));
+
+    const list = screen.getByTestId("highlights-list");
+    expect(within(list).getByText("0.5")).toBeInTheDocument();
+    expect(within(list).getByText("moderate positive")).toBeInTheDocument();
+  });
+
+  it("excludes constant columns and names them", () => {
+    render(<CorrelationHeatmap correlation={withDeadColumn} />);
+
+    const note = screen.getByTestId("excluded-note");
+    expect(note).toHaveTextContent("dead");
+    expect(note).toHaveTextContent(/no variance/i);
+  });
+
+  it("renders a lower-triangular matrix with a muted diagonal", () => {
+    render(<CorrelationHeatmap correlation={withDeadColumn} />);
+
+    const table = screen.getByTestId("correlation-table");
+    // Lower-triangle value present, dead column dropped from the grid entirely.
+    expect(within(table).getByText("0.5")).toBeInTheDocument();
+    expect(within(table).queryByText("dead")).not.toBeInTheDocument();
+    // Two identity cells render a muted "1"; the redundant upper "0.5" is gone.
+    expect(within(table).getAllByText("1")).toHaveLength(2);
+    expect(within(table).getAllByText("0.5")).toHaveLength(1);
+  });
+});

--- a/dataloom-frontend/src/Components/visualizations/ChartBuilderPanel.tsx
+++ b/dataloom-frontend/src/Components/visualizations/ChartBuilderPanel.tsx
@@ -1,0 +1,223 @@
+import { useMemo, useState } from "react";
+import type { AggFunc, ChartParams, ChartType } from "../../api/visualizations";
+import { useChartView } from "../../context/ChartViewContext";
+import { useProjectContext } from "../../context/ProjectContext";
+import Button from "../common/Button";
+import ColumnSelect from "../common/ColumnSelect";
+import Select, { type SelectOption } from "../common/Select";
+import { columnsFor, usesAgg, type Dtypes } from "./chartFields";
+
+// "heatmap" is a builder-only option: correlation has its own renderer, so it
+// doesn't go through the chart endpoint.
+type BuilderType = ChartType | "heatmap";
+
+const BASE_TYPES: SelectOption[] = [
+  { value: "histogram", label: "Histogram" },
+  { value: "bar", label: "Bar" },
+  { value: "line", label: "Line" },
+  { value: "area", label: "Area" },
+  { value: "scatter", label: "Scatter" },
+  { value: "pie", label: "Pie" },
+];
+
+const AGG_OPTIONS: SelectOption[] = (["sum", "mean", "median", "min", "max", "count"] as AggFunc[]).map(
+  (a) => ({ value: a, label: a.charAt(0).toUpperCase() + a.slice(1) }),
+);
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="mb-3">
+      <label className="mb-1 block text-sm font-medium text-gray-700">{label}</label>
+      {children}
+    </div>
+  );
+}
+
+interface ChartBuilderPanelProps {
+  onClose: () => void;
+}
+
+/**
+ * No-code chart builder, docked in the right side panel like the transform
+ * forms. Column dropdowns are filtered to the dtypes each chart type accepts and
+ * irrelevant controls are hidden, so an invalid config can't be submitted.
+ * On Render it hands the request to ChartViewContext, which renders it in the
+ * Charts tab.
+ */
+export default function ChartBuilderPanel({ onClose }: ChartBuilderPanelProps) {
+  const { columns, dtypes } = useProjectContext() as unknown as {
+    columns: string[];
+    dtypes: Dtypes;
+  };
+  const { renderChart, showHeatmap } = useChartView();
+
+  const [chartType, setChartType] = useState<BuilderType>("histogram");
+  const [column, setColumn] = useState("");
+  const [category, setCategory] = useState("");
+  const [value, setValue] = useState("");
+  const [x, setX] = useState("");
+  const [y, setY] = useState("");
+  const [color, setColor] = useState("");
+  const [agg, setAgg] = useState<AggFunc>("sum");
+  const [bins, setBins] = useState(20);
+
+  const numericCols = useMemo(() => columnsFor("value", columns, dtypes), [columns, dtypes]);
+  const xCols = useMemo(() => columnsFor("x", columns, dtypes), [columns, dtypes]);
+
+  // Correlation needs two numeric columns; only offer it when that's possible.
+  const typeOptions = useMemo<SelectOption[]>(
+    () =>
+      numericCols.length >= 2
+        ? [...BASE_TYPES, { value: "heatmap", label: "Correlation heatmap" }]
+        : BASE_TYPES,
+    [numericCols.length],
+  );
+
+  const params = useMemo<ChartParams | null>(() => {
+    switch (chartType) {
+      case "histogram":
+        return column ? { chart_type: "histogram", column, bins } : null;
+      case "bar":
+        if (!category) return null;
+        if (agg !== "count" && !value) return null;
+        return { chart_type: "bar", category, value: agg === "count" ? undefined : value, agg };
+      case "pie":
+        return category ? { chart_type: "pie", category, value: value || undefined } : null;
+      case "line":
+      case "area":
+        return x && y ? { chart_type: chartType, x, y: [y] } : null;
+      case "scatter":
+        return x && y ? { chart_type: "scatter", x, y: [y], color: color || undefined } : null;
+      default:
+        return null;
+    }
+  }, [chartType, column, category, value, x, y, color, agg, bins]);
+
+  const canRender = chartType === "heatmap" || params !== null;
+
+  const handleRender = () => {
+    if (chartType === "heatmap") showHeatmap();
+    else if (params) renderChart(params);
+  };
+
+  return (
+    <div data-testid="chart-builder-panel">
+      <Field label="Chart type">
+        <Select
+          data-testid="chart-type-select"
+          value={chartType}
+          onChange={(v) => setChartType(v as BuilderType)}
+          options={typeOptions}
+        />
+      </Field>
+
+      {chartType === "histogram" && (
+        <>
+          <Field label="Column">
+            <ColumnSelect
+              data-testid="histogram-column"
+              value={column}
+              onChange={setColumn}
+              options={numericCols}
+              placeholder="Select a numeric column…"
+            />
+          </Field>
+          <Field label={`Bins: ${bins}`}>
+            <input
+              type="range"
+              min={2}
+              max={60}
+              value={bins}
+              onChange={(e) => setBins(Number(e.target.value))}
+              className="w-full accent-blue-600"
+            />
+          </Field>
+        </>
+      )}
+
+      {(chartType === "bar" || chartType === "pie") && (
+        <Field label="Category">
+          <ColumnSelect
+            data-testid="category-select"
+            value={category}
+            onChange={setCategory}
+            options={columns}
+            placeholder="Select a column…"
+          />
+        </Field>
+      )}
+
+      {usesAgg(chartType) && (
+        <Field label="Aggregation">
+          <Select
+            data-testid="agg-select"
+            value={agg}
+            onChange={(v) => setAgg(v as AggFunc)}
+            options={AGG_OPTIONS}
+          />
+        </Field>
+      )}
+
+      {(chartType === "bar" || chartType === "pie") && (
+        <Field label={chartType === "pie" ? "Value (optional)" : "Value"}>
+          <ColumnSelect
+            data-testid="value-select"
+            value={value}
+            onChange={setValue}
+            options={numericCols}
+            disabled={chartType === "bar" && agg === "count"}
+            includeEmptyOption={chartType === "pie"}
+            emptyLabel="Count"
+            placeholder="Select a numeric column…"
+          />
+        </Field>
+      )}
+
+      {(chartType === "line" || chartType === "area" || chartType === "scatter") && (
+        <>
+          <Field label="X axis">
+            <ColumnSelect
+              data-testid="x-select"
+              value={x}
+              onChange={setX}
+              options={chartType === "scatter" ? numericCols : xCols}
+              placeholder="Select a column…"
+            />
+          </Field>
+          <Field label="Y axis">
+            <ColumnSelect
+              data-testid="y-select"
+              value={y}
+              onChange={setY}
+              options={numericCols}
+              placeholder="Select a numeric column…"
+            />
+          </Field>
+        </>
+      )}
+
+      {chartType === "scatter" && (
+        <Field label="Color (optional)">
+          <ColumnSelect
+            data-testid="color-select"
+            value={color}
+            onChange={setColor}
+            options={columns}
+            includeEmptyOption
+            emptyLabel="None"
+            placeholder="None"
+          />
+        </Field>
+      )}
+
+      <div className="mt-4 flex justify-between">
+        <Button type="button" onClick={handleRender} disabled={!canRender}>
+          Render
+        </Button>
+        <Button type="button" variant="secondary" onClick={onClose}>
+          Close
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/dataloom-frontend/src/Components/visualizations/ChartRenderer.tsx
+++ b/dataloom-frontend/src/Components/visualizations/ChartRenderer.tsx
@@ -1,0 +1,179 @@
+import {
+  Area,
+  AreaChart,
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  Legend,
+  Line,
+  LineChart,
+  Pie,
+  PieChart,
+  ResponsiveContainer,
+  Scatter,
+  ScatterChart,
+  Tooltip,
+  XAxis,
+  YAxis,
+  ZAxis,
+} from "recharts";
+import type { ChartSpec } from "../../api/visualizations";
+
+// The project's accent (blue-500). Single-series charts use it alone.
+const ACCENT = "#3b82f6";
+// Restrained palette for multi-series charts, anchored on the accent and kept
+// calm to match the app's blue/gray system.
+const SERIES = [ACCENT, "#64748b", "#0d9488", "#f59e0b", "#a855f7"];
+// Pie slices read as one monochrome blue ramp (dark → light) rather than a
+// rainbow; the "Other" bucket is muted gray.
+const PIE_FROM = [29, 78, 216]; // blue-700
+const PIE_TO = [191, 219, 254]; // blue-200
+const OTHER_COLOR = "#cbd5e1"; // slate-300
+
+const HEIGHT = 320;
+const TEXT = "#6b7280"; // gray-500, for axis ticks and titles
+const AXIS_FONT = 11;
+const tooltipStyle = { fontSize: 12, borderRadius: 8, border: "1px solid #e5e7eb" } as const;
+const legendStyle = { fontSize: 12 } as const;
+
+/** Color for pie slice `i` of `n`: a step along the blue ramp ("Other" → gray). */
+function pieColor(i: number, n: number, label: unknown): string {
+  if (label === "Other") return OTHER_COLOR;
+  const t = n <= 1 ? 0 : i / (n - 1);
+  const c = PIE_FROM.map((from, k) => Math.round(from + ((PIE_TO[k] ?? from) - from) * t));
+  return `rgb(${c[0]}, ${c[1]}, ${c[2]})`;
+}
+
+/**
+ * Merge multi-series line/area data into one row set keyed by x, so each series
+ * becomes a column the chart can plot against a shared axis.
+ */
+function mergeByX(spec: ChartSpec): Array<Record<string, string | number | null>> {
+  const rows = new Map<string | number, Record<string, string | number | null>>();
+  for (const series of spec.series) {
+    for (const point of series.data) {
+      const key = point.x ?? "";
+      const row = rows.get(key) ?? { x: point.x };
+      row[series.name] = point.y;
+      rows.set(key, row);
+    }
+  }
+  return Array.from(rows.values());
+}
+
+/** Render a backend ChartSpec with the matching Recharts component. */
+export default function ChartRenderer({ spec }: { spec: ChartSpec }) {
+  const axisProps = { tick: { fontSize: AXIS_FONT, fill: TEXT }, stroke: "#d1d5db" } as const;
+  // Recharts renders these as the visible axis titles; widened margins below
+  // leave room so they aren't clipped.
+  const xLabel = { value: spec.x_label, position: "insideBottom" as const, offset: -8, fontSize: AXIS_FONT, fill: TEXT };
+  const yLabel = {
+    value: spec.y_label,
+    angle: -90,
+    position: "insideLeft" as const,
+    style: { textAnchor: "middle" as const },
+    fontSize: AXIS_FONT,
+    fill: TEXT,
+  };
+  const margin = { top: 8, right: 24, bottom: 36, left: 20 };
+
+  switch (spec.chart_type) {
+    case "histogram":
+    case "bar": {
+      const data = spec.series[0]?.data ?? [];
+      return (
+        <ResponsiveContainer width="100%" height={HEIGHT}>
+          <BarChart data={data} margin={margin}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#f3f4f6" />
+            <XAxis dataKey="x" label={xLabel} {...axisProps} />
+            <YAxis label={yLabel} {...axisProps} />
+            <Tooltip contentStyle={tooltipStyle} />
+            <Bar dataKey="y" fill={ACCENT} radius={[2, 2, 0, 0]} name={spec.series[0]?.name} />
+          </BarChart>
+        </ResponsiveContainer>
+      );
+    }
+
+    case "line":
+    case "area": {
+      const data = mergeByX(spec);
+      const ChartComp = spec.chart_type === "line" ? LineChart : AreaChart;
+      return (
+        <ResponsiveContainer width="100%" height={HEIGHT}>
+          <ChartComp data={data} margin={margin}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#f3f4f6" />
+            <XAxis dataKey="x" label={xLabel} {...axisProps} />
+            <YAxis label={yLabel} {...axisProps} />
+            <Tooltip contentStyle={tooltipStyle} />
+            {spec.series.length > 1 && <Legend wrapperStyle={legendStyle} />}
+            {spec.series.map((series, i) =>
+              spec.chart_type === "line" ? (
+                <Line
+                  key={series.name}
+                  type="monotone"
+                  dataKey={series.name}
+                  stroke={SERIES[i % SERIES.length]}
+                  strokeWidth={2}
+                  dot={false}
+                />
+              ) : (
+                <Area
+                  key={series.name}
+                  type="monotone"
+                  dataKey={series.name}
+                  stroke={SERIES[i % SERIES.length]}
+                  fill={SERIES[i % SERIES.length]}
+                  fillOpacity={0.2}
+                />
+              ),
+            )}
+          </ChartComp>
+        </ResponsiveContainer>
+      );
+    }
+
+    case "scatter":
+      return (
+        <ResponsiveContainer width="100%" height={HEIGHT}>
+          <ScatterChart margin={margin}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#f3f4f6" />
+            <XAxis type="number" dataKey="x" name={spec.x_label} label={xLabel} {...axisProps} />
+            <YAxis type="number" dataKey="y" name={spec.y_label} label={yLabel} {...axisProps} />
+            <ZAxis range={[36, 36]} />
+            <Tooltip cursor={{ strokeDasharray: "3 3" }} contentStyle={tooltipStyle} />
+            {spec.series.length > 1 && <Legend wrapperStyle={legendStyle} />}
+            {spec.series.map((series, i) => (
+              <Scatter
+                key={series.name}
+                name={series.name}
+                data={series.data}
+                fill={SERIES[i % SERIES.length]}
+                fillOpacity={0.6}
+              />
+            ))}
+          </ScatterChart>
+        </ResponsiveContainer>
+      );
+
+    case "pie": {
+      const data = spec.series[0]?.data ?? [];
+      return (
+        <ResponsiveContainer width="100%" height={HEIGHT}>
+          <PieChart>
+            <Tooltip contentStyle={tooltipStyle} />
+            <Legend wrapperStyle={legendStyle} />
+            <Pie data={data} dataKey="y" nameKey="x" outerRadius={110} stroke="#fff" strokeWidth={1}>
+              {data.map((point, i) => (
+                <Cell key={i} fill={pieColor(i, data.length, point.x)} />
+              ))}
+            </Pie>
+          </PieChart>
+        </ResponsiveContainer>
+      );
+    }
+
+    default:
+      return null;
+  }
+}

--- a/dataloom-frontend/src/Components/visualizations/SuggestionCard.tsx
+++ b/dataloom-frontend/src/Components/visualizations/SuggestionCard.tsx
@@ -1,0 +1,28 @@
+interface SuggestionCardProps {
+  /** Short type chip, e.g. "Histogram" or "Heatmap". */
+  typeLabel: string;
+  /** Human title of the suggested chart. */
+  title: string;
+  active: boolean;
+  onSelect: () => void;
+}
+
+/** A clickable card for one suggested visualization. */
+export default function SuggestionCard({ typeLabel, title, active, onSelect }: SuggestionCardProps) {
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className={`flex min-w-[180px] flex-col items-start gap-1 rounded-md border px-3 py-2 text-left transition-colors ${
+        active
+          ? "border-blue-500 bg-blue-50"
+          : "border-gray-200 bg-white hover:border-blue-300 hover:bg-gray-50"
+      }`}
+    >
+      <span className="rounded bg-gray-100 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-gray-500">
+        {typeLabel}
+      </span>
+      <span className="text-sm font-medium text-gray-900">{title}</span>
+    </button>
+  );
+}

--- a/dataloom-frontend/src/Components/visualizations/__tests__/ChartBuilderPanel.test.tsx
+++ b/dataloom-frontend/src/Components/visualizations/__tests__/ChartBuilderPanel.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import ChartBuilderPanel from "../ChartBuilderPanel";
+
+const columns = ["region", "revenue", "cost"];
+const dtypes = { region: "str", revenue: "int", cost: "float" };
+
+const renderChart = vi.fn();
+const showHeatmap = vi.fn();
+
+// ChartBuilderPanel reads columns/dtypes from ProjectContext and drives the shared
+// chart view; mock both so the panel can be rendered in isolation.
+vi.mock("../../../context/ProjectContext", () => ({
+  useProjectContext: () => ({ columns, dtypes }),
+}));
+vi.mock("../../../context/ChartViewContext", () => ({
+  useChartView: () => ({ renderChart, showHeatmap }),
+}));
+
+beforeEach(() => {
+  renderChart.mockReset();
+  showHeatmap.mockReset();
+});
+
+function renderPanel() {
+  render(<ChartBuilderPanel onClose={vi.fn()} />);
+}
+
+const renderButton = () => screen.getByRole("button", { name: "Render" });
+
+/** Open the popover trigger with the given testid and click an option by name.
+ * Scopes to the open panel: a just-closed popover lingers in the DOM. */
+function pick(testid: string, name: RegExp | string) {
+  fireEvent.click(screen.getByTestId(testid));
+  const panel = document.querySelector('[data-state="open"]') as HTMLElement;
+  fireEvent.click(within(panel).getByRole("option", { name }));
+}
+
+describe("ChartBuilderPanel", () => {
+  it("disables Render until a valid configuration is chosen", () => {
+    renderPanel();
+    // Histogram is the default and starts with no column selected.
+    expect(renderButton()).toBeDisabled();
+
+    pick("histogram-column", /revenue/);
+    expect(renderButton()).toBeEnabled();
+
+    fireEvent.click(renderButton());
+    expect(renderChart).toHaveBeenCalledWith({ chart_type: "histogram", column: "revenue", bins: 20 });
+  });
+
+  it("offers only numeric columns for a histogram", () => {
+    renderPanel();
+    fireEvent.click(screen.getByTestId("histogram-column"));
+    const names = within(screen.getByRole("listbox"))
+      .getAllByRole("option")
+      .map((o) => o.textContent);
+    expect(names).toHaveLength(2);
+    expect(names!.join(" ")).toContain("revenue");
+    expect(names!.join(" ")).toContain("cost");
+    expect(names!.join(" ")).not.toContain("region");
+  });
+
+  it("disables the value field when the bar aggregation is count", () => {
+    renderPanel();
+    pick("chart-type-select", "Bar");
+
+    pick("agg-select", "Count");
+    expect(screen.getByTestId("value-select")).toBeDisabled();
+    // Category alone is enough for a count bar chart.
+    pick("category-select", /region/);
+    expect(renderButton()).toBeEnabled();
+
+    pick("agg-select", "Sum");
+    // Sum needs a value column, so Render is blocked again until one is picked.
+    expect(screen.getByTestId("value-select")).toBeEnabled();
+    expect(renderButton()).toBeDisabled();
+  });
+
+  it("requires both axes for a scatter plot", () => {
+    renderPanel();
+    pick("chart-type-select", "Scatter");
+
+    pick("x-select", /revenue/);
+    expect(renderButton()).toBeDisabled();
+    pick("y-select", /cost/);
+    expect(renderButton()).toBeEnabled();
+
+    fireEvent.click(renderButton());
+    expect(renderChart).toHaveBeenCalledWith({
+      chart_type: "scatter",
+      x: "revenue",
+      y: ["cost"],
+      color: undefined,
+    });
+  });
+
+  it("routes the correlation heatmap to showHeatmap with no field selectors", () => {
+    renderPanel();
+    pick("chart-type-select", "Correlation heatmap");
+
+    expect(screen.queryByTestId("x-select")).not.toBeInTheDocument();
+    expect(renderButton()).toBeEnabled();
+
+    fireEvent.click(renderButton());
+    expect(showHeatmap).toHaveBeenCalledOnce();
+    expect(renderChart).not.toHaveBeenCalled();
+  });
+});

--- a/dataloom-frontend/src/Components/visualizations/chartFields.ts
+++ b/dataloom-frontend/src/Components/visualizations/chartFields.ts
@@ -1,0 +1,44 @@
+/**
+ * Shared helpers describing which columns and controls each chart type accepts.
+ * Drives the builder's enable/disable logic so invalid configurations can't be
+ * submitted. Dtype labels are the backend's `map_dtype` output
+ * (int/float/bool/datetime/str).
+ */
+export type Dtypes = Record<string, string>;
+
+export const isNumeric = (dtype: string | undefined): boolean =>
+  dtype === "int" || dtype === "float";
+
+export const isCategorical = (dtype: string | undefined): boolean =>
+  dtype === "str" || dtype === "bool";
+
+export const isDatetime = (dtype: string | undefined): boolean => dtype === "datetime";
+
+/** Columns valid as the numeric/category/x/y field for a given chart type. */
+export function columnsFor(
+  field: "histogram" | "category" | "value" | "x" | "y" | "color",
+  columns: string[],
+  dtypes: Dtypes,
+): string[] {
+  switch (field) {
+    case "histogram":
+    case "value":
+    case "y":
+      return columns.filter((c) => isNumeric(dtypes[c]));
+    case "x":
+      // Line/area read better with an ordered axis, but scatter needs numeric;
+      // allow numeric or datetime and let the chart type narrow further.
+      return columns.filter((c) => isNumeric(dtypes[c]) || isDatetime(dtypes[c]));
+    case "category":
+    case "color":
+      return columns;
+    default:
+      return columns;
+  }
+}
+
+/** Whether a chart type uses the aggregation control. */
+export const usesAgg = (chartType: string): boolean => chartType === "bar";
+
+/** Whether a chart type uses the bin-size control. */
+export const usesBins = (chartType: string): boolean => chartType === "histogram";

--- a/dataloom-frontend/src/Components/workspace/ChartsTab.tsx
+++ b/dataloom-frontend/src/Components/workspace/ChartsTab.tsx
@@ -1,0 +1,147 @@
+import { lazy, Suspense } from "react";
+import { useParams } from "react-router-dom";
+import { LuChartColumnBig, LuSparkles } from "react-icons/lu";
+import type { ChartSpec, ChartType } from "../../api/visualizations";
+import { useChartView } from "../../context/ChartViewContext";
+import { useProjectContext } from "../../context/ProjectContext";
+import useChartSuggestions from "../../hooks/useChartSuggestions";
+import useCorrelation from "../../hooks/useCorrelation";
+import CorrelationHeatmap from "../profiling/CorrelationHeatmap";
+import { isNumeric } from "../visualizations/chartFields";
+import SuggestionCard from "../visualizations/SuggestionCard";
+import type { WorkspaceTab } from "../../context/WorkspaceTabsContext";
+
+// Recharts is heavy; keep it in its own chunk, loaded when a chart first renders.
+const ChartRenderer = lazy(() => import("../visualizations/ChartRenderer"));
+
+const TYPE_LABEL: Record<ChartType, string> = {
+  histogram: "Histogram",
+  bar: "Bar",
+  line: "Line",
+  area: "Area",
+  scatter: "Scatter",
+  pie: "Pie",
+};
+
+// Subtle graph-paper backdrop for the empty canvas.
+const GRID_BG = {
+  backgroundImage:
+    "linear-gradient(#f1f5f9 1px, transparent 1px), linear-gradient(90deg, #f1f5f9 1px, transparent 1px)",
+  backgroundSize: "22px 22px",
+};
+
+/** Short, honest note about how the data was reduced for rendering. */
+function MetaNote({ spec }: { spec: ChartSpec }) {
+  const notes: string[] = [];
+  if (spec.meta?.sampled) notes.push("showing a sample of the data");
+  if (spec.meta?.truncated) notes.push("less frequent values grouped");
+  if (notes.length === 0) return null;
+  return <p className="mt-2 text-center text-xs italic text-gray-400">{notes.join(" · ")}</p>;
+}
+
+/**
+ * Charts tab — the visualization display surface. The no-code builder lives in
+ * the docked side panel (see ChartBuilderPanel); this tab shows the result plus
+ * quick-start suggestion cards, sharing state via ChartViewContext.
+ */
+export function ChartsTab() {
+  const { projectId } = useParams() as { projectId: string };
+  const { columns, dtypes, dataVersion } = useProjectContext() as unknown as {
+    columns: string[];
+    dtypes: Record<string, string>;
+    dataVersion: number;
+  };
+  const { spec, mode, loading, error, activeKey, selectSuggestion, showHeatmap } = useChartView();
+
+  const { suggestions } = useChartSuggestions(projectId, true, dataVersion);
+  const correlation = useCorrelation(projectId, mode === "heatmap", dataVersion);
+  const hasCorrelation = columns.filter((c) => isNumeric(dtypes[c])).length >= 2;
+
+  const suggestionCards = (
+    <>
+      {hasCorrelation && (
+        <SuggestionCard
+          typeLabel="Heatmap"
+          title="Correlation between numeric columns"
+          active={activeKey === "heatmap"}
+          onSelect={showHeatmap}
+        />
+      )}
+      {suggestions?.map((suggestion, i) => (
+        <SuggestionCard
+          key={i}
+          typeLabel={TYPE_LABEL[suggestion.chart_type]}
+          title={suggestion.title}
+          active={activeKey === `s${i}`}
+          onSelect={() => selectSuggestion(suggestion, `s${i}`)}
+        />
+      ))}
+    </>
+  );
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-auto p-4">
+      {/* Suggestions strip */}
+      {(hasCorrelation || (suggestions && suggestions.length > 0)) && (
+        <div className="mb-4">
+          <div className="mb-2 flex items-center gap-1.5 text-xs font-medium uppercase tracking-wider text-gray-400">
+            <LuSparkles className="h-3.5 w-3.5" />
+            Suggestions
+          </div>
+          <div className="flex flex-wrap gap-2">{suggestionCards}</div>
+        </div>
+      )}
+
+      {/* Canvas */}
+      <div className="flex min-h-0 flex-1 flex-col rounded-lg border border-gray-200 bg-white p-4">
+        {mode === "heatmap" ? (
+          <CorrelationHeatmap
+            correlation={correlation.correlation}
+            error={correlation.error}
+            onRetry={correlation.refetch}
+          />
+        ) : error ? (
+          <div className="flex flex-1 items-center justify-center text-sm text-gray-500">
+            Couldn’t build that chart.
+          </div>
+        ) : loading ? (
+          <div className="flex flex-1 items-center justify-center text-sm text-gray-400">
+            Building chart…
+          </div>
+        ) : mode === "chart" && spec ? (
+          <div>
+            <h3 className="mb-1 text-center text-sm font-medium text-gray-700">{spec.title}</h3>
+            <Suspense
+              fallback={
+                <div className="flex h-80 items-center justify-center text-sm text-gray-400">
+                  Loading chart…
+                </div>
+              }
+            >
+              <ChartRenderer spec={spec} />
+            </Suspense>
+            <MetaNote spec={spec} />
+          </div>
+        ) : (
+          <EmptyState />
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** Quiet placeholder canvas shown before a chart is built (the builder is docked). */
+function EmptyState() {
+  return (
+    <div style={GRID_BG} className="flex flex-1 items-center justify-center rounded-md">
+      <LuChartColumnBig className="h-10 w-10 text-gray-200" />
+    </div>
+  );
+}
+
+export const CHARTS_TAB: WorkspaceTab = {
+  id: "charts",
+  title: "Charts",
+  type: "charts",
+  closeable: true,
+};

--- a/dataloom-frontend/src/Components/workspace/featureRegistry.ts
+++ b/dataloom-frontend/src/Components/workspace/featureRegistry.ts
@@ -29,9 +29,17 @@ export interface FeaturePanel {
 
 /**
  * What a menu item does when clicked. Declarative because the registry can't call
- * hooks; MenuNavbar interprets it against useWorkspaceTabs / usePanel.
+ * hooks; MenuNavbar interprets it against useWorkspaceTabs / usePanel. Fields
+ * compose — e.g. Charts opens its tab and docks the builder panel together.
  */
-export type MenuAction = { openTab: WorkspaceTab } | { togglePanel: string };
+export interface MenuAction {
+  /** Open (or focus) this workspace tab. */
+  openTab?: WorkspaceTab;
+  /** Dock this side panel open. */
+  openPanel?: string;
+  /** Toggle this side panel (open if closed, close if open). */
+  togglePanel?: string;
+}
 
 /** A ribbon menu item contributed by a feature. */
 export interface FeatureMenuItem {

--- a/dataloom-frontend/src/Components/workspace/features/charts.tsx
+++ b/dataloom-frontend/src/Components/workspace/features/charts.tsx
@@ -1,0 +1,27 @@
+import { LuChartColumnBig } from "react-icons/lu";
+import ChartBuilderPanel from "../../visualizations/ChartBuilderPanel";
+import { ChartsTab, CHARTS_TAB } from "../ChartsTab";
+import { registerFeature } from "../featureRegistry";
+
+/**
+ * Charts feature — data visualization. The rendered charts live in the Charts
+ * tab; the no-code builder docks in the right side panel. The Profiling ▸ Charts
+ * menu item opens both at once (openTab + openPanel). Chart/heatmap state is
+ * bridged between the two by ChartViewContext (provided in DataScreen).
+ */
+registerFeature({
+  id: "charts",
+  tabs: [{ type: "charts", component: ChartsTab }],
+  panels: [{ name: "ChartBuilder", title: "Chart Builder", component: ChartBuilderPanel }],
+  menu: [
+    {
+      ribbon: "Profiling",
+      group: "Profiling",
+      order: 2,
+      label: "Charts",
+      icon: LuChartColumnBig,
+      action: { openTab: CHARTS_TAB, openPanel: "ChartBuilder" },
+      activePanel: "ChartBuilder",
+    },
+  ],
+});

--- a/dataloom-frontend/src/api/index.js
+++ b/dataloom-frontend/src/api/index.js
@@ -21,3 +21,4 @@ export {
   getColumnProfiles,
   getCorrelationMatrix,
 } from "./profiling";
+export { getChartSuggestions, getChart } from "./visualizations";

--- a/dataloom-frontend/src/api/visualizations.ts
+++ b/dataloom-frontend/src/api/visualizations.ts
@@ -1,0 +1,92 @@
+/**
+ * API functions for data visualization (chart suggestions + single charts).
+ *
+ * The backend computes aggregated chart data; every chart shares one
+ * {@link ChartSpec} shape so the frontend maps `chart_type` to a renderer.
+ * @module api/visualizations
+ */
+import client from "./client";
+
+export type ChartType = "histogram" | "bar" | "line" | "area" | "scatter" | "pie";
+
+/** Aggregation for a bar chart (matches the backend AggFunc enum). */
+export type AggFunc = "sum" | "mean" | "median" | "min" | "max" | "count";
+
+/** A single datum. x is a label, number, or ISO date; y is numeric. */
+export interface ChartPoint {
+  x: string | number | null;
+  y: number | null;
+}
+
+/** A named set of points, optionally tinted with a color. */
+export interface ChartSeries {
+  name: string;
+  data: ChartPoint[];
+  color?: string | null;
+}
+
+/** Honesty flags about how the data was reduced for rendering. */
+export interface ChartMeta {
+  sampled?: boolean | null;
+  truncated?: boolean | null;
+  total_rows?: number | null;
+  bins?: number | null;
+}
+
+/** Self-describing chart payload rendered as-is by the frontend. */
+export interface ChartSpec {
+  chart_type: ChartType;
+  title: string;
+  x_label: string;
+  y_label: string;
+  series: ChartSeries[];
+  meta?: ChartMeta | null;
+}
+
+/** Parameters for {@link getChart}; required fields depend on `chart_type`. */
+export interface ChartParams {
+  chart_type: ChartType;
+  /** Numeric column for a histogram. */
+  column?: string;
+  /** Grouping column for a bar/pie chart. */
+  category?: string;
+  /** Numeric value column for a bar/pie chart. */
+  value?: string;
+  /** X-axis column for a line/area/scatter chart. */
+  x?: string;
+  /** Y-axis column(s) for a line/area/scatter chart. */
+  y?: string[];
+  /** Optional color-grouping column for a scatter chart. */
+  color?: string;
+  /** Aggregation for a bar chart. */
+  agg?: AggFunc;
+  /** Bucket count for a histogram. */
+  bins?: number;
+}
+
+/**
+ * Fetch up to three charts recommended from the dataset's column shapes.
+ * @param projectId - The project ID.
+ * @returns Ready-to-render chart specs.
+ */
+export const getChartSuggestions = async (projectId: string): Promise<ChartSpec[]> => {
+  const response = await client.get<{ suggestions: ChartSpec[] }>(
+    `/projects/${projectId}/charts/suggest`,
+  );
+  return response.data.suggestions;
+};
+
+/**
+ * Build a single chart from the project's dataset.
+ * @param projectId - The project ID.
+ * @param params - The chart configuration.
+ * @returns The chart spec.
+ */
+export const getChart = async (projectId: string, params: ChartParams): Promise<ChartSpec> => {
+  const response = await client.get<ChartSpec>(`/projects/${projectId}/charts`, {
+    params,
+    // FastAPI reads a repeated `y` (`y=a&y=b`); send it that way, not `y[]=`.
+    paramsSerializer: { indexes: null },
+  });
+  return response.data;
+};

--- a/dataloom-frontend/src/context/ChartViewContext.tsx
+++ b/dataloom-frontend/src/context/ChartViewContext.tsx
@@ -1,0 +1,120 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { getChart, type ChartParams, type ChartSpec } from "../api/visualizations";
+import { useProjectContext } from "./ProjectContext";
+
+/** What the Charts tab is currently showing. */
+export type ChartMode = "empty" | "chart" | "heatmap";
+
+interface ChartViewValue {
+  spec: ChartSpec | null;
+  mode: ChartMode;
+  loading: boolean;
+  error: boolean;
+  /** Key of the selected suggestion/heatmap, for highlighting cards. */
+  activeKey: string | null;
+  /** Build a chart from builder params (re-fetches automatically on data change). */
+  renderChart: (params: ChartParams, key?: string) => void;
+  /** Show a pre-computed suggestion spec directly. */
+  selectSuggestion: (spec: ChartSpec, key: string) => void;
+  /** Switch to the correlation heatmap. */
+  showHeatmap: () => void;
+}
+
+const ChartViewContext = createContext<ChartViewValue | null>(null);
+
+/** Access the shared chart view. Bridges the docked builder and the Charts tab. */
+// eslint-disable-next-line react-refresh/only-export-components
+export function useChartView(): ChartViewValue {
+  const context = useContext(ChartViewContext);
+  if (!context) throw new Error("useChartView must be used within a ChartViewProvider");
+  return context;
+}
+
+/**
+ * Holds the current visualization so the side-panel builder (inputs) and the
+ * Charts tab (output) stay in sync, and owns the `getChart` fetch. A chart built
+ * from builder params re-fetches when the dataset changes (`dataVersion`), so it
+ * always reflects the latest transforms; a clicked suggestion is a snapshot.
+ */
+export function ChartViewProvider({ children }: { children: ReactNode }) {
+  const { projectId, dataVersion } = useProjectContext() as unknown as {
+    projectId: string;
+    dataVersion: number;
+  };
+
+  const [spec, setSpec] = useState<ChartSpec | null>(null);
+  const [mode, setMode] = useState<ChartMode>("empty");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(false);
+  const [activeKey, setActiveKey] = useState<string | null>(null);
+  // Last builder params, replayed when the dataset changes so the chart refreshes.
+  const lastParams = useRef<ChartParams | null>(null);
+
+  const fetchChart = useCallback(
+    async (params: ChartParams) => {
+      setLoading(true);
+      setError(false);
+      try {
+        const result = await getChart(projectId, params);
+        setSpec(result);
+      } catch (err) {
+        console.error("Error building chart:", err);
+        setError(true);
+        setSpec(null);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [projectId],
+  );
+
+  const renderChart = useCallback(
+    (params: ChartParams, key?: string) => {
+      lastParams.current = params;
+      setMode("chart");
+      setActiveKey(key ?? null);
+      void fetchChart(params);
+    },
+    [fetchChart],
+  );
+
+  const selectSuggestion = useCallback((suggestion: ChartSpec, key: string) => {
+    lastParams.current = null;
+    setMode("chart");
+    setError(false);
+    setLoading(false);
+    setSpec(suggestion);
+    setActiveKey(key);
+  }, []);
+
+  const showHeatmap = useCallback(() => {
+    lastParams.current = null;
+    setMode("heatmap");
+    setError(false);
+    setSpec(null);
+    setActiveKey("heatmap");
+  }, []);
+
+  // When the dataset changes, replay the last builder params so the shown chart
+  // reflects the new data. Heatmap refreshes via its own dataVersion-keyed hook.
+  useEffect(() => {
+    if (mode === "chart" && lastParams.current) void fetchChart(lastParams.current);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dataVersion]);
+
+  const value = useMemo<ChartViewValue>(
+    () => ({ spec, mode, loading, error, activeKey, renderChart, selectSuggestion, showHeatmap }),
+    [spec, mode, loading, error, activeKey, renderChart, selectSuggestion, showHeatmap],
+  );
+
+  return <ChartViewContext.Provider value={value}>{children}</ChartViewContext.Provider>;
+}

--- a/dataloom-frontend/src/hooks/__tests__/useChartSuggestions.test.ts
+++ b/dataloom-frontend/src/hooks/__tests__/useChartSuggestions.test.ts
@@ -1,0 +1,85 @@
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import useChartSuggestions from "../useChartSuggestions";
+import { getChartSuggestions, type ChartSpec } from "../../api/visualizations";
+import { clearProfilingCache } from "../../utils/profilingCache";
+
+vi.mock("../../api/visualizations", () => ({
+  getChartSuggestions: vi.fn(),
+}));
+
+const mockGet = vi.mocked(getChartSuggestions);
+
+const sample: ChartSpec[] = [
+  { chart_type: "histogram", title: "Distribution of x", x_label: "x", y_label: "Count", series: [] },
+];
+
+beforeEach(() => {
+  mockGet.mockReset();
+  clearProfilingCache();
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+describe("useChartSuggestions", () => {
+  it("does not fetch when disabled", () => {
+    renderHook(() => useChartSuggestions("p1", false, 0));
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it("fetches suggestions when enabled", async () => {
+    mockGet.mockResolvedValue(sample);
+
+    const { result } = renderHook(() => useChartSuggestions("p1", true, 0));
+
+    await waitFor(() => expect(result.current.suggestions).not.toBeNull());
+    expect(result.current.suggestions?.[0]?.chart_type).toBe("histogram");
+    expect(result.current.error).toBe(false);
+  });
+
+  it("sets error when the fetch fails", async () => {
+    mockGet.mockRejectedValue(new Error("boom"));
+
+    const { result } = renderHook(() => useChartSuggestions("p1", true, 0));
+
+    await waitFor(() => expect(result.current.error).toBe(true));
+    expect(result.current.suggestions).toBeNull();
+  });
+
+  it("serves the cache without refetching while the version is unchanged", async () => {
+    mockGet.mockResolvedValue(sample);
+
+    const first = renderHook(() => useChartSuggestions("p1", true, 0));
+    await waitFor(() => expect(first.result.current.suggestions).not.toBeNull());
+    expect(mockGet).toHaveBeenCalledTimes(1);
+    first.unmount();
+
+    const second = renderHook(() => useChartSuggestions("p1", true, 0));
+    await waitFor(() => expect(second.result.current.suggestions).not.toBeNull());
+    expect(mockGet).toHaveBeenCalledTimes(1);
+  });
+
+  it("refetches when the data version changes", async () => {
+    mockGet.mockResolvedValue(sample);
+
+    const { rerender, result } = renderHook(
+      ({ version }) => useChartSuggestions("p1", true, version),
+      { initialProps: { version: 0 } },
+    );
+    await waitFor(() => expect(result.current.suggestions).not.toBeNull());
+    expect(mockGet).toHaveBeenCalledTimes(1);
+
+    rerender({ version: 1 });
+    await waitFor(() => expect(mockGet).toHaveBeenCalledTimes(2));
+  });
+
+  it("refetch() forces a reload past the cache", async () => {
+    mockGet.mockResolvedValue(sample);
+
+    const { result } = renderHook(() => useChartSuggestions("p1", true, 0));
+    await waitFor(() => expect(result.current.suggestions).not.toBeNull());
+    expect(mockGet).toHaveBeenCalledTimes(1);
+
+    act(() => result.current.refetch());
+    await waitFor(() => expect(mockGet).toHaveBeenCalledTimes(2));
+  });
+});

--- a/dataloom-frontend/src/hooks/__tests__/useCorrelation.test.ts
+++ b/dataloom-frontend/src/hooks/__tests__/useCorrelation.test.ts
@@ -1,0 +1,83 @@
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import useCorrelation from "../useCorrelation";
+import { getCorrelationMatrix } from "../../api/profiling";
+import { clearProfilingCache } from "../../utils/profilingCache";
+
+vi.mock("../../api/profiling", () => ({
+  getCorrelationMatrix: vi.fn(),
+}));
+
+const mockGet = vi.mocked(getCorrelationMatrix);
+
+const sample = { columns: ["a", "b"], matrix: [[1, 0.5], [0.5, 1]] };
+
+beforeEach(() => {
+  mockGet.mockReset();
+  clearProfilingCache();
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+describe("useCorrelation", () => {
+  it("does not fetch when disabled", () => {
+    renderHook(() => useCorrelation("p1", false, 0));
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it("fetches the correlation matrix when enabled", async () => {
+    mockGet.mockResolvedValue(sample);
+
+    const { result } = renderHook(() => useCorrelation("p1", true, 0));
+
+    await waitFor(() => expect(result.current.correlation).not.toBeNull());
+    expect(result.current.correlation?.columns).toEqual(["a", "b"]);
+    expect(result.current.error).toBe(false);
+  });
+
+  it("sets error when the fetch fails", async () => {
+    mockGet.mockRejectedValue(new Error("boom"));
+
+    const { result } = renderHook(() => useCorrelation("p1", true, 0));
+
+    await waitFor(() => expect(result.current.error).toBe(true));
+    expect(result.current.correlation).toBeNull();
+  });
+
+  it("serves the cache without refetching while the version is unchanged", async () => {
+    mockGet.mockResolvedValue(sample);
+
+    const first = renderHook(() => useCorrelation("p1", true, 0));
+    await waitFor(() => expect(first.result.current.correlation).not.toBeNull());
+    expect(mockGet).toHaveBeenCalledTimes(1);
+    first.unmount();
+
+    const second = renderHook(() => useCorrelation("p1", true, 0));
+    await waitFor(() => expect(second.result.current.correlation).not.toBeNull());
+    expect(mockGet).toHaveBeenCalledTimes(1);
+  });
+
+  it("refetches when the data version changes", async () => {
+    mockGet.mockResolvedValue(sample);
+
+    const { rerender, result } = renderHook(
+      ({ version }) => useCorrelation("p1", true, version),
+      { initialProps: { version: 0 } },
+    );
+    await waitFor(() => expect(result.current.correlation).not.toBeNull());
+    expect(mockGet).toHaveBeenCalledTimes(1);
+
+    rerender({ version: 1 });
+    await waitFor(() => expect(mockGet).toHaveBeenCalledTimes(2));
+  });
+
+  it("refetch() forces a reload past the cache", async () => {
+    mockGet.mockResolvedValue(sample);
+
+    const { result } = renderHook(() => useCorrelation("p1", true, 0));
+    await waitFor(() => expect(result.current.correlation).not.toBeNull());
+    expect(mockGet).toHaveBeenCalledTimes(1);
+
+    act(() => result.current.refetch());
+    await waitFor(() => expect(mockGet).toHaveBeenCalledTimes(2));
+  });
+});

--- a/dataloom-frontend/src/hooks/useChartSuggestions.ts
+++ b/dataloom-frontend/src/hooks/useChartSuggestions.ts
@@ -1,0 +1,69 @@
+import { useCallback, useEffect, useState } from "react";
+import { getChartSuggestions, type ChartSpec } from "../api/visualizations";
+import { getCached, setCached } from "../utils/profilingCache";
+
+interface UseChartSuggestionsResult {
+  suggestions: ChartSpec[] | null;
+  error: boolean;
+  /** Force a refetch (e.g. from a retry button), bypassing the cache. */
+  refetch: () => void;
+}
+
+const NAMESPACE = "chart-suggestions";
+
+/**
+ * Fetch the dataset's auto-suggested charts, cached by `dataVersion`. While the
+ * cache holds the current version the hook serves it without hitting the API; it
+ * refetches only after a content change bumps the version. Mirrors
+ * {@link useCorrelation}'s caching.
+ *
+ * `dataVersion` is ProjectContext's content-mutation counter (changes on any
+ * edit, never on pagination).
+ */
+export default function useChartSuggestions(
+  projectId: string | undefined,
+  enabled: boolean,
+  dataVersion: number,
+): UseChartSuggestionsResult {
+  const [suggestions, setSuggestions] = useState<ChartSpec[] | null>(null);
+  const [error, setError] = useState(false);
+  // Bumped by refetch() to force a cache-bypassing reload from the same version.
+  const [reloadToken, setReloadToken] = useState(0);
+
+  const refetch = useCallback(() => setReloadToken((t) => t + 1), []);
+
+  useEffect(() => {
+    if (!enabled || !projectId) return;
+
+    if (reloadToken === 0) {
+      const cached = getCached<ChartSpec[]>(NAMESPACE, projectId, dataVersion);
+      if (cached) {
+        setSuggestions(cached);
+        setError(false);
+        return;
+      }
+    }
+
+    let cancelled = false;
+    setSuggestions(null);
+    setError(false);
+
+    getChartSuggestions(projectId)
+      .then((data) => {
+        if (cancelled) return;
+        setCached(NAMESPACE, projectId, dataVersion, data);
+        setSuggestions(data);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        console.error("Error fetching chart suggestions:", err);
+        setError(true);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [projectId, enabled, dataVersion, reloadToken]);
+
+  return { suggestions, error, refetch };
+}

--- a/dataloom-frontend/src/hooks/useCorrelation.ts
+++ b/dataloom-frontend/src/hooks/useCorrelation.ts
@@ -1,0 +1,70 @@
+import { useCallback, useEffect, useState } from "react";
+import { getCorrelationMatrix, type Correlation } from "../api/profiling";
+import { getCached, setCached } from "../utils/profilingCache";
+
+interface UseCorrelationResult {
+  correlation: Correlation | null;
+  error: boolean;
+  /** Force a refetch (e.g. from a retry button), bypassing the cache. */
+  refetch: () => void;
+}
+
+const NAMESPACE = "correlation";
+
+/**
+ * Fetch the pairwise Pearson correlation matrix over the project's numeric
+ * columns, cached by `dataVersion`. While the cache holds the current version
+ * the hook serves it without hitting the API; it refetches only after a content
+ * change bumps the version. See {@link useDatasetSummary} for the shared caching
+ * rationale.
+ *
+ * `dataVersion` is ProjectContext's content-mutation counter (changes on any
+ * edit, never on pagination).
+ */
+export default function useCorrelation(
+  projectId: string | undefined,
+  enabled: boolean,
+  dataVersion: number,
+): UseCorrelationResult {
+  const [correlation, setCorrelation] = useState<Correlation | null>(null);
+  const [error, setError] = useState(false);
+  // Bumped by refetch() to force a cache-bypassing reload from the same version.
+  const [reloadToken, setReloadToken] = useState(0);
+
+  const refetch = useCallback(() => setReloadToken((t) => t + 1), []);
+
+  useEffect(() => {
+    if (!enabled || !projectId) return;
+
+    if (reloadToken === 0) {
+      const cached = getCached<Correlation>(NAMESPACE, projectId, dataVersion);
+      if (cached) {
+        setCorrelation(cached);
+        setError(false);
+        return;
+      }
+    }
+
+    let cancelled = false;
+    setCorrelation(null);
+    setError(false);
+
+    getCorrelationMatrix(projectId)
+      .then((data) => {
+        if (cancelled) return;
+        setCached(NAMESPACE, projectId, dataVersion, data);
+        setCorrelation(data);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        console.error("Error fetching correlation matrix:", err);
+        setError(true);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [projectId, enabled, dataVersion, reloadToken]);
+
+  return { correlation, error, refetch };
+}


### PR DESCRIPTION
## Description

Adds **data visualization** as a Charts feature. Opening **Profiling ▸ Charts**
gives a Charts tab (rendered charts + auto-suggestions) with a docked no-code
**chart builder** in the right side panel. Six chart types — histogram, bar,
line, area, scatter, pie — plus dtype-driven suggestions and an embedded
correlation heatmap. The backend computes aggregated chart data (so payloads stay
bounded regardless of dataset size); the frontend renders with Recharts
(lazy-loaded into its own chunk).

Built on the tabbed-workspace **feature registry** from #401: the whole feature is
a single `workspace/features/charts.tsx` adapter declaring its tab, its docked
panel, and its menu entry.

> **Depends on #401.** This branch is stacked on `feat/tabs-layout`, so the diff
> currently includes that PR's registry commit. Once #401 merges I'll rebase, and
> this reduces to just the Charts commit.

Fixes #399

## Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

- [X] Existing tests pass (backend 498, frontend 153)
- [X] New tests added (visualization service + endpoints; chart-builder panel, chart-suggestion and correlation hooks, correlation heatmap)
- [X] Manual testing

## Screenshots (if applicable)

_Charts tab with the docked chart builder — to be attached._

## Checklist

- [X] My code follows the project's style guidelines
- [X] I have performed a self-review
- [X] I have added/updated documentation as needed
- [X] My changes generate no new warnings
- [X] Tests pass locally
