### PR TITLE
feat: add hover tooltips to toolbar icons

### DIFF
--- a/dataloom-frontend/src/Components/MenuNavbar.jsx
+++ b/dataloom-frontend/src/Components/MenuNavbar.jsx
@@ -80,7 +80,15 @@ const MenuNavbar = ({ projectId }) => {
   // Core ribbon items — the ones that need component-local state/handlers and so
   // can't be declared as (declarative) feature menu items.
   const coreItems = [
-    { ribbon: "File", group: "Save", order: 0, label: "Save", icon: LuSave, onClick: handleSave },
+    {
+      ribbon: "File",
+      group: "Save",
+      order: 0,
+      label: "Save",
+      icon: LuSave,
+      onClick: handleSave,
+      hover: "Save the current state of the project as a new checkpoint.",
+    },
     {
       ribbon: "File",
       group: "Save",
@@ -88,8 +96,17 @@ const MenuNavbar = ({ projectId }) => {
       label: "Export",
       icon: LuDownload,
       onClick: () => setShowExportModal(true),
+      hover: "Export the data to a file.",
     },
-    { ribbon: "File", group: "Save", order: 2, label: "Undo", icon: LuUndo2, onClick: handleUndo },
+    {
+      ribbon: "File",
+      group: "Save",
+      order: 2,
+      label: "Undo",
+      icon: LuUndo2,
+      onClick: handleUndo,
+      hover: "Undo the last transformation.",
+    },
     {
       ribbon: "Profiling",
       group: "Profiling",
@@ -98,6 +115,7 @@ const MenuNavbar = ({ projectId }) => {
       icon: LuColumns3,
       onClick: handleToggleColumnProfiles,
       active: showColumnProfiles,
+      hover: "View the profile of each column.",
     },
   ];
 
@@ -168,6 +186,7 @@ const MenuNavbar = ({ projectId }) => {
                       data-testid={`toolbar-${item.label.toLowerCase().replace(/ /g, "-")}`}
                       onClick={item.onClick}
                       disabled={item.disabled}
+                      title={item.hover}
                       className={`flex flex-col items-center gap-1 px-3 py-1.5 rounded-md transition-colors ${
                         isActive
                           ? "bg-blue-50 text-blue-600"

--- a/dataloom-frontend/src/Components/forms/FillEmptyForm.tsx
+++ b/dataloom-frontend/src/Components/forms/FillEmptyForm.tsx
@@ -115,29 +115,17 @@ const FillEmptyForm = ({ projectId, onClose }: { projectId: string; onClose: () 
 
         <div className="flex justify-between mt-2">
           <div className="flex gap-2">
-            <Button
-              type="submit"
-              disabled={isSubmitDisabled || loading || saving || isPreviewMode}
-            >
+            <Button type="submit" disabled={isSubmitDisabled || loading || saving || isPreviewMode}>
               {loading ? "Applying..." : "Apply"}
             </Button>
             {isPreviewMode && (
-              <Button
-                type="button"
-                onClick={handleSave}
-                disabled={saving}
-                variant="success"
-              >
+              <Button type="button" onClick={handleSave} disabled={saving} variant="success">
                 {saving ? "Saving..." : "Save Changes"}
               </Button>
             )}
           </div>
 
-          <Button
-            type="button"
-            onClick={handleCancel}
-            variant="secondary"
-          >
+          <Button type="button" onClick={handleCancel} variant="secondary">
             Cancel
           </Button>
         </div>

--- a/dataloom-frontend/src/Components/workspace/featureRegistry.ts
+++ b/dataloom-frontend/src/Components/workspace/featureRegistry.ts
@@ -56,6 +56,8 @@ export interface FeatureMenuItem {
   disabledInPreview?: boolean;
   /** Highlight the item while this panel is the active one. */
   activePanel?: string;
+  /** Tooltip text to show on hover. */
+  hover?: string;
 }
 
 /** A tab contribution: a tab type mapped to the component that renders it. */

--- a/dataloom-frontend/src/Components/workspace/features/history.tsx
+++ b/dataloom-frontend/src/Components/workspace/features/history.tsx
@@ -26,6 +26,7 @@ registerFeature({
       label: "Logs",
       icon: LuHistory,
       action: { openTab: LOGS_TAB },
+      hover: "View the history of transformations.",
     },
     {
       ribbon: "File",
@@ -34,6 +35,7 @@ registerFeature({
       label: "Checkpoints",
       icon: LuBookmark,
       action: { openTab: CHECKPOINTS_TAB },
+      hover: "View and revert to previous checkpoints.",
     },
   ],
 });

--- a/dataloom-frontend/src/Components/workspace/features/profiling.tsx
+++ b/dataloom-frontend/src/Components/workspace/features/profiling.tsx
@@ -26,6 +26,7 @@ registerFeature({
       label: "Summary",
       icon: LuLayoutDashboard,
       action: { openTab: SUMMARY_TAB },
+      hover: "View a summary of the dataset.",
     },
   ],
 });

--- a/dataloom-frontend/src/Components/workspace/features/transforms.tsx
+++ b/dataloom-frontend/src/Components/workspace/features/transforms.tsx
@@ -59,6 +59,7 @@ registerFeature({
       action: { togglePanel: "FilterForm" },
       disabledInPreview: true,
       activePanel: "FilterForm",
+      hover: "Filter rows based on conditions you specify.",
     },
     {
       ribbon: "Data",
@@ -69,6 +70,7 @@ registerFeature({
       action: { togglePanel: "SampleRowsForm" },
       disabledInPreview: true,
       activePanel: "SampleRowsForm",
+      hover: "Take a random sample of rows from the dataset.",
     },
     {
       ribbon: "Data",
@@ -79,6 +81,7 @@ registerFeature({
       action: { togglePanel: "SortForm" },
       disabledInPreview: true,
       activePanel: "SortForm",
+      hover: "Sort rows based on one or more columns.",
     },
     {
       ribbon: "Data",
@@ -89,6 +92,7 @@ registerFeature({
       action: { togglePanel: "DropDuplicateForm" },
       disabledInPreview: true,
       activePanel: "DropDuplicateForm",
+      hover: "Drop duplicate rows from the dataset.",
     },
     {
       ribbon: "Data",
@@ -99,6 +103,7 @@ registerFeature({
       action: { togglePanel: "GroupByForm" },
       disabledInPreview: true,
       activePanel: "GroupByForm",
+      hover: "Group rows by one or more columns and apply an aggregation.",
     },
     {
       ribbon: "Data",
@@ -109,6 +114,7 @@ registerFeature({
       action: { togglePanel: "CastDataTypeForm" },
       disabledInPreview: true,
       activePanel: "CastDataTypeForm",
+      hover: "Change the data type of a column.",
     },
     {
       ribbon: "Data",
@@ -119,6 +125,7 @@ registerFeature({
       action: { togglePanel: "TrimWhitespaceForm" },
       disabledInPreview: true,
       activePanel: "TrimWhitespaceForm",
+      hover: "Trim whitespace from the beginning and end of a column.",
     },
     {
       ribbon: "Data",
@@ -129,6 +136,7 @@ registerFeature({
       action: { togglePanel: "StringReplaceForm" },
       disabledInPreview: true,
       activePanel: "StringReplaceForm",
+      hover: "Replace a string in a column with another string.",
     },
     {
       ribbon: "Data",
@@ -139,6 +147,7 @@ registerFeature({
       action: { togglePanel: "FillEmptyForm" },
       disabledInPreview: true,
       activePanel: "FillEmptyForm",
+      hover: "Fill empty cells in a column with a specific value.",
     },
     // Data ▸ Query
     {
@@ -150,6 +159,7 @@ registerFeature({
       action: { togglePanel: "AdvQueryFilterForm" },
       disabledInPreview: true,
       activePanel: "AdvQueryFilterForm",
+      hover: "Filter rows using a SQL-like query.",
     },
     {
       ribbon: "Data",
@@ -160,6 +170,7 @@ registerFeature({
       action: { togglePanel: "PivotTableForm" },
       disabledInPreview: true,
       activePanel: "PivotTableForm",
+      hover: "Create a pivot table from the data.",
     },
     {
       ribbon: "Data",
@@ -170,6 +181,7 @@ registerFeature({
       action: { togglePanel: "MeltForm" },
       disabledInPreview: true,
       activePanel: "MeltForm",
+      hover: "Unpivot the data from a wide to a long format.",
     },
   ],
 });


### PR DESCRIPTION
## Description

This PR implements hover tooltips for all toolbar icons in the `MenuNavbar.jsx` component. Previously, the toolbar lacked descriptive information for its specialized tools, requiring users to click each tool to understand its purpose. Now, hovering over any icon displays a brief description explaining its function, significantly improving the user experience, speeding up workflows, and reducing the learning curve for new users.

Fixes #406

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

Verified that the `title` attribute correctly extracts and renders descriptive hover text dynamically from the updated items array within the `tabs` object. Checked across toolbar options (Filter, Sample, Sort, Drop Dup, etc.) to ensure tooltips display cleanly in the browser without UI breakage.

- [ ] Existing tests pass
- [ ] New tests added
- [x] Manual testing

## Screenshots 

<img width="1710" height="1112" alt="image" src="https://github.com/user-attachments/assets/ad709474-a6e7-4479-bbcc-47da1fde1e85" />


## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally