### PR TITLE
fix: GroupBy Cancel does not revert data to original state (fixes #405)

### DIFF
--- a/dataloom-frontend/src/Components/forms/GroupByForm.jsx
+++ b/dataloom-frontend/src/Components/forms/GroupByForm.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
 import PropTypes from "prop-types";
 import { transformProject } from "../../api";
 import { GROUPBY } from "../../constants/operationTypes";
@@ -25,6 +25,20 @@ const GroupByForm = ({ projectId, onClose }) => {
   const [loading, setLoading] = useState(false);
   const { error, clearError, handleError } = useError();
   const { saving, handleSave } = usePreviewSave({ clearError, handleError, onClose });
+  const cancelledRef = useRef(false);
+  const cancelPreviewRef = useRef(cancelPreview);
+  const isPreviewModeRef = useRef(isPreviewMode);
+  cancelPreviewRef.current = cancelPreview;
+  isPreviewModeRef.current = isPreviewMode;
+
+  useEffect(() => {
+    return () => {
+      cancelledRef.current = true;
+      if (isPreviewModeRef.current) {
+        cancelPreviewRef.current();
+      }
+    };
+  }, []);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -43,6 +57,7 @@ const GroupByForm = ({ projectId, onClose }) => {
         },
       };
       const response = await transformProject(projectId, payload, { preview: true });
+      if (cancelledRef.current) return;
       enterPreviewMode(response.columns, response.rows, response.dtypes, { projectId, payload });
     } catch (err) {
       handleError(err);
@@ -60,7 +75,7 @@ const GroupByForm = ({ projectId, onClose }) => {
   };
 
   return (
-    <div>
+    <div data-testid="groupby-form">
       <form onSubmit={handleSubmit}>
         <div className="mb-3">
           <label className="block mb-1 text-sm font-medium text-gray-700">Group By Columns:</label>
@@ -80,6 +95,7 @@ const GroupByForm = ({ projectId, onClose }) => {
             onChange={setAggColumn}
             options={availableColumns.filter((col) => !selectedColumns.includes(col))}
             required
+            data-testid="groupby-agg-column"
           />
         </div>
         <div className="mb-4">
@@ -102,7 +118,12 @@ const GroupByForm = ({ projectId, onClose }) => {
               </Button>
             )}
           </div>
-          <Button type="button" variant="secondary" onClick={handleCancel}>
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={handleCancel}
+            disabled={loading || saving}
+          >
             Cancel
           </Button>
         </div>

--- a/dataloom-frontend/src/test/GroupByForm.test.jsx
+++ b/dataloom-frontend/src/test/GroupByForm.test.jsx
@@ -1,0 +1,197 @@
+import { render, within } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import GroupByForm from "../Components/forms/GroupByForm";
+import { transformProject } from "../api";
+
+vi.mock("../api", () => ({
+  transformProject: vi.fn(),
+}));
+
+const mockContext = {
+  columns: ["City", "Amount", "Date"],
+  dtypes: { City: "string", Amount: "float", Date: "date" },
+  columnOrder: [0, 1, 2],
+  updateData: vi.fn(),
+  enterPreviewMode: vi.fn(),
+  cancelPreview: vi.fn(),
+  confirmPreview: vi.fn(),
+  refreshProject: vi.fn(),
+  pageSize: 50,
+  pendingTransform: null,
+  isPreviewMode: false,
+};
+
+vi.mock("../context/ProjectContext", () => ({
+  useProjectContext: () => mockContext,
+}));
+
+vi.mock("../context/HistoryRefreshContext", () => ({
+  useHistoryRefresh: () => ({ refreshLogs: vi.fn(), refreshCheckpoints: vi.fn() }),
+}));
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  mockContext.isPreviewMode = false;
+  mockContext.pendingTransform = null;
+});
+
+describe("GroupByForm", () => {
+  it("calls enterPreviewMode after successful apply", async () => {
+    transformProject.mockResolvedValueOnce({
+      columns: ["City", "Amount"],
+      rows: [["Paris", "300"]],
+      dtypes: { City: "string", Amount: "float" },
+    });
+
+    const { getByText, getByTestId, getByRole } = render(
+      <GroupByForm projectId="proj-1" onClose={vi.fn()} />,
+    );
+    const { fireEvent } = await import("@testing-library/react");
+
+    fireEvent.click(getByText("City"));
+    fireEvent.click(getByTestId("groupby-agg-column"));
+    fireEvent.click(within(getByRole("listbox")).getByText("Amount"));
+    fireEvent.click(getByText("Apply GroupBy"));
+
+    await vi.waitFor(() => {
+      expect(mockContext.enterPreviewMode).toHaveBeenCalledWith(
+        ["City", "Amount"],
+        [["Paris", "300"]],
+        { City: "string", Amount: "float" },
+        {
+          payload: {
+            operation_type: "groupby",
+            groupby_params: {
+              columns: ["City"],
+              agg_column: "Amount",
+              agg_function: "sum",
+            },
+          },
+          projectId: "proj-1",
+        },
+      );
+    });
+  });
+
+  it("does not call enterPreviewMode when transform fails", async () => {
+    transformProject.mockRejectedValueOnce(new Error("Server error"));
+
+    const { getByText, getByTestId, getByRole } = render(
+      <GroupByForm projectId="proj-1" onClose={vi.fn()} />,
+    );
+    const { fireEvent } = await import("@testing-library/react");
+
+    fireEvent.click(getByText("City"));
+    fireEvent.click(getByTestId("groupby-agg-column"));
+    fireEvent.click(within(getByRole("listbox")).getByText("Amount"));
+    fireEvent.click(getByText("Apply GroupBy"));
+
+    await vi.waitFor(() => {
+      expect(mockContext.enterPreviewMode).not.toHaveBeenCalled();
+    });
+  });
+
+  it("does not call enterPreviewMode when user closes during loading", async () => {
+    let resolveTransform;
+    transformProject.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveTransform = resolve;
+        }),
+    );
+
+    const { getByText, getByTestId, getByRole, unmount } = render(
+      <GroupByForm projectId="proj-1" onClose={vi.fn()} />,
+    );
+    const { fireEvent } = await import("@testing-library/react");
+
+    fireEvent.click(getByText("City"));
+    fireEvent.click(getByTestId("groupby-agg-column"));
+    fireEvent.click(within(getByRole("listbox")).getByText("Amount"));
+    fireEvent.click(getByText("Apply GroupBy"));
+    unmount();
+
+    resolveTransform({
+      columns: ["City", "Amount"],
+      rows: [["Paris", "300"]],
+      dtypes: { City: "string", Amount: "float" },
+    });
+
+    await vi.waitFor(() => {
+      expect(mockContext.enterPreviewMode).not.toHaveBeenCalled();
+    });
+  });
+
+  it("allows re-submit after a cancelled in-flight request", async () => {
+    let resolveFirst;
+    transformProject.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveFirst = resolve;
+        }),
+    );
+
+    const { getByText, getByTestId, getByRole, unmount } = render(
+      <GroupByForm projectId="proj-1" onClose={vi.fn()} />,
+    );
+    const { fireEvent } = await import("@testing-library/react");
+
+    fireEvent.click(getByText("City"));
+    fireEvent.click(getByTestId("groupby-agg-column"));
+    fireEvent.click(within(getByRole("listbox")).getByText("Amount"));
+    fireEvent.click(getByText("Apply GroupBy"));
+    unmount();
+    resolveFirst({ columns: [], rows: [], dtypes: {} });
+
+    transformProject.mockResolvedValueOnce({
+      columns: ["City", "Amount"],
+      rows: [["Paris", "300"]],
+      dtypes: { City: "string", Amount: "float" },
+    });
+
+    const {
+      getByText: getByText2,
+      getByTestId: getByTestId2,
+      getByRole: getByRole2,
+    } = render(<GroupByForm projectId="proj-1" onClose={vi.fn()} />);
+    fireEvent.click(getByText2("City"));
+    fireEvent.click(getByTestId2("groupby-agg-column"));
+    fireEvent.click(within(getByRole2("listbox")).getByText("Amount"));
+    fireEvent.click(getByText2("Apply GroupBy"));
+
+    await vi.waitFor(() => {
+      expect(mockContext.enterPreviewMode).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("calls cancelPreview when Cancel clicked in preview mode", async () => {
+    mockContext.isPreviewMode = true;
+
+    const { getByText } = render(<GroupByForm projectId="proj-1" onClose={vi.fn()} />);
+    const { fireEvent } = await import("@testing-library/react");
+
+    fireEvent.click(getByText("Cancel"));
+
+    expect(mockContext.cancelPreview).toHaveBeenCalled();
+  });
+
+  it("calls onClose when Cancel clicked outside preview mode", async () => {
+    const onClose = vi.fn();
+
+    const { getByText } = render(<GroupByForm projectId="proj-1" onClose={onClose} />);
+    const { fireEvent } = await import("@testing-library/react");
+
+    fireEvent.click(getByText("Cancel"));
+
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("calls cancelPreview on unmount when in preview mode", async () => {
+    mockContext.isPreviewMode = true;
+
+    const { unmount } = render(<GroupByForm projectId="proj-1" onClose={vi.fn()} />);
+    unmount();
+
+    expect(mockContext.cancelPreview).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Description

Fixes #405. The GroupBy form now correctly reverts the data table when Cancel is used, even when the panel's header X button dismisses the form instead of the in-form Cancel button.

### Root cause

The original GroupBy implementation had persist=True in TRANSFORMATION_REGISTRY (the only reshaping-style transform with that setting), which caused the working file to be overwritten on every Apply — making Cancel non-functional.

### What this PR does

The upstream already adopted a universal preview-before-persist pattern (PR #410). This PR adds the remaining guardrails on top:

| Scenario | Before | After |
|---|---|---|
| Click **Cancel** in preview mode | Already worked (upstream code) | Works (unchanged) |
| Click panel header **X** while in preview mode | Bypassed cancelPreview — data stayed grouped | useEffect cleanup calls cancelPreview() on unmount |
| **Cancel/close while Apply in flight** | Pending response could call enterPreviewMode after unmount | cancelledRef guards async continuation; Cancel button disabled during loading |
| No error handling in revert path | N/A — upstream has no async revert in handleCancel | N/A (cancelPreview is synchronous) |

### Changes

**dataloom-frontend/src/Components/forms/GroupByForm.jsx**
- Add cancelledRef + useEffect cleanup: sets ref on unmount and calls cancelPreview() if in preview mode (fixes X button bypass)
- Check cancelledRef.current in handleSubmit before calling enterPreviewMode (fixes race condition)
- Disable Cancel button while loading is true
- Wrap form in data-testid="groupby-form", add data-testid="groupby-agg-column" to ColumnSelect

**dataloom-frontend/src/test/GroupByForm.test.jsx** (new)
- 6 tests covering: apply success, apply failure, close-during-loading, Cancel in preview mode, Cancel outside preview mode, unmount cleanup in preview mode

### Testing
- npx vitest run — 162 tests pass across 31 test files (6 new)
- npx eslint — clean
