### PR TITLE
fix: read uploaded JSON as UTF-8 regardless of platform locale

### DIFF
--- a/dataloom-backend/app/utils/file_formats.py
+++ b/dataloom-backend/app/utils/file_formats.py
@@ -116,7 +116,7 @@ def _read_json(path: Path) -> pd.DataFrame:
     Raises:
         ValueError: If the JSON is not object-shaped or nests more than one level.
     """
-    with open(path) as f:
+    with open(path, encoding="utf-8") as f:
         data = json.load(f)
 
     if isinstance(data, dict):

--- a/dataloom-backend/tests/test_file_formats.py
+++ b/dataloom-backend/tests/test_file_formats.py
@@ -176,6 +176,36 @@ class TestJson:
             read_table_safe(path)
         assert exc.value.status_code == 400
 
+    def test_raw_utf8_read_is_locale_independent(self, tmp_path, monkeypatch):
+        """A JSON upload with raw UTF-8 bytes must decode correctly anywhere.
+
+        Most tools emit JSON as raw UTF-8 (ensure_ascii=False), but ``open()``
+        without an explicit encoding uses the platform default codec, so the
+        same file decodes to mojibake (or raises UnicodeDecodeError) on non-UTF-8
+        locales: Western Windows (cp1252), or an ASCII C/POSIX locale in slim
+        containers. This can't reproduce on the maintainers' UTF-8 dev boxes, so
+        we simulate the platform default by forcing cp1252 whenever the reader
+        opens the file in text mode without asking for an encoding.
+        """
+        import app.utils.file_formats as file_formats
+
+        real_open = open
+
+        def platform_default_open(file, mode="r", *args, **kwargs):
+            if "b" not in mode and "encoding" not in kwargs and len(args) < 2:
+                kwargs["encoding"] = "cp1252"
+            return real_open(file, mode, *args, **kwargs)
+
+        monkeypatch.setattr(file_formats, "open", platform_default_open, raising=False)
+
+        path = tmp_path / "data.json"
+        path.write_bytes(json.dumps([{"city": "München", "note": "café"}], ensure_ascii=False).encode("utf-8"))
+
+        df = read_table_safe(path)
+
+        assert df.iloc[0]["city"] == "München"
+        assert df.iloc[0]["note"] == "café"
+
 
 class TestHelperErrors:
     def test_missing_file_is_404(self, tmp_path):


### PR DESCRIPTION

## Description

`_read_json` in `dataloom-backend/app/utils/file_formats.py` opened uploaded JSON
files with the builtin `open()` and no `encoding=` argument, so the file was
decoded with the platform default codec (`locale.getpreferredencoding(False)`).
That default is UTF-8 on typical macOS/Linux dev machines, but it is `cp1252` on
Western Windows, `cp932`/`cp949` on JP/KR Windows, and ASCII when the process runs
under a `C`/`POSIX` locale (common in slim Docker images and some CI runners).

Because most tools emit JSON as raw UTF-8 (`ensure_ascii=False`), an ordinary
upload such as `[{"city": "München", "note": "café"}]` is affected: on a non-UTF-8
locale the non-ASCII text is silently corrupted into mojibake (e.g. `München`
becomes `MÃ¼nchen`), and a value containing bytes outside the platform codec (for
example an emoji under an ASCII locale) raises `UnicodeDecodeError`, which surfaces
to the client as `HTTP 500 "Error reading file"`.

`.json` is an allowed upload extension and is wired to `_read_json`, so this is
reachable from the public upload endpoint. The bug is invisible on the
maintainers' UTF-8 dev machines and only bites Windows and containerized
deployments, so it is a classic "works on my machine" issue.

The fix passes `encoding="utf-8"` explicitly so JSON reads are locale-independent.
This matches the rest of the module (the CSV/TSV writer already defaults to
`encoding="utf-8"`, and `to_json` emits UTF-8) and the pandas readers used for the
other formats (`read_csv`/`read_excel`/`read_parquet`), which are already
UTF-8/binary regardless of locale. There is no behavior change on UTF-8 hosts.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

Added a regression test, `TestJson::test_raw_utf8_read_is_locale_independent`, that
writes a `.json` file containing raw UTF-8 bytes with non-ASCII values and asserts
they round-trip. Because a non-UTF-8 platform default cannot be reproduced directly
on a UTF-8 dev box, the test simulates it by forcing `cp1252` on encoding-less
text-mode opens performed by the reader. It fails on the current code
(`AssertionError: 'MÃ¼nchen' == 'München'`) and passes with the fix.

- [x] Existing tests pass
- [x] New tests added
- [x] Manual testing

Commands run from `dataloom-backend/` (Python 3.12, `DATABASE_URL` pointed at
SQLite, as the backend CI does):

- `uv run ruff check .` -> All checks passed
- `uv run ruff format --check .` -> already formatted
- `uv run pytest tests/test_file_formats.py tests/test_multiformat_upload.py` -> 77 passed
- `uv run pytest` (full backend suite) -> 464 passed

## Screenshots (if applicable)

N/A (backend-only change).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed (no docs affected)
- [x] My changes generate no new warnings
- [x] Tests pass locally

---

## The diff (for reference)

```diff
diff --git a/dataloom-backend/app/utils/file_formats.py b/dataloom-backend/app/utils/file_formats.py
@@ def _read_json(path: Path) -> pd.DataFrame:
-    with open(path) as f:
+    with open(path, encoding="utf-8") as f:
         data = json.load(f)
```

Plus a 30-line regression test in `dataloom-backend/tests/test_file_formats.py`
(`TestJson::test_raw_utf8_read_is_locale_independent`).
