### PR TITLE
fix(logging): exclude taskName from JSONFormatter passthrough

### DIFF
--- a/dataloom-backend/app/utils/logging.py
+++ b/dataloom-backend/app/utils/logging.py
@@ -36,6 +36,7 @@ _STANDARD_ATTRS = frozenset(
         "processName",
         "relativeCreated",
         "stack_info",
+        "taskName",
         "thread",
         "threadName",
     }

--- a/dataloom-backend/tests/test_logging.py
+++ b/dataloom-backend/tests/test_logging.py
@@ -1,0 +1,71 @@
+"""Tests for the structured JSON logging formatter.
+
+These tests exercise ``JSONFormatter`` in isolation, without any HTTP or
+database fixtures, since the formatter is a pure ``logging.Formatter``.
+"""
+
+import json
+import logging
+
+from app.utils.logging import JSONFormatter, request_id_var
+
+
+def _make_record(msg: str = "request complete", extra: dict | None = None) -> logging.LogRecord:
+    record = logging.LogRecord("app.test", logging.INFO, "path", 1, msg, None, None)
+    for key, value in (extra or {}).items():
+        setattr(record, key, value)
+    return record
+
+
+def test_plain_record_emits_only_base_fields():
+    """A record with no extras must not leak standard LogRecord attributes.
+
+    On Python 3.12+ every LogRecord carries a standard ``taskName`` attribute;
+    it must be excluded rather than surfaced as a spurious top-level JSON key.
+    """
+    output = JSONFormatter().format(_make_record())
+    entry = json.loads(output)
+
+    assert set(entry.keys()) == {"timestamp", "level", "logger", "message"}
+    assert "taskName" not in entry
+
+
+def test_taskName_is_not_surfaced():
+    record = _make_record()
+    # taskName is a standard attribute on Python 3.12+; force it here so the
+    # test also guards the behavior on earlier runtimes.
+    record.taskName = "Task-1"
+
+    entry = json.loads(JSONFormatter().format(record))
+
+    assert "taskName" not in entry
+
+
+def test_extra_fields_still_pass_through():
+    """Genuine extras passed via ``Logger.extra`` remain top-level JSON keys."""
+    output = JSONFormatter().format(
+        _make_record(
+            extra={
+                "method": "GET",
+                "path": "/projects/recent",
+                "status_code": 200,
+                "duration_ms": 12.5,
+            }
+        )
+    )
+    entry = json.loads(output)
+
+    assert entry["method"] == "GET"
+    assert entry["path"] == "/projects/recent"
+    assert entry["status_code"] == 200
+    assert entry["duration_ms"] == 12.5
+
+
+def test_request_id_included_when_set():
+    token = request_id_var.set("abc-123")
+    try:
+        entry = json.loads(JSONFormatter().format(_make_record()))
+    finally:
+        request_id_var.reset(token)
+
+    assert entry["request_id"] == "abc-123"


### PR DESCRIPTION


`JSONFormatter` in `dataloom-backend/app/utils/logging.py` surfaces any
`LogRecord` attribute that is not in the `_STANDARD_ATTRS` blocklist as a
top-level JSON key (the passthrough logic over `record.__dict__`). This is how
genuine `Logger.extra` fields (`method`, `path`, `status_code`, `duration_ms`)
reach the output.

On Python 3.12+ every `LogRecord` also carries a standard `taskName` attribute
(added upstream in CPython via bpo-33356 / gh-77714), and `taskName` was the
only standard attribute missing from `_STANDARD_ATTRS`. As a result, every JSON
log line emitted a spurious `"taskName": null` key (or an asyncio task name)
on the runtime the project requires (`requires-python >= 3.12`).

Example on Python 3.12, before this change:

```json
{"timestamp": "...", "level": "INFO", "logger": "app.test", "message": "request complete", "taskName": null}
```

The fix adds `"taskName"` to `_STANDARD_ATTRS` (in its alphabetical position),
so it is treated like every other standard attribute and no longer leaks into
the output. This restores the intent of the blocklist added in the structured
logging work.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

Added `dataloom-backend/tests/test_logging.py` with pure-formatter tests (no
HTTP or database fixtures needed, since `JSONFormatter` is a plain
`logging.Formatter`):

- a plain record emits exactly `{timestamp, level, logger, message}` and no
  `taskName`;
- `taskName` is excluded even when explicitly set on the record;
- genuine extras passed via `Logger.extra` (`method`, `path`, `status_code`,
  `duration_ms`) still pass through as top-level keys;
- `request_id` from the `ContextVar` is still included when set.

Verified red -> green: with the one-line change reverted, the two `taskName`
assertions fail and the other two still pass; with the change applied, all four
pass.

Commands run from `dataloom-backend` on Python 3.12 (`DATABASE_URL` set to a
SQLite URL, matching CI):

```
uv run ruff check app/utils/logging.py tests/test_logging.py   # passed
uv run ruff format --check app/utils/logging.py tests/test_logging.py   # already formatted
uv run pytest tests/test_logging.py   # 4 passed
uv run pytest   # full suite, 467 passed
```

- [x] Existing tests pass
- [x] New tests added
- [ ] Manual testing

## Screenshots (if applicable)

N/A (backend logging change).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally
