### PR TITLE
fix: match filter "contains" literally instead of as a regex

### DIFF
--- a/dataloom-backend/app/services/transformation_service.py
+++ b/dataloom-backend/app/services/transformation_service.py
@@ -92,7 +92,7 @@ def apply_filter(df: pd.DataFrame, column: str, condition: str, value: str) -> p
         "<": lambda col, val: df[col < val],
         ">=": lambda col, val: df[col >= val],
         "<=": lambda col, val: df[col <= val],
-        "contains": lambda col, val: df[col.astype(str).str.contains(val, na=False, case=False)],
+        "contains": lambda col, val: df[col.astype(str).str.contains(val, na=False, case=False, regex=False)],
     }
 
     condition_str = condition.value if hasattr(condition, "value") else str(condition)

--- a/dataloom-backend/tests/test_transformations.py
+++ b/dataloom-backend/tests/test_transformations.py
@@ -74,6 +74,20 @@ class TestFilter:
         assert len(result) == 2  # Alice and Charlie
         assert "Bob" not in result["name"].values
 
+    def test_filter_contains_literal_metacharacters(self):
+        """contains should match values with regex metacharacters literally, not crash."""
+        df = pd.DataFrame({"c": ["price (USD)", "plain"]})
+        result = apply_filter(df, "c", "contains", "(")
+        assert len(result) == 1
+        assert result.iloc[0]["c"] == "price (USD)"
+
+    def test_filter_contains_dot_is_literal(self):
+        """A '.' in the search value should match a literal dot, not any character."""
+        df = pd.DataFrame({"c": ["a.b", "axb", "a+b"]})
+        result = apply_filter(df, "c", "contains", "a.b")
+        assert len(result) == 1
+        assert result.iloc[0]["c"] == "a.b"
+
     def test_filter_invalid_condition(self, sample_df):
         with pytest.raises(TransformationError, match="Unsupported"):
             apply_filter(sample_df, "name", "invalid", "Alice")


### PR DESCRIPTION


The `"contains"` filter operator in `apply_filter`
(`dataloom-backend/app/services/transformation_service.py`) called
`pandas.Series.str.contains(val, na=False, case=False)` without `regex=False`.
`str.contains` defaults to `regex=True`, so the user's search value was
interpreted as a regular expression rather than the literal substring the
"contains" feature promises. This produced two distinct wrong behaviors from one
root cause:

1. **Crash (HTTP 500).** A value containing a regex metacharacter that is not a
   valid standalone expression (for example `(`, `[`, `*`, or `price (USD)`)
   raises `pyarrow.lib.ArrowInvalid: Invalid regular expression`. That exception
   is not a `TransformationError`, so the transform endpoint catches it in its
   generic `except Exception` branch and returns `500 Internal server error`.
   Filtering for common literal text like `price (USD)`, `cost [x]`, or `100%`
   therefore fails with a 500.
2. **Silent wrong results.** Metacharacters like `.` match any character. For a
   column `["a.b", "axb", "a+b"]`, `contains "a.b"` returns all three rows
   instead of only the literal `a.b`.

The fix passes `regex=False` so the value is matched as a literal substring. This
mirrors the sibling `string_replace` transform in the same file, which already
passes `regex=False`, and matches the documented intent of a "contains" filter.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

Added two regression tests to `TestFilter` in
`dataloom-backend/tests/test_transformations.py`:

- `test_filter_contains_literal_metacharacters` - `contains "("` over
  `["price (USD)", "plain"]` returns the single literal match. Before the fix
  this raised `ArrowInvalid` (surfacing as HTTP 500).
- `test_filter_contains_dot_is_literal` - `contains "a.b"` over
  `["a.b", "axb", "a+b"]` returns only the literal `a.b`. Before the fix this
  returned all three rows.

Both fail on the unpatched code and pass with the fix. The pre-existing
`test_filter_contains` uses the plain substring `"li"`, which never exercised
regex characters, so it continues to pass.

Commands run from `dataloom-backend`:

```
uv run ruff check app/services/transformation_service.py tests/test_transformations.py
uv run ruff format --check app/services/transformation_service.py tests/test_transformations.py
uv run pytest -q
```

- [x] Existing tests pass (full backend suite: 481 passed)
- [x] New tests added
- [x] Manual testing (reproduced both the 500 and the wrong-result cases before
      the fix; confirmed both resolved after)

## Screenshots (if applicable)

N/A (backend behavior change).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed (none needed)
- [x] My changes generate no new warnings
- [x] Tests pass locally
