### PR TITLE
refactor: move /meta endpoint to projects router and add ProjectMetaResponse schema

### DIFF
--- a/dataloom-backend/app/api/endpoints/profiling.py
+++ b/dataloom-backend/app/api/endpoints/profiling.py
@@ -69,16 +69,3 @@ async def get_correlation_matrix(
     """Return the pairwise Pearson correlation over numeric columns."""
     df = load_project_df(project)
     return profiling_service.correlation_matrix(df)
-
-
-@router.get("/{project_id}/meta", response_model=schemas.LastResponse)
-async def get_project_meta(
-    project: models.Project = Depends(get_project_or_404),
-):
-    """Fetch project metadata only — no row data."""
-    return schemas.LastResponse(
-        project_id=project.project_id,
-        name=project.name,
-        description=project.description,
-        last_modified=project.last_modified,
-    )

--- a/dataloom-backend/app/api/endpoints/projects.py
+++ b/dataloom-backend/app/api/endpoints/projects.py
@@ -495,3 +495,16 @@ async def update_project_endpoint(
         "description": updated.description,
         "file_path": updated.file_path,
     }
+
+
+@router.get("/{project_id}/meta", response_model=schemas.ProjectMetaResponse)
+async def get_project_meta(
+    project: models.Project = Depends(get_project_or_404),
+):
+    """Fetch project metadata only — no row data."""
+    return schemas.ProjectMetaResponse(
+        project_id=project.project_id,
+        name=project.name,
+        description=project.description,
+        last_modified=project.last_modified,
+    )

--- a/dataloom-backend/app/schemas.py
+++ b/dataloom-backend/app/schemas.py
@@ -635,3 +635,14 @@ class UpdateProjectResponse(BaseModel):
     file_path: str
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class ProjectMetaResponse(BaseModel):
+    """Metadata response for a single project."""
+
+    project_id: uuid.UUID
+    name: str
+    description: str | None
+    last_modified: datetime.datetime
+
+    model_config = ConfigDict(from_attributes=True)


### PR DESCRIPTION
## Description
`GET /projects/{id}/meta` was placed in `profiling.py` whose module docstring explicitly scopes it to DataFrame-reading routes. The `/meta` endpoint touches no DataFrame — it is plain project metadata CRUD that belongs beside `update_project_endpoint` in `projects.py`. It also reused `LastResponse` whose docstring says "Response for recently modified projects", which is misleading in the generated API docs for a single-project fetch.

This PR moves the endpoint to `projects.py` and introduces a dedicated `ProjectMetaResponse` schema.

Fixes #416 

## Type of Change
- [x] Breaking change

## How Has This Been Tested?
- Verified `/projects/{id}/meta` returns correct metadata
- Verified profiling routes unaffected
- [x] Existing tests pass
- [x] Manual testing

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally