### PR TITLE
feat: add more files to an existing project with append and file inve…

### DIFF
--- a/dataloom-backend/alembic/versions/0264244c1240_add_project_files_table.py
+++ b/dataloom-backend/alembic/versions/0264244c1240_add_project_files_table.py
@@ -1,0 +1,42 @@
+"""add project files table
+
+Revision ID: 0264244c1240
+Revises: c2f56609809e
+Create Date: 2026-07-05 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "0264244c1240"
+down_revision: str | Sequence[str] | None = "c2f56609809e"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "project_files",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("project_id", sa.Uuid(), nullable=False),
+        sa.Column("file_path", sa.String(), nullable=False),
+        sa.Column("original_filename", sa.String(), nullable=False),
+        sa.Column("uploaded_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(
+            ["project_id"],
+            ["projects.project_id"],
+            name="project_files_project_id_fkey",
+            ondelete="CASCADE",
+        ),
+    )
+    op.create_index(op.f("ix_project_files_project_id"), "project_files", ["project_id"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_project_files_project_id"), table_name="project_files")
+    op.drop_table("project_files")

--- a/dataloom-backend/app/api/endpoints/project_files.py
+++ b/dataloom-backend/app/api/endpoints/project_files.py
@@ -1,0 +1,203 @@
+"""Add-file (append) API endpoints.
+
+Lets users grow a project by appending more files: a stateless alignment
+preview, the append itself, the project's file inventory, and re-appending an
+inventory file whose rows were reverted away.
+
+Each append stores the incoming file immutably and logs an ``addFile``
+operation referencing it, so save/revert/undo replay stays correct: every
+project state remains reconstructible from the original upload plus the log
+chain. The stored files form the inventory (``project_files``) and are never
+modified or deleted by data operations.
+"""
+
+import shutil
+import tempfile
+import uuid
+from contextlib import suppress
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
+from sqlmodel import Session
+
+from app import database, models, schemas
+from app.api.dependencies import get_project_or_404, load_project_df
+from app.services.append_service import analyze_append, append_dataframes
+from app.services.file_service import store_added_file
+from app.services.project_service import (
+    create_project_file,
+    get_project_file,
+    get_project_files,
+    log_transformation,
+)
+from app.utils.logging import get_logger
+from app.utils.pandas_helpers import dataframe_to_response, read_table_safe, save_table_safe
+from app.utils.security import validate_upload_file
+
+logger = get_logger(__name__)
+
+router = APIRouter()
+
+
+def _read_upload_df(file: UploadFile):
+    """Parse an uploaded file into a DataFrame without storing it.
+
+    Writes to a temp file so the format registry can dispatch on the
+    extension, then cleans up. Parse failures surface as a clean 400 — a
+    malformed upload is a client error, not a server fault.
+    """
+    suffix = Path(file.filename).suffix.lower()
+    with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
+        shutil.copyfileobj(file.file, tmp)
+        tmp_path = Path(tmp.name)
+    try:
+        return read_table_safe(tmp_path)
+    except HTTPException as e:
+        raise HTTPException(status_code=400, detail=f"Could not parse the uploaded {suffix} file.") from e
+    finally:
+        with suppress(FileNotFoundError):
+            tmp_path.unlink()
+
+
+def _append_and_log(
+    db: Session,
+    project: models.Project,
+    stored_path: str,
+    original_filename: str,
+    project_file_id: uuid.UUID,
+) -> dict:
+    """Append a stored inventory file onto the working copy and log it.
+
+    Mirrors the transform endpoint's persistence contract: the working copy is
+    written first, and if audit logging fails the file is restored so state
+    never diverges from the log chain.
+
+    Returns:
+        The ProjectResponse payload for the combined data.
+    """
+    df = load_project_df(project)
+    new_df = read_table_safe(Path(stored_path))
+    combined = append_dataframes(df, new_df)
+
+    save_table_safe(combined, project.file_path)
+    details = {
+        "add_file_params": {
+            "file_path": stored_path,
+            "project_file_id": str(project_file_id),
+            "original_filename": original_filename,
+            "rows_added": len(new_df),
+        }
+    }
+    try:
+        log_transformation(db, project.project_id, schemas.OperationType.addFile, details)
+    except Exception:
+        # Compensate the disk mutation so the working copy never holds rows
+        # that the log chain cannot reproduce.
+        try:
+            save_table_safe(df, project.file_path)
+        except Exception:
+            logger.exception(
+                "Failed to restore working copy after log failure: project_id=%s file=%s",
+                project.project_id,
+                original_filename,
+            )
+        raise
+
+    total_rows = len(combined)
+    resp = dataframe_to_response(combined)
+    return {
+        "filename": project.name,
+        "file_path": project.file_path,
+        "project_id": project.project_id,
+        "page": 1,
+        "page_size": total_rows,
+        "total_rows": total_rows,
+        "total_pages": 1,
+        **resp,
+    }
+
+
+@router.post("/{project_id}/files/preview", response_model=schemas.AppendPreviewResponse)
+async def preview_add_file(
+    file: UploadFile = File(...),
+    project: models.Project = Depends(get_project_or_404),
+):
+    """Preview how an uploaded file would align with the project's data.
+
+    Stateless: the file is parsed, compared, and discarded. Nothing is stored
+    until the client confirms via ``POST /{project_id}/files``.
+    """
+    await validate_upload_file(file)
+    new_df = _read_upload_df(file)
+    df = load_project_df(project)
+    return analyze_append(df, new_df)
+
+
+@router.post("/{project_id}/files", response_model=schemas.ProjectResponse)
+async def add_file(
+    file: UploadFile = File(...),
+    db: Session = Depends(database.get_db),
+    project: models.Project = Depends(get_project_or_404),
+):
+    """Append an uploaded file's rows to the project.
+
+    Stores the file in the project's inventory, appends its rows onto the
+    working copy (columns unioned, gaps left empty), and logs a replayable
+    ``addFile`` operation.
+    """
+    logger.info("Add file request: project=%s, file=%s", project.project_id, file.filename)
+    await validate_upload_file(file)
+
+    try:
+        stored_path = store_added_file(file)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
+    # Validate the stored file parses before recording anything.
+    try:
+        read_table_safe(stored_path)
+    except HTTPException as e:
+        with suppress(FileNotFoundError):
+            stored_path.unlink()
+        ext = Path(file.filename).suffix.lower()
+        if e.status_code >= 500:
+            raise HTTPException(status_code=400, detail=f"Could not parse the uploaded {ext} file.") from e
+        raise
+
+    project_file = create_project_file(db, project.project_id, str(stored_path), file.filename)
+    return _append_and_log(db, project, str(stored_path), file.filename, project_file.id)
+
+
+@router.get("/{project_id}/files", response_model=list[schemas.ProjectFileResponse])
+async def list_project_files(
+    db: Session = Depends(database.get_db),
+    project: models.Project = Depends(get_project_or_404),
+):
+    """List the project's file inventory (files added after the initial upload)."""
+    return get_project_files(db, project.project_id)
+
+
+@router.post("/{project_id}/files/{file_id}/append", response_model=schemas.ProjectResponse)
+async def reappend_project_file(
+    file_id: uuid.UUID,
+    db: Session = Depends(database.get_db),
+    project: models.Project = Depends(get_project_or_404),
+):
+    """Append an inventory file's rows to the project again.
+
+    For restoring a file whose rows were removed by revert/undo — the stored
+    file is immutable, so the append is identical to the original one.
+    """
+    project_file = get_project_file(db, file_id, project.project_id)
+    if project_file is None:
+        raise HTTPException(status_code=404, detail="Project file not found")
+    if not Path(project_file.file_path).exists():
+        raise HTTPException(status_code=404, detail="Stored file is missing from disk")
+
+    return _append_and_log(
+        db,
+        project,
+        project_file.file_path,
+        project_file.original_filename,
+        project_file.id,
+    )

--- a/dataloom-backend/app/api/endpoints/projects.py
+++ b/dataloom-backend/app/api/endpoints/projects.py
@@ -24,6 +24,7 @@ from app.services.project_service import (
     delete_change_log,
     delete_project,
     get_last_change_log,
+    get_project_files,
     get_projects,
     get_recent_projects,
     rename_project,
@@ -383,6 +384,8 @@ async def delete_project_endpoint(
     project_id = project.project_id
     project_name = project.name
     file_path = project.file_path
+    # Snapshot inventory paths before the rows are deleted with the project.
+    inventory_paths = [f.file_path for f in get_project_files(db, project_id)]
 
     logger.info("Delete project request: id=%s, name=%s, file_path=%s", project_id, project_name, file_path)
 
@@ -401,6 +404,14 @@ async def delete_project_endpoint(
             project_name,
             file_path,
         )
+
+    for inventory_path in inventory_paths:
+        try:
+            Path(inventory_path).unlink()
+        except FileNotFoundError:
+            logger.warning("Inventory file already missing: %s", inventory_path)
+        except OSError:
+            logger.exception("Failed to delete inventory file: id=%s, path=%s", project_id, inventory_path)
 
     return {"success": True, "message": "Project deleted"}
 

--- a/dataloom-backend/app/main.py
+++ b/dataloom-backend/app/main.py
@@ -12,7 +12,7 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
-from app.api.endpoints import auth, profiling, projects, transformations, user_logs, visualizations
+from app.api.endpoints import auth, profiling, project_files, projects, transformations, user_logs, visualizations
 from app.config import get_settings
 from app.database import verify_database_connection
 from app.exceptions import AppException, app_exception_handler
@@ -101,6 +101,7 @@ app.include_router(auth.router, prefix="/auth", tags=["auth"])
 app.include_router(projects.router, prefix="/projects", tags=["projects"])
 app.include_router(transformations.router, prefix="/projects", tags=["transformations"])
 app.include_router(profiling.router, prefix="/projects", tags=["profiling"])
+app.include_router(project_files.router, prefix="/projects", tags=["project_files"])
 app.include_router(visualizations.router, prefix="/projects", tags=["visualizations"])
 app.include_router(user_logs.router, prefix="/logs", tags=["user_logs"])
 

--- a/dataloom-backend/app/models.py
+++ b/dataloom-backend/app/models.py
@@ -85,6 +85,42 @@ class Project(SQLModel, table=True):
         back_populates="project",
         sa_relationship_kwargs={"cascade": "all, delete-orphan"},
     )
+    files: list["ProjectFile"] = Relationship(
+        back_populates="project",
+        sa_relationship_kwargs={"cascade": "all, delete-orphan"},
+    )
+
+
+class ProjectFile(SQLModel, table=True):
+    """An immutable source file added to a project after the initial upload.
+
+    Forms the project's file inventory: the stored file is never modified or
+    deleted by data operations, so an append that is later undone or reverted
+    away can always be re-applied from the inventory.
+    """
+
+    __tablename__ = "project_files"
+
+    id: uuid_mod.UUID = Field(
+        default_factory=uuid_mod.uuid4,
+        sa_column=Column(sa.Uuid, primary_key=True, default=uuid_mod.uuid4),
+    )
+    project_id: uuid_mod.UUID = Field(
+        sa_column=Column(
+            sa.Uuid,
+            sa.ForeignKey("projects.project_id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+    )
+    file_path: str
+    original_filename: str
+    uploaded_at: datetime | None = Field(
+        default=None,
+        sa_column=Column(DateTime, server_default=func.now(), nullable=False),
+    )
+
+    project: Project | None = Relationship(back_populates="files")
 
 
 class ProjectChangeLog(SQLModel, table=True):

--- a/dataloom-backend/app/schemas.py
+++ b/dataloom-backend/app/schemas.py
@@ -44,6 +44,7 @@ class OperationType(StrEnum):
     melt = "melt"
     sample = "sample"
     stringReplace = "stringReplace"
+    addFile = "addFile"
 
 
 class DropDup(StrEnum):
@@ -349,6 +350,36 @@ class ProjectResponse(BaseModel):
     row_count: int
     rows: list[list]
     dtypes: dict[str, str] = {}
+
+
+# --- Add-file (append) schemas ---
+
+
+class DtypeClash(BaseModel):
+    """A matched column whose simplified dtype differs between the two files."""
+
+    column: str
+    existing_dtype: str
+    incoming_dtype: str
+
+
+class AppendPreviewResponse(BaseModel):
+    """How an incoming file would align with the project's current data."""
+
+    matched_columns: list[str]
+    new_columns: list[str]
+    missing_columns: list[str]
+    dtype_clashes: list[DtypeClash]
+    current_row_count: int
+    incoming_row_count: int
+
+
+class ProjectFileResponse(BaseModel):
+    """An entry in a project's file inventory."""
+
+    id: uuid.UUID
+    original_filename: str
+    uploaded_at: datetime.datetime | None = None
 
 
 # --- Profiling response schemas ---

--- a/dataloom-backend/app/services/append_service.py
+++ b/dataloom-backend/app/services/append_service.py
@@ -1,0 +1,66 @@
+"""Pure functions for appending one dataset onto another.
+
+Each function takes DataFrames and returns plain data or a new DataFrame.
+No side effects — file I/O is handled by the endpoint layer. This mirrors
+``transformation_service``'s style.
+"""
+
+import pandas as pd
+
+from app.utils.pandas_helpers import map_dtype
+
+
+def append_dataframes(df: pd.DataFrame, new_df: pd.DataFrame) -> pd.DataFrame:
+    """Stack ``new_df``'s rows below ``df``, unioning columns.
+
+    Columns present in only one frame are kept and filled with NaN for the
+    other frame's rows. Column order is ``df``'s columns first, then any new
+    columns in their order of appearance in ``new_df``.
+
+    Args:
+        df: The project's current DataFrame.
+        new_df: The incoming file's DataFrame.
+
+    Returns:
+        The combined DataFrame with a fresh RangeIndex.
+    """
+    return pd.concat([df, new_df], join="outer", ignore_index=True, sort=False)
+
+
+def analyze_append(df: pd.DataFrame, new_df: pd.DataFrame) -> dict:
+    """Describe how ``new_df`` would align with ``df`` on append.
+
+    Args:
+        df: The project's current DataFrame.
+        new_df: The incoming file's DataFrame.
+
+    Returns:
+        Dict with matched/new/missing column lists, dtype clashes among the
+        matched columns, and both row counts. Dtypes use the same simplified
+        names the table UI shows (``map_dtype``).
+    """
+    matched_columns = [col for col in df.columns if col in new_df.columns]
+    new_columns = [col for col in new_df.columns if col not in df.columns]
+    missing_columns = [col for col in df.columns if col not in new_df.columns]
+
+    dtype_clashes = []
+    for col in matched_columns:
+        existing_dtype = map_dtype(df[col].dtype)
+        incoming_dtype = map_dtype(new_df[col].dtype)
+        if existing_dtype != incoming_dtype:
+            dtype_clashes.append(
+                {
+                    "column": col,
+                    "existing_dtype": existing_dtype,
+                    "incoming_dtype": incoming_dtype,
+                }
+            )
+
+    return {
+        "matched_columns": matched_columns,
+        "new_columns": new_columns,
+        "missing_columns": missing_columns,
+        "dtype_clashes": dtype_clashes,
+        "current_row_count": len(df),
+        "incoming_row_count": len(new_df),
+    }

--- a/dataloom-backend/app/services/file_service.py
+++ b/dataloom-backend/app/services/file_service.py
@@ -16,21 +16,19 @@ def _copy_path_for(original_path: Path) -> Path:
     return original_path.with_name(f"{original_path.stem}_copy{original_path.suffix}")
 
 
-def store_upload(file) -> tuple[Path, Path]:
-    """Store an uploaded file and create a working copy in the same format.
+def _validated_write(file) -> Path:
+    """Validate an upload and write it to a sanitized path in the upload dir.
 
     Validates the file extension against the supported-format registry and
     enforces the configured ``max_upload_size_bytes`` limit via chunked
-    streaming before writing anything to disk. The working copy keeps the
-    native extension, so revert/undo can re-read the original in its own format.
-    The file pointer is reset to 0 after validation so ``shutil.copyfileobj``
-    writes a complete file.
+    streaming before writing anything to disk. The file pointer is reset to 0
+    after validation so ``shutil.copyfileobj`` writes a complete file.
 
     Args:
         file: The FastAPI UploadFile object.
 
     Returns:
-        Tuple of (original_path, copy_path).
+        Path the file was written to.
 
     Raises:
         ValueError: If the file format is unsupported or it exceeds
@@ -59,10 +57,54 @@ def store_upload(file) -> tuple[Path, Path]:
     file.file.seek(0)
 
     safe_name = sanitize_filename(file.filename)
-    original_path = resolve_upload_path(safe_name)
+    target_path = resolve_upload_path(safe_name)
 
-    with open(original_path, "wb+") as f:
+    with open(target_path, "wb+") as f:
         shutil.copyfileobj(file.file, f)
+
+    return target_path
+
+
+def store_added_file(file) -> Path:
+    """Store a file added to an existing project's inventory.
+
+    Same validation and sanitized-name storage as ``store_upload``, but writes
+    a single immutable file: inventory files are only ever read (append and
+    replay), so no ``_copy`` working twin is created.
+
+    Args:
+        file: The FastAPI UploadFile object.
+
+    Returns:
+        Path to the stored file.
+
+    Raises:
+        ValueError: If the file format is unsupported or it exceeds
+            ``settings.max_upload_size_bytes``.
+    """
+    stored_path = _validated_write(file)
+    logger.info("Stored added file: %s", stored_path)
+    return stored_path
+
+
+def store_upload(file) -> tuple[Path, Path]:
+    """Store an uploaded file and create a working copy in the same format.
+
+    The working copy keeps the native extension, so revert/undo can re-read
+    the original in its own format. Validation and sanitized-name storage are
+    shared with ``store_added_file`` via ``_validated_write``.
+
+    Args:
+        file: The FastAPI UploadFile object.
+
+    Returns:
+        Tuple of (original_path, copy_path).
+
+    Raises:
+        ValueError: If the file format is unsupported or it exceeds
+            ``settings.max_upload_size_bytes``.
+    """
+    original_path = _validated_write(file)
 
     copy_path = _copy_path_for(original_path)
     shutil.copy2(original_path, copy_path)

--- a/dataloom-backend/app/services/project_service.py
+++ b/dataloom-backend/app/services/project_service.py
@@ -41,6 +41,74 @@ def create_project(
     return project
 
 
+def create_project_file(
+    db: Session,
+    project_id: uuid.UUID,
+    file_path: str,
+    original_filename: str,
+) -> models.ProjectFile:
+    """Record an added file in a project's inventory.
+
+    Args:
+        db: Database session.
+        project_id: The project the file was added to.
+        file_path: Path to the stored immutable file.
+        original_filename: The filename as uploaded by the user.
+
+    Returns:
+        The created ProjectFile model instance.
+    """
+    project_file = models.ProjectFile(
+        project_id=project_id,
+        file_path=file_path,
+        original_filename=original_filename,
+    )
+    db.add(project_file)
+    db.commit()
+    db.refresh(project_file)
+    logger.info("Added project file: id=%s, project_id=%s, name=%s", project_file.id, project_id, original_filename)
+    return project_file
+
+
+def get_project_files(db: Session, project_id: uuid.UUID) -> list[models.ProjectFile]:
+    """Fetch a project's file inventory ordered by upload time ascending.
+
+    Args:
+        db: Database session.
+        project_id: The project to query.
+
+    Returns:
+        List of ProjectFile model instances.
+    """
+    return (
+        db.query(models.ProjectFile)
+        .filter(models.ProjectFile.project_id == project_id)
+        .order_by(models.ProjectFile.uploaded_at)
+        .all()
+    )
+
+
+def get_project_file(db: Session, file_id: uuid.UUID, project_id: uuid.UUID) -> models.ProjectFile | None:
+    """Fetch a single inventory file scoped to a project.
+
+    Args:
+        db: Database session.
+        file_id: The inventory file primary key.
+        project_id: The project the file must belong to.
+
+    Returns:
+        The ProjectFile model instance, or None if not found in this project.
+    """
+    return (
+        db.query(models.ProjectFile)
+        .filter(
+            models.ProjectFile.id == file_id,
+            models.ProjectFile.project_id == project_id,
+        )
+        .first()
+    )
+
+
 def get_recent_projects(db: Session, owner_id: uuid.UUID, limit: int = 3) -> list[models.Project]:
     """Fetch a user's most recently modified projects.
 
@@ -85,6 +153,11 @@ def delete_project(db: Session, project: models.Project) -> None:
             .filter(models.Checkpoint.project_id == project_id)
             .delete(synchronize_session=False)
         )
+        deleted_files = (
+            db.query(models.ProjectFile)
+            .filter(models.ProjectFile.project_id == project_id)
+            .delete(synchronize_session=False)
+        )
         deleted_projects = (
             db.query(models.Project).filter(models.Project.project_id == project_id).delete(synchronize_session=False)
         )
@@ -98,12 +171,13 @@ def delete_project(db: Session, project: models.Project) -> None:
         logger.warning("Project delete matched no project row: id=%s, name=%s", project_id, project_name)
 
     logger.info(
-        "Deleted project: id=%s, name=%s, projects=%d, logs=%d, checkpoints=%d",
+        "Deleted project: id=%s, name=%s, projects=%d, logs=%d, checkpoints=%d, files=%d",
         project_id,
         project_name,
         deleted_projects,
         deleted_logs,
         deleted_checkpoints,
+        deleted_files,
     )
 
 

--- a/dataloom-backend/app/services/transformation_service.py
+++ b/dataloom-backend/app/services/transformation_service.py
@@ -6,11 +6,14 @@ No side effects -- saving to disk is handled by the caller.
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from pathlib import Path
 
 import pandas as pd
 
 from app.schemas import FillStrategy, MeltParams, OperationType
+from app.services.append_service import append_dataframes
 from app.utils.logging import get_logger
+from app.utils.pandas_helpers import read_table_safe
 from app.utils.security import validate_query_string
 
 logger = get_logger(__name__)
@@ -765,6 +768,32 @@ def sample_rows(df: pd.DataFrame, sample_size: int, random_seed: int | None = No
     return sampled.reset_index(drop=True)
 
 
+def apply_add_file(df: pd.DataFrame, file_path: str) -> pd.DataFrame:
+    """Append a stored inventory file's rows onto the DataFrame.
+
+    The one deliberately impure function in this module: replaying an append
+    requires reading the immutable stored file back from disk. The path always
+    comes from server-written ``addFile`` log entries (or the endpoint that
+    writes them), never from client input.
+
+    Args:
+        df: Source DataFrame.
+        file_path: Path to the stored inventory file (inside the upload dir).
+
+    Returns:
+        The combined DataFrame with columns unioned and a fresh index.
+
+    Raises:
+        TransformationError: If the stored file is missing or unreadable.
+    """
+    try:
+        new_df = read_table_safe(Path(file_path))
+    except Exception as e:
+        logger.warning("Could not read stored file for addFile replay: %s", file_path)
+        raise TransformationError("Stored file for this append is missing or unreadable") from e
+    return append_dataframes(df, new_df)
+
+
 @dataclass(frozen=True)
 class TransformationSpec:
     """Describes how to validate, dispatch, and persist one transformation.
@@ -949,6 +978,17 @@ TRANSFORMATION_REGISTRY: dict[OperationType, TransformationSpec] = {
             d["groupby_params"]["agg_column"],
             d["groupby_params"]["agg_function"],
         ),
+    ),
+    # addFile is executed by the /projects/{id}/files endpoint, never by
+    # /transform: TransformationInput has no add_file_params field, so a
+    # /transform request with this operation always 400s at the params check.
+    # The registry entry exists so save/revert/undo replay the append through
+    # the same dispatch seam as every other logged operation.
+    OperationType.addFile: TransformationSpec(
+        func="apply_add_file",
+        params_field="add_file_params",
+        missing_error="Add file operations must use the /files endpoint",
+        build_args=lambda d: (d["add_file_params"]["file_path"],),
     ),
 }
 

--- a/dataloom-backend/tests/test_add_file.py
+++ b/dataloom-backend/tests/test_add_file.py
@@ -1,0 +1,251 @@
+"""Tests for the add-file (append) feature.
+
+Covers the pure append/analyze functions, the addFile replay path, and the
+/projects/{id}/files endpoints end-to-end: preview, append, inventory,
+undo/revert interplay, re-append, and deletion cleanup.
+"""
+
+import uuid
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from app import models
+from app.services.append_service import analyze_append, append_dataframes
+from app.services.transformation_service import TransformationError, apply_add_file
+
+BASE_CSV = b"name,age\nAlice,30\nBob,25\nCharlie,35\n"
+SAME_COLS_CSV = b"name,age\nDana,40\nEve,45\n"
+NEW_COLS_CSV = b"name,city\nDana,Paris\nEve,Oslo\n"
+CLASH_CSV = b"name,age\nDana,forty\nEve,unknown\n"
+
+
+def _upload(client, content: bytes = BASE_CSV, name: str = "base.csv"):
+    response = client.post(
+        "/projects/upload",
+        files={"file": (name, content, "application/octet-stream")},
+        data={"projectName": "Append Test", "projectDescription": "add-file tests"},
+    )
+    assert response.status_code == 200
+    return response.json()
+
+
+def _add_file(client, project_id, content: bytes, name: str = "added.csv"):
+    return client.post(
+        f"/projects/{project_id}/files",
+        files={"file": (name, content, "application/octet-stream")},
+    )
+
+
+class TestAppendDataframes:
+    def test_same_columns_stack(self):
+        df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+        new_df = pd.DataFrame({"a": [5], "b": [6]})
+
+        combined = append_dataframes(df, new_df)
+
+        assert list(combined.columns) == ["a", "b"]
+        assert len(combined) == 3
+        assert list(combined["a"]) == [1, 2, 5]
+
+    def test_column_union_fills_nan_both_ways(self):
+        df = pd.DataFrame({"a": [1], "b": [2]})
+        new_df = pd.DataFrame({"b": [3], "c": [4]})
+
+        combined = append_dataframes(df, new_df)
+
+        assert list(combined.columns) == ["a", "b", "c"]
+        assert pd.isna(combined.loc[1, "a"])  # missing in new file
+        assert pd.isna(combined.loc[0, "c"])  # missing in existing data
+        assert list(combined["b"]) == [2, 3]
+
+    def test_fresh_index(self):
+        df = pd.DataFrame({"a": [1, 2]})
+        combined = append_dataframes(df, pd.DataFrame({"a": [3]}))
+        assert list(combined.index) == [0, 1, 2]
+
+
+class TestAnalyzeAppend:
+    def test_alignment_report(self):
+        df = pd.DataFrame({"name": ["x"], "age": [1], "city": ["y"]})
+        new_df = pd.DataFrame({"name": ["z"], "email": ["e"]})
+
+        report = analyze_append(df, new_df)
+
+        assert report["matched_columns"] == ["name"]
+        assert report["new_columns"] == ["email"]
+        assert report["missing_columns"] == ["age", "city"]
+        assert report["dtype_clashes"] == []
+        assert report["current_row_count"] == 1
+        assert report["incoming_row_count"] == 1
+
+    def test_dtype_clash_detected(self):
+        df = pd.DataFrame({"age": [30, 25]})
+        new_df = pd.DataFrame({"age": ["forty", "fifty"]})
+
+        report = analyze_append(df, new_df)
+
+        assert report["dtype_clashes"] == [{"column": "age", "existing_dtype": "int", "incoming_dtype": "str"}]
+
+
+class TestApplyAddFileReplay:
+    def test_appends_stored_file(self, tmp_path):
+        stored = tmp_path / "stored.csv"
+        pd.DataFrame({"a": [3, 4]}).to_csv(stored, index=False)
+        df = pd.DataFrame({"a": [1, 2]})
+
+        result = apply_add_file(df, str(stored))
+
+        assert list(result["a"]) == [1, 2, 3, 4]
+
+    def test_missing_file_raises_transformation_error(self, tmp_path):
+        with pytest.raises(TransformationError, match="missing or unreadable"):
+            apply_add_file(pd.DataFrame({"a": [1]}), str(tmp_path / "gone.csv"))
+
+
+class TestPreviewEndpoint:
+    def test_preview_reports_alignment_without_mutating(self, client):
+        project_id = _upload(client)["project_id"]
+
+        response = client.post(
+            f"/projects/{project_id}/files/preview",
+            files={"file": ("new.csv", NEW_COLS_CSV, "application/octet-stream")},
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["matched_columns"] == ["name"]
+        assert body["new_columns"] == ["city"]
+        assert body["missing_columns"] == ["age"]
+        assert body["current_row_count"] == 3
+        assert body["incoming_row_count"] == 2
+
+        # Nothing stored, nothing appended.
+        details = client.get(f"/projects/get/{project_id}").json()
+        assert details["total_rows"] == 3
+        assert client.get(f"/projects/{project_id}/files").json() == []
+
+    def test_preview_rejects_unparseable_file(self, client):
+        project_id = _upload(client)["project_id"]
+        response = client.post(
+            f"/projects/{project_id}/files/preview",
+            files={"file": ("bad.json", b"{not valid json", "application/octet-stream")},
+        )
+        assert response.status_code == 400
+
+    def test_requires_auth(self, anon_client):
+        response = anon_client.post(
+            "/projects/00000000-0000-0000-0000-000000000001/files/preview",
+            files={"file": ("new.csv", SAME_COLS_CSV, "application/octet-stream")},
+        )
+        assert response.status_code == 401
+
+
+class TestAddFileEndpoint:
+    def test_appends_rows_and_records_inventory(self, client, db):
+        project_id = _upload(client)["project_id"]
+
+        response = _add_file(client, project_id, SAME_COLS_CSV, "feb.csv")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["total_rows"] == 5
+        assert body["columns"] == ["name", "age"]
+
+        inventory = client.get(f"/projects/{project_id}/files").json()
+        assert len(inventory) == 1
+        assert inventory[0]["original_filename"] == "feb.csv"
+
+        logs = db.query(models.ProjectChangeLog).filter_by(project_id=uuid.UUID(project_id)).all()
+        assert len(logs) == 1
+        assert logs[0].action_type == "addFile"
+        assert logs[0].action_details["add_file_params"]["rows_added"] == 2
+
+    def test_new_columns_unioned_with_gaps(self, client):
+        project_id = _upload(client)["project_id"]
+
+        response = _add_file(client, project_id, NEW_COLS_CSV)
+
+        body = response.json()
+        assert body["columns"] == ["name", "age", "city"]
+        assert body["total_rows"] == 5
+        # Existing rows have no city; appended rows have no age.
+        first_row, last_row = body["rows"][0], body["rows"][-1]
+        assert first_row[2] is None
+        assert last_row[1] is None
+
+    def test_unparseable_file_leaves_no_trace(self, client, db):
+        project_id = _upload(client)["project_id"]
+
+        response = _add_file(client, project_id, b"{not valid json", "bad.json")
+
+        assert response.status_code == 400
+        assert client.get(f"/projects/{project_id}/files").json() == []
+        assert db.query(models.ProjectChangeLog).filter_by(project_id=uuid.UUID(project_id)).count() == 0
+        details = client.get(f"/projects/get/{project_id}").json()
+        assert details["total_rows"] == 3
+
+    def test_transform_endpoint_rejects_addfile(self, client):
+        """addFile must not be reachable through /transform (no file path injection)."""
+        project_id = _upload(client)["project_id"]
+        response = client.post(
+            f"/projects/{project_id}/transform",
+            json={"operation_type": "addFile"},
+        )
+        assert response.status_code == 400
+
+
+class TestUndoRevertInterplay:
+    def test_undo_removes_appended_rows_but_keeps_inventory(self, client):
+        project_id = _upload(client)["project_id"]
+        _add_file(client, project_id, SAME_COLS_CSV)
+
+        response = client.post(f"/projects/{project_id}/undo")
+
+        assert response.status_code == 200
+        assert response.json()["total_rows"] == 3
+        assert len(client.get(f"/projects/{project_id}/files").json()) == 1
+
+    def test_revert_to_checkpoint_replays_append(self, client):
+        """The core replay guarantee: a checkpointed append survives revert."""
+        project_id = _upload(client)["project_id"]
+        _add_file(client, project_id, SAME_COLS_CSV)
+        assert client.post(f"/projects/{project_id}/save", params={"commit_message": "with feb"}).status_code == 200
+        checkpoint_id = client.get(f"/logs/checkpoints/{project_id}").json()[0]["id"]
+
+        response = client.post(f"/projects/{project_id}/revert", params={"checkpoint_id": checkpoint_id})
+
+        assert response.status_code == 200
+        assert response.json()["total_rows"] == 5
+
+    def test_reappend_after_full_revert(self, client):
+        project_id = _upload(client)["project_id"]
+        _add_file(client, project_id, SAME_COLS_CSV)
+
+        assert client.post(f"/projects/{project_id}/revert").json()["total_rows"] == 3
+
+        file_id = client.get(f"/projects/{project_id}/files").json()[0]["id"]
+        response = client.post(f"/projects/{project_id}/files/{file_id}/append")
+
+        assert response.status_code == 200
+        assert response.json()["total_rows"] == 5
+
+    def test_reappend_unknown_file_404(self, client):
+        project_id = _upload(client)["project_id"]
+        response = client.post(f"/projects/{project_id}/files/00000000-0000-0000-0000-000000000001/append")
+        assert response.status_code == 404
+
+
+class TestDeleteCleanup:
+    def test_delete_project_removes_inventory_rows_and_files(self, client, db):
+        project_id = _upload(client)["project_id"]
+        _add_file(client, project_id, SAME_COLS_CSV)
+        stored_path = Path(db.query(models.ProjectFile).filter_by(project_id=uuid.UUID(project_id)).one().file_path)
+        assert stored_path.exists()
+
+        response = client.delete(f"/projects/{project_id}")
+
+        assert response.status_code == 200
+        assert db.query(models.ProjectFile).filter_by(project_id=uuid.UUID(project_id)).count() == 0
+        assert not stored_path.exists()

--- a/dataloom-frontend/src/Components/DataScreen.jsx
+++ b/dataloom-frontend/src/Components/DataScreen.jsx
@@ -14,6 +14,7 @@ import "./workspace/features/transforms";
 import "./workspace/features/history";
 import "./workspace/features/profiling";
 import "./workspace/features/charts";
+import "./workspace/features/addFile";
 import WorkspaceTabBar from "./workspace/WorkspaceTabBar";
 import RightPanel from "./workspace/RightPanel";
 import MenuNavbar from "./MenuNavbar";

--- a/dataloom-frontend/src/Components/MenuNavbar.jsx
+++ b/dataloom-frontend/src/Components/MenuNavbar.jsx
@@ -16,7 +16,7 @@ import { getFeatureMenu } from "./workspace/featureRegistry";
 // Ribbon skeleton: the top tabs and the group order within each. Features and the
 // core items below slot their entries into these buckets; layout stays stable.
 const RIBBON_LAYOUT = {
-  File: ["Save", "History"],
+  File: ["Save", "Source", "History"],
   Data: ["Transform", "Query"],
   Profiling: ["Profiling"],
 };

--- a/dataloom-frontend/src/Components/files/AddFilePanel.tsx
+++ b/dataloom-frontend/src/Components/files/AddFilePanel.tsx
@@ -1,0 +1,250 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { LuFilePlus, LuRotateCcw } from "react-icons/lu";
+import {
+  addFileToProject,
+  getProjectFiles,
+  previewAddFile,
+  reappendProjectFile,
+  type AppendPreview,
+  type ProjectFileEntry,
+} from "../../api/projectFiles";
+import { useHistoryRefresh } from "../../context/HistoryRefreshContext";
+import { useProjectContext } from "../../context/ProjectContext";
+import { useToast } from "../../context/ToastContext";
+import useError from "../../hooks/useError";
+import FormErrorAlert from "../common/FormErrorAlert";
+import { ACCEPTED_EXTENSIONS } from "../../utils/fileUtils";
+
+const ACCEPT_ATTR = ACCEPTED_EXTENSIONS.join(",");
+
+const errorDetail = (err: unknown, fallback: string): string =>
+  (err as { response?: { data?: { detail?: string } } }).response?.data?.detail || fallback;
+
+/**
+ * Docked panel for appending more files to the current project.
+ *
+ * Preview-then-confirm: picking a file fetches a column-alignment report
+ * (matched / new / missing columns, dtype clashes) and nothing changes until
+ * the user confirms the append. Below the form, the project's file inventory
+ * lists every previously added file — appends removed by revert/undo can be
+ * re-applied from there, so an added file is never lost.
+ */
+const AddFilePanel = ({ projectId, onClose }: { projectId: string; onClose: () => void }) => {
+  const { refreshProject, pageSize } = useProjectContext();
+  const { refreshLogs } = useHistoryRefresh();
+  const { showToast } = useToast();
+  const { error, clearError, handleError } = useError();
+
+  const [preview, setPreview] = useState<AppendPreview | null>(null);
+  const [duplicateName, setDuplicateName] = useState<string | null>(null);
+  const [previewing, setPreviewing] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [inventory, setInventory] = useState<ProjectFileEntry[]>([]);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  // The selected File is only read inside handlers (never rendered — the
+  // native input shows its own filename), so a ref avoids a re-render.
+  const fileRef = useRef<File | null>(null);
+
+  const loadInventory = useCallback(async () => {
+    try {
+      setInventory(await getProjectFiles(projectId));
+    } catch {
+      // Inventory is auxiliary; the append form works without it.
+      setInventory([]);
+    }
+  }, [projectId]);
+
+  useEffect(() => {
+    loadInventory();
+  }, [loadInventory]);
+
+  const resetSelection = () => {
+    fileRef.current = null;
+    setPreview(null);
+    setDuplicateName(null);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
+
+  const handleFileChange = async (selected: File | null) => {
+    clearError();
+    setPreview(null);
+    fileRef.current = selected;
+    if (!selected) {
+      setDuplicateName(null);
+      return;
+    }
+
+    setDuplicateName(
+      inventory.some((entry) => entry.original_filename === selected.name) ? selected.name : null,
+    );
+
+    setPreviewing(true);
+    try {
+      setPreview(await previewAddFile(projectId, selected));
+    } catch (err) {
+      handleError(err);
+      resetSelection();
+      showToast(errorDetail(err, "Could not analyze the selected file."), "error");
+    } finally {
+      setPreviewing(false);
+    }
+  };
+
+  const afterAppend = async (message: string) => {
+    await refreshProject(projectId, 1, pageSize);
+    refreshLogs();
+    await loadInventory();
+    showToast(message, "success");
+  };
+
+  const handleAppend = async () => {
+    const file = fileRef.current;
+    if (!file || !preview) return;
+    clearError();
+    setSubmitting(true);
+    try {
+      await addFileToProject(projectId, file);
+      const newColsNote =
+        preview.new_columns.length > 0 ? `, added ${preview.new_columns.length} new column(s)` : "";
+      resetSelection();
+      await afterAppend(`Appended ${preview.incoming_row_count} row(s)${newColsNote}.`);
+    } catch (err) {
+      handleError(err);
+      showToast(errorDetail(err, "Failed to append the file."), "error");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleReappend = async (entry: ProjectFileEntry) => {
+    clearError();
+    setSubmitting(true);
+    try {
+      await reappendProjectFile(projectId, entry.id);
+      await afterAppend(`Re-appended "${entry.original_filename}".`);
+    } catch (err) {
+      handleError(err);
+      showToast(errorDetail(err, "Failed to re-append the file."), "error");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div>
+      <div className="mb-4">
+        <label htmlFor="add-file-input" className="block text-sm font-medium text-gray-700 mb-1">
+          File:
+        </label>
+        <input
+          ref={fileInputRef}
+          type="file"
+          id="add-file-input"
+          data-testid="add-file-input"
+          accept={ACCEPT_ATTR}
+          disabled={previewing || submitting}
+          onChange={(e) => handleFileChange(e.target.files?.[0] ?? null)}
+          className="block w-full text-sm text-gray-700 file:mr-3 file:rounded-md file:border-0 file:bg-blue-50 file:px-3 file:py-2 file:text-sm file:font-medium file:text-blue-700 hover:file:bg-blue-100"
+        />
+        <p className="text-xs text-gray-400 mt-1">
+          Rows are appended below the current data. Matching columns line up; new columns are added
+          with empty cells.
+        </p>
+      </div>
+
+      {previewing && <p className="text-sm text-gray-500 mb-4">Analyzing file…</p>}
+
+      {preview && (
+        <div className="mb-4 rounded-md border border-gray-200 bg-gray-50 p-3 text-sm">
+          <p className="font-medium text-gray-800 mb-2">
+            {preview.incoming_row_count} row(s) will be appended to {preview.current_row_count}.
+          </p>
+          <ul className="space-y-1">
+            <li className="text-green-700">
+              ✓ {preview.matched_columns.length} matching column(s)
+            </li>
+            {preview.new_columns.length > 0 && (
+              <li className="text-blue-700">
+                + New column(s): {preview.new_columns.join(", ")}
+                <span className="text-gray-500"> (empty for existing rows)</span>
+              </li>
+            )}
+            {preview.missing_columns.length > 0 && (
+              <li className="text-amber-700">
+                ⚠ Not in this file: {preview.missing_columns.join(", ")}
+                <span className="text-gray-500"> (empty for new rows)</span>
+              </li>
+            )}
+            {preview.dtype_clashes.map((clash) => (
+              <li key={clash.column} className="text-amber-700">
+                ⚠ &quot;{clash.column}&quot; type differs: {clash.existing_dtype} vs{" "}
+                {clash.incoming_dtype}
+              </li>
+            ))}
+            {duplicateName && (
+              <li className="text-amber-700">
+                ⚠ &quot;{duplicateName}&quot; was already added to this project — appending again
+                will duplicate its rows.
+              </li>
+            )}
+          </ul>
+        </div>
+      )}
+
+      <FormErrorAlert message={error} />
+
+      <div className="flex justify-between mt-2">
+        <button
+          type="button"
+          onClick={handleAppend}
+          disabled={!preview || submitting || previewing}
+          className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-md font-medium transition-colors duration-150 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          <span className="inline-flex items-center gap-2">
+            <LuFilePlus />
+            {preview ? `Append ${preview.incoming_row_count} row(s)` : "Append"}
+          </span>
+        </button>
+        <button
+          type="button"
+          onClick={onClose}
+          className="bg-white border border-gray-300 text-gray-700 hover:bg-gray-50 px-4 py-2 rounded-md font-medium transition-colors duration-150"
+        >
+          Close
+        </button>
+      </div>
+
+      {inventory.length > 0 && (
+        <div className="mt-6 border-t border-gray-200 pt-4">
+          <h3 className="text-sm font-medium text-gray-700 mb-2">Files added to this project</h3>
+          <ul className="space-y-2">
+            {inventory.map((entry) => (
+              <li
+                key={entry.id}
+                className="flex items-center justify-between rounded-md border border-gray-200 px-3 py-2 text-sm"
+              >
+                <span className="truncate text-gray-800" title={entry.original_filename}>
+                  {entry.original_filename}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => handleReappend(entry)}
+                  disabled={submitting}
+                  title="Append this file's rows again (e.g. after a revert)"
+                  className="ml-2 inline-flex shrink-0 items-center gap-1 text-blue-600 hover:text-blue-800 disabled:opacity-50"
+                >
+                  <LuRotateCcw /> Re-append
+                </button>
+              </li>
+            ))}
+          </ul>
+          <p className="text-xs text-gray-400 mt-2">
+            Added files are kept even if their rows are removed by undo or revert.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default AddFilePanel;

--- a/dataloom-frontend/src/Components/files/__tests__/AddFilePanel.test.tsx
+++ b/dataloom-frontend/src/Components/files/__tests__/AddFilePanel.test.tsx
@@ -1,0 +1,128 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import AddFilePanel from "../AddFilePanel";
+import type { AppendPreview, ProjectFileEntry } from "../../../api/projectFiles";
+
+const previewAddFile = vi.fn();
+const addFileToProject = vi.fn();
+const getProjectFiles = vi.fn();
+const reappendProjectFile = vi.fn();
+const refreshProject = vi.fn();
+const refreshLogs = vi.fn();
+const showToast = vi.fn();
+
+vi.mock("../../../api/projectFiles", () => ({
+  previewAddFile: (...args: unknown[]) => previewAddFile(...args),
+  addFileToProject: (...args: unknown[]) => addFileToProject(...args),
+  getProjectFiles: (...args: unknown[]) => getProjectFiles(...args),
+  reappendProjectFile: (...args: unknown[]) => reappendProjectFile(...args),
+}));
+vi.mock("../../../context/ProjectContext", () => ({
+  useProjectContext: () => ({ refreshProject, pageSize: 50 }),
+}));
+vi.mock("../../../context/HistoryRefreshContext", () => ({
+  useHistoryRefresh: () => ({ refreshLogs }),
+}));
+vi.mock("../../../context/ToastContext", () => ({
+  useToast: () => ({ showToast }),
+}));
+
+const PREVIEW: AppendPreview = {
+  matched_columns: ["name"],
+  new_columns: ["city"],
+  missing_columns: ["age"],
+  dtype_clashes: [{ column: "id", existing_dtype: "int", incoming_dtype: "str" }],
+  current_row_count: 3,
+  incoming_row_count: 2,
+};
+
+const INVENTORY: ProjectFileEntry[] = [
+  { id: "f1", original_filename: "feb.csv", uploaded_at: "2026-07-05T00:00:00" },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getProjectFiles.mockResolvedValue([]);
+});
+
+function renderPanel() {
+  render(<AddFilePanel projectId="p1" onClose={vi.fn()} />);
+}
+
+const appendButton = () => screen.getByRole("button", { name: /^append/i });
+
+const chooseFile = () => {
+  const file = new File(["name,city\nDana,Paris"], "feb.csv", { type: "text/csv" });
+  fireEvent.change(screen.getByTestId("add-file-input"), { target: { files: [file] } });
+  return file;
+};
+
+describe("AddFilePanel", () => {
+  it("keeps Append disabled until a preview has loaded, then shows the alignment report", async () => {
+    previewAddFile.mockResolvedValue(PREVIEW);
+    renderPanel();
+
+    expect(appendButton()).toBeDisabled();
+
+    const file = chooseFile();
+    await waitFor(() => expect(appendButton()).toBeEnabled());
+
+    expect(previewAddFile).toHaveBeenCalledWith("p1", file);
+    expect(screen.getByText(/2 row\(s\) will be appended to 3/)).toBeInTheDocument();
+    expect(screen.getByText(/New column\(s\): city/)).toBeInTheDocument();
+    expect(screen.getByText(/Not in this file: age/)).toBeInTheDocument();
+    expect(screen.getByText(/"id" type differs: int vs\s+str/)).toBeInTheDocument();
+  });
+
+  it("appends on confirm and refreshes project data, logs, and inventory", async () => {
+    previewAddFile.mockResolvedValue(PREVIEW);
+    addFileToProject.mockResolvedValue({ total_rows: 5, columns: ["name", "age", "city"] });
+    renderPanel();
+
+    chooseFile();
+    await waitFor(() => expect(appendButton()).toBeEnabled());
+    fireEvent.click(appendButton());
+
+    await waitFor(() => expect(addFileToProject).toHaveBeenCalledWith("p1", expect.any(File)));
+    expect(refreshProject).toHaveBeenCalledWith("p1", 1, 50);
+    expect(refreshLogs).toHaveBeenCalled();
+    expect(showToast).toHaveBeenCalledWith(expect.stringMatching(/Appended 2 row/), "success");
+    // Selection resets so the same flow can be repeated for another file.
+    expect(appendButton()).toBeDisabled();
+  });
+
+  it("resets the selection when the preview fails", async () => {
+    previewAddFile.mockRejectedValue({ response: { data: { detail: "Could not parse" } } });
+    renderPanel();
+
+    chooseFile();
+
+    await waitFor(() => expect(showToast).toHaveBeenCalledWith("Could not parse", "error"));
+    expect(appendButton()).toBeDisabled();
+  });
+
+  it("warns when the selected filename is already in the inventory", async () => {
+    getProjectFiles.mockResolvedValue(INVENTORY);
+    previewAddFile.mockResolvedValue(PREVIEW);
+    renderPanel();
+    await screen.findByRole("button", { name: /re-append/i });
+
+    chooseFile(); // fixture file is named feb.csv, same as the inventory entry
+
+    await waitFor(() => expect(appendButton()).toBeEnabled());
+    expect(screen.getByText(/"feb.csv" was already added/)).toBeInTheDocument();
+  });
+
+  it("lists the inventory and re-appends from it", async () => {
+    getProjectFiles.mockResolvedValue(INVENTORY);
+    reappendProjectFile.mockResolvedValue({ total_rows: 5, columns: ["name"] });
+    renderPanel();
+
+    const reappend = await screen.findByRole("button", { name: /re-append/i });
+    fireEvent.click(reappend);
+
+    await waitFor(() => expect(reappendProjectFile).toHaveBeenCalledWith("p1", "f1"));
+    expect(refreshProject).toHaveBeenCalled();
+    expect(showToast).toHaveBeenCalledWith('Re-appended "feb.csv".', "success");
+  });
+});

--- a/dataloom-frontend/src/Components/workspace/features/addFile.tsx
+++ b/dataloom-frontend/src/Components/workspace/features/addFile.tsx
@@ -1,0 +1,25 @@
+import { LuFilePlus } from "react-icons/lu";
+import AddFilePanel from "../../files/AddFilePanel";
+import { registerFeature } from "../featureRegistry";
+
+/**
+ * Add File feature — append more files to the current project. The docked
+ * panel previews column alignment before confirming and lists the project's
+ * file inventory for re-appending files removed by revert/undo.
+ */
+registerFeature({
+  id: "add-file",
+  panels: [{ name: "AddFilePanel", title: "Add File", component: AddFilePanel }],
+  menu: [
+    {
+      ribbon: "File",
+      group: "Source",
+      order: 0,
+      label: "Add File",
+      icon: LuFilePlus,
+      action: { togglePanel: "AddFilePanel" },
+      disabledInPreview: true,
+      activePanel: "AddFilePanel",
+    },
+  ],
+});

--- a/dataloom-frontend/src/api/index.js
+++ b/dataloom-frontend/src/api/index.js
@@ -24,3 +24,9 @@ export {
   getCorrelationMatrix,
 } from "./profiling";
 export { getChartSuggestions, getChart } from "./visualizations";
+export {
+  previewAddFile,
+  addFileToProject,
+  getProjectFiles,
+  reappendProjectFile,
+} from "./projectFiles";

--- a/dataloom-frontend/src/api/projectFiles.ts
+++ b/dataloom-frontend/src/api/projectFiles.ts
@@ -1,0 +1,93 @@
+/**
+ * API functions for adding files to an existing project (append) and the
+ * project's file inventory.
+ * @module api/projectFiles
+ */
+import client from "./client";
+
+/** A matched column whose simplified dtype differs between the two files. */
+export interface DtypeClash {
+  column: string;
+  existing_dtype: string;
+  incoming_dtype: string;
+}
+
+/** How an incoming file would align with the project's current data. */
+export interface AppendPreview {
+  matched_columns: string[];
+  new_columns: string[];
+  missing_columns: string[];
+  dtype_clashes: DtypeClash[];
+  current_row_count: number;
+  incoming_row_count: number;
+}
+
+/** An entry in the project's file inventory (files added after upload). */
+export interface ProjectFileEntry {
+  id: string;
+  original_filename: string;
+  uploaded_at: string | null;
+}
+
+/** The fields of the append response the panel consumes. */
+export interface AppendResult {
+  total_rows: number;
+  columns: string[];
+}
+
+const asForm = (file: File): FormData => {
+  const form = new FormData();
+  form.append("file", file);
+  return form;
+};
+
+/**
+ * Preview how a file would align with the project's data on append.
+ * Stateless — nothing is stored until {@link addFileToProject} confirms.
+ * @param projectId - The project ID.
+ * @param file - The file to analyze.
+ * @returns Matched/new/missing columns, dtype clashes, and row counts.
+ */
+export const previewAddFile = async (projectId: string, file: File): Promise<AppendPreview> => {
+  const response = await client.post<AppendPreview>(
+    `/projects/${projectId}/files/preview`,
+    asForm(file),
+  );
+  return response.data;
+};
+
+/**
+ * Append a file's rows to the project and store it in the file inventory.
+ * @param projectId - The project ID.
+ * @param file - The file to append.
+ * @returns The combined project data.
+ */
+export const addFileToProject = async (projectId: string, file: File): Promise<AppendResult> => {
+  const response = await client.post<AppendResult>(`/projects/${projectId}/files`, asForm(file));
+  return response.data;
+};
+
+/**
+ * Fetch the project's file inventory.
+ * @param projectId - The project ID.
+ * @returns Files added to the project, oldest first.
+ */
+export const getProjectFiles = async (projectId: string): Promise<ProjectFileEntry[]> => {
+  const response = await client.get<ProjectFileEntry[]>(`/projects/${projectId}/files`);
+  return response.data;
+};
+
+/**
+ * Append an inventory file's rows to the project again (e.g. after a revert
+ * removed them).
+ * @param projectId - The project ID.
+ * @param fileId - The inventory file ID.
+ * @returns The combined project data.
+ */
+export const reappendProjectFile = async (
+  projectId: string,
+  fileId: string,
+): Promise<AppendResult> => {
+  const response = await client.post<AppendResult>(`/projects/${projectId}/files/${fileId}/append`);
+  return response.data;
+};


### PR DESCRIPTION
…ntory

## Description

- append via pd.concat outer join: matching columns stack rows, new columns are unioned with empty cells for the other side
- addFile is a logged, replayable operation dispatched through TRANSFORMATION_REGISTRY, so save/revert/undo reconstruction from the original file plus the log chain stays correct
- new project_files table (+ Alembic migration) forms an immutable per-project file inventory; files survive revert/undo and can be re-appended from the panel
- endpoints under /projects/{id}/files: stateless alignment preview (matched/new/missing columns, dtype clashes), append, list, re-append; addFile is rejected on /transform so file paths cannot be injected
- AddFilePanel docked in the right side panel with preview-then-confirm UX, registered as a File > Source ribbon feature
- warn in the preview when the selected filename is already in the inventory, since appending again duplicates its rows
- tests added and passing: 19 backend (append/analyze units, endpoint flows incl. replay and delete cleanup), 5 frontend (panel behavior)

Fixes #411 

## Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

- [X] Existing tests pass
- [X] New tests added
- [X] Manual testing

## Screenshots
<img width="1915" height="879" alt="image" src="https://github.com/user-attachments/assets/7e385a3e-236b-4bf2-9718-4d6884d78932" />


## Checklist

- [X] My code follows the project's style guidelines
- [X] I have performed a self-review
- [X] I have added/updated documentation as needed
- [X] My changes generate no new warnings
- [X] Tests pass locally
