### PR TITLE
fix: show active state for summary ribbon item

### DIFF
--- a/dataloom-frontend/src/Components/MenuNavbar.jsx
+++ b/dataloom-frontend/src/Components/MenuNavbar.jsx
@@ -29,7 +29,7 @@ const MenuNavbar = ({ projectId }) => {
 
   const { updateData, refreshProject, pageSize, projectName, isPreviewMode } = useProjectContext();
   const { activePanel, openPanel, togglePanel, closePanel } = usePanel();
-  const { openTab } = useWorkspaceTabs();
+  const { openTab, activeTabId } = useWorkspaceTabs();
   const { refreshLogs, refreshCheckpoints } = useHistoryRefresh();
   const { showColumnProfiles, toggleColumnProfiles } = useColumnProfilesView();
 
@@ -133,7 +133,11 @@ const MenuNavbar = ({ projectId }) => {
       if (toggle) togglePanel(toggle);
     },
     disabled: item.disabledInPreview ? isPreviewMode : false,
-    active: item.activePanel ? activePanel === item.activePanel : false,
+    active: item.activePanel
+      ? activePanel === item.activePanel
+      : item.action?.openTab
+        ? activeTabId === item.action.openTab.id
+        : false,
   }));
 
   const allItems = [...coreItems, ...featureItems];


### PR DESCRIPTION
## Description

Fixes the Profiling ribbon active state so the **Summary** item is highlighted when the Summary workspace tab is active.

Previously, feature menu items only derived their active state from `activePanel`, so tab-based items like Summary did not appear active even after being opened.

Fixes #423 

## Type of Change

* [x] Bug fix

## How Has This Been Tested?

Manually verified the following scenario:

* Opened a project.

* Navigated to the **Profiling** ribbon tab.

* Clicked **Summary**.

* Confirmed the Summary tab opens and the Summary ribbon item is highlighted.

* [x] Manual testing

## Screenshot
<img width="548" height="356" alt="Screenshot 2026-07-06 at 00 30 37" src="https://github.com/user-attachments/assets/86f52346-bfec-401d-8c7e-48978da73982" />


## Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review
* [x] I have added/updated documentation as needed
* [x] My changes generate no new warnings
* [x] Tests pass locally
