### PR TITLE
fix(transform): reject dropDuplicate keep=true with 422 instead of 500

### DIFF
--- a/dataloom-backend/app/schemas.py
+++ b/dataloom-backend/app/schemas.py
@@ -235,6 +235,16 @@ class DropDuplicates(BaseModel):
     columns: str
     keep: DropDup | bool
 
+    @field_validator("keep")
+    @classmethod
+    def keep_bool_must_be_false(cls, v):
+        # pandas.drop_duplicates only accepts "first", "last", or False.
+        # False means "drop all duplicates"; True is not a valid option, so
+        # reject it here instead of letting pandas raise a 500 downstream.
+        if v is True:
+            raise ValueError('keep must be "first", "last", or false')
+        return v
+
 
 class AdvQuery(BaseModel):
     """Parameters for an advanced pandas query filter."""

--- a/dataloom-backend/tests/test_transform_http_semantics.py
+++ b/dataloom-backend/tests/test_transform_http_semantics.py
@@ -129,6 +129,27 @@ def test_transform_add_col_without_valid_name_returns_422(client, project_id, ad
     assert response.status_code == 422
 
 
+def test_transform_drop_duplicate_keep_true_returns_422(client, project_id):
+    # keep=True passes schema typing (DropDup | bool) but pandas rejects it;
+    # it must be a clean 422, not an Internal server error 500.
+    response = client.post(
+        f"/projects/{project_id}/transform",
+        json={"operation_type": "dropDuplicate", "drop_duplicate": {"columns": "name", "keep": True}},
+    )
+
+    assert response.status_code == 422
+
+
+@pytest.mark.parametrize("keep", ["first", "last", False])
+def test_transform_drop_duplicate_valid_keep_succeeds(client, project_id, keep):
+    response = client.post(
+        f"/projects/{project_id}/transform",
+        json={"operation_type": "dropDuplicate", "drop_duplicate": {"columns": "name", "keep": keep}},
+    )
+
+    assert response.status_code == 200, response.text
+
+
 def test_transform_returns_500_on_unexpected_exception(client, project_id, monkeypatch):
     # Patch the endpoint's imported service module to force an unexpected crash.
     from app.api.endpoints import transformations as transformations_endpoint

--- a/dataloom-backend/tests/test_transformations.py
+++ b/dataloom-backend/tests/test_transformations.py
@@ -439,6 +439,21 @@ class TestDropDuplicates:
         with pytest.raises(TransformationError):
             drop_duplicates(sample_df, "nonexistent", "first")
 
+    def test_schema_rejects_keep_true(self):
+        # keep=True is not a valid pandas option and would crash downstream;
+        # the schema must reject it instead of forwarding it to drop_duplicates.
+        from app import schemas
+
+        with pytest.raises(ValueError):
+            schemas.DropDuplicates(columns="name", keep=True)
+
+    @pytest.mark.parametrize("keep", ["first", "last", False])
+    def test_schema_accepts_valid_keep(self, keep):
+        from app import schemas
+
+        params = schemas.DropDuplicates(columns="name", keep=keep)
+        assert params.keep == keep
+
 
 class TestAdvancedQuery:
     def test_simple_query(self, sample_df):


### PR DESCRIPTION


The `dropDuplicate` transform returns `500 Internal Server Error` when a request sends `keep: true`.

The `DropDuplicates` request schema types `keep` as `DropDup | bool` (`dataloom-backend/app/schemas.py`), so `{"keep": true}` passes validation. `drop_duplicates` then forwards it verbatim to pandas (`return df.drop_duplicates(subset=col_list, keep=keep)` in `dataloom-backend/app/services/transformation_service.py`), but `pandas.DataFrame.drop_duplicates` only accepts `"first"`, `"last"`, or `False` and raises `ValueError: keep must be either "first", "last" or False` for `keep=True`. That `ValueError` is not a `TransformationError`, so the `/transform` endpoint catches it in its generic `except Exception` branch (`dataloom-backend/app/api/endpoints/transformations.py`) and returns `500 {"detail": "Internal server error"}` instead of a clean client error.

This adds a `field_validator("keep")` on `DropDuplicates` that rejects `keep=True` at the request-validation boundary, so the endpoint returns a `422` before the handler runs. The valid paths are untouched: `"first"` and `"last"` still work, and `False` still means "drop all duplicates". The fix mirrors the existing declarative validators in the same file (e.g. `AddColumn.name_must_not_be_blank`, `StringReplaceParams.find_value_must_not_be_empty`) and follows CONTRIBUTING ("Use Pydantic schemas in `app/schemas.py` for request/response validation").

This matches the project's existing "bad input should be a clean error, not a 500" pattern (see the graceful-failure assertions in `tests/test_multiformat_upload.py` and the sibling `*_returns_422` HTTP tests).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

Backend suite run from `dataloom-backend` with `DATABASE_URL=sqlite:///./test.db` (Python 3.12):

- `uv run pytest` -> full backend suite passes (471 passed).
- Targeted: `uv run pytest tests/test_transform_http_semantics.py tests/test_transformations.py::TestDropDuplicates -v` -> 21 passed, including the new cases:
  - schema level: `keep=True` raises; `keep in {"first", "last", False}` is accepted.
  - HTTP level: `POST /projects/{id}/transform` with `dropDuplicate` + `keep=true` returns `422`; `keep in {"first", "last", False}` returns `200`.
- `uv run ruff check .` and `uv run ruff format --check .` -> clean.
- Red/green confirmed: with the validator temporarily neutralized, the `keep=true` HTTP test returns `500` (with the pandas `ValueError` traceback) and the schema test does not raise; with the fix in place both pass. So the tests genuinely exercise the fix rather than passing vacuously.

- [x] Existing tests pass
- [x] New tests added
- [ ] Manual testing

## Screenshots (if applicable)

N/A (backend request-validation change).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [ ] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally
