### PR TITLE
fix: enforce 72-byte password limit on reset and change endpoints

### DIFF
--- a/dataloom-backend/app/api/endpoints/auth.py
+++ b/dataloom-backend/app/api/endpoints/auth.py
@@ -102,8 +102,6 @@ async def reset_password(
     _rate_limit: None = Depends(rate_limit),
 ):
     """Reset password using a valid reset token."""
-    if len(payload.new_password) < 8:
-        raise HTTPException(status_code=422, detail="Password must be at least 8 characters")
     try:
         reset_token = auth_service.validate_reset_token(db, payload.token)
         auth_service.reset_user_password(db, reset_token, payload.new_password)
@@ -133,9 +131,6 @@ def change_password(
     db: Session = Depends(database.get_db),
 ):
     """Change the currently authenticated user's password."""
-    if len(payload.new_password) < 8:
-        raise HTTPException(status_code=422, detail="Password must be at least 8 characters")
-
     try:
         auth_service.change_user_password(
             db,

--- a/dataloom-backend/app/schemas.py
+++ b/dataloom-backend/app/schemas.py
@@ -620,6 +620,16 @@ class ResetPasswordRequest(BaseModel):
     token: str
     new_password: str
 
+    @field_validator("new_password")
+    @classmethod
+    def password_length_ok(cls, v: str) -> str:
+        byte_len = len(v.encode("utf-8"))
+        if byte_len < 8:
+            raise ValueError("password must be at least 8 characters")
+        if byte_len > 72:
+            raise ValueError("password must be at most 72 bytes")
+        return v
+
 
 class UpdateEmailRequest(BaseModel):
     """Request body for updating the authenticated user's email."""
@@ -632,6 +642,16 @@ class ChangePasswordRequest(BaseModel):
 
     current_password: str
     new_password: str
+
+    @field_validator("new_password")
+    @classmethod
+    def password_length_ok(cls, v: str) -> str:
+        byte_len = len(v.encode("utf-8"))
+        if byte_len < 8:
+            raise ValueError("password must be at least 8 characters")
+        if byte_len > 72:
+            raise ValueError("password must be at most 72 bytes")
+        return v
 
 
 class DeleteAccountRequest(BaseModel):

--- a/dataloom-backend/tests/test_auth.py
+++ b/dataloom-backend/tests/test_auth.py
@@ -170,6 +170,18 @@ class TestProfileManagement:
 
         assert response.status_code == 422
 
+    def test_change_password_long_password_returns_422(self, client):
+        """Should reject new passwords longer than bcrypt's 72-byte limit with a clean 422."""
+        response = client.patch(
+            "/auth/me/password",
+            json={
+                "current_password": "testpassword",
+                "new_password": "a" * 73,
+            },
+        )
+
+        assert response.status_code == 422
+
     def test_delete_account_success(self, client, test_user, db):
         response = client.request(
             "DELETE",
@@ -346,6 +358,26 @@ class TestPasswordReset:
         response = anon_client.post(
             "/auth/reset-password",
             json={"token": raw_token, "new_password": "short"},
+        )
+        assert response.status_code == 422
+
+    def test_reset_password_long_password(self, anon_client, db):
+        """Should reject passwords longer than bcrypt's 72-byte limit with a clean 422."""
+        user = create_user(db, "long@example.com", "oldpassword123")
+
+        raw_token = secrets.token_urlsafe(32)
+        token_hash = hashlib.sha256(raw_token.encode()).hexdigest()
+        reset_token = models.PasswordResetToken(
+            user_id=user.id,
+            token_hash=token_hash,
+            expires_at=datetime.now(UTC) + timedelta(hours=1),
+        )
+        db.add(reset_token)
+        db.commit()
+
+        response = anon_client.post(
+            "/auth/reset-password",
+            json={"token": raw_token, "new_password": "a" * 73},
         )
         assert response.status_code == 422
 


### PR DESCRIPTION


Signup already validates a new password against bcrypt's supported length range
(8..72 bytes) via a `password_length_ok` field validator on `SignupRequest` in
`dataloom-backend/app/schemas.py`, and `tests/test_auth.py` asserts a 73-character
signup password returns a clean `422`.

The reset-password and change-password flows only enforced the **lower** bound.
`ResetPasswordRequest` and `ChangePasswordRequest` declared `new_password: str`
with no validator, and the endpoints did a manual `len(payload.new_password) < 8`
check. An over-72-byte `new_password` therefore passed validation and reached
`auth_service.hash_password`, which calls `bcrypt.hashpw`. In bcrypt 5.x that
raises `ValueError` for inputs longer than 72 bytes (it no longer silently
truncates), and both handlers wrap the call in
`except ValueError as e: raise HTTPException(status_code=400, detail=str(e))`, so
the raw internal bcrypt message is returned verbatim to the API client:

```
PATCH /auth/me/password
{"current_password": "testpassword", "new_password": "aaaa... (73 chars)"}

400 {"detail": "password cannot be longer than 72 bytes, truncate manually if necessary (e.g. my_password[:72])"}
```

`POST /auth/reset-password` with a valid token and an over-72-byte `new_password`
returns the identical 400. This is inconsistent with signup (which returns 422)
and leaks an internal library message as if it were an API contract error.

This change adds the same byte-based `password_length_ok` validator (mirroring
`SignupRequest`) to `ResetPasswordRequest` and `ChangePasswordRequest`, so both
bounds are enforced at the schema layer and an out-of-range password now fails
Pydantic validation and returns a clean `422`, matching signup. The now-redundant
manual minimum-length checks in the two endpoints are removed. The endpoints'
existing `except ValueError` blocks are unchanged and still handle their genuine
business errors (invalid/expired/used reset token, incorrect current password).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

Added two regression tests to `dataloom-backend/tests/test_auth.py`, mirroring the
existing `test_signup_long_password_returns_422`:

- `test_change_password_long_password_returns_422` sends a 73-character
  `new_password` to `PATCH /auth/me/password` and asserts `422`.
- `test_reset_password_long_password` seeds a valid reset token and sends a
  73-character `new_password` to `POST /auth/reset-password`, asserting `422`.

Verified red -> green: with the schema/endpoint changes reverted (tests kept),
both new tests fail with `assert 400 == 422` (the endpoints leak the bcrypt
message as a 400); with the change applied, both pass. Signup's existing
long-password test passes in both states.

Commands run from `dataloom-backend` on Python 3.12 (`DATABASE_URL` set to a
SQLite URL, matching CI):

```
uv run ruff check app/schemas.py app/api/endpoints/auth.py tests/test_auth.py   # All checks passed
uv run ruff format --check app/schemas.py app/api/endpoints/auth.py tests/test_auth.py   # already formatted
uv run pytest tests/test_auth.py -k long_password   # 3 passed
uv run pytest tests/test_auth.py   # 37 passed
uv run pytest   # full backend suite, 481 passed
```

- [x] Existing tests pass
- [x] New tests added
- [ ] Manual testing

## Screenshots (if applicable)

N/A (backend validation change).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally
