### PR TITLE
fix: translate page-local row index to global DataFrame index for add/delete/edit row

### DIFF
--- a/dataloom-frontend/src/Components/Table.tsx
+++ b/dataloom-frontend/src/Components/Table.tsx
@@ -173,9 +173,10 @@ const Table = ({ projectId, showColumnProfiles = false }: TableProps) => {
 
   const handleAddRow = async (index: number) => {
     try {
+      const globalIndex = (page - 1) * pageSize + index;
       const response = await applyTransform({
         operation_type: ADD_ROW,
-        row_params: { index },
+        row_params: { index: globalIndex },
       });
       updateTableData(response);
       refreshProject(projectId, 1, pageSize);
@@ -226,9 +227,10 @@ const Table = ({ projectId, showColumnProfiles = false }: TableProps) => {
 
   const handleDeleteRow = async (index: number) => {
     try {
+      const globalIndex = (page - 1) * pageSize + index;
       const response = await applyTransform({
         operation_type: DELETE_ROW,
-        row_params: { index },
+        row_params: { index: globalIndex },
       });
       updateTableData(response);
       refreshProject(projectId, 1, pageSize);
@@ -328,11 +330,12 @@ const Table = ({ projectId, showColumnProfiles = false }: TableProps) => {
             ? (columnOrder[cellIndex - 1] as number) + 1
             : cellIndex;
 
+      const globalRowIndex = (page - 1) * pageSize + rowIndex;
       const response = await applyTransform({
         operation_type: CHANGE_CELL_VALUE,
         change_cell_value: {
           col_index: backendColIndex,
-          row_index: rowIndex,
+          row_index: globalRowIndex,
           fill_value: newValue,
         },
       });


### PR DESCRIPTION
## Bug

On any page > 1, row-level operations (cell edit, add row, delete row) send a **page-local** row index (0-based within the visible page) to the backend, which treats it as a global DataFrame index. This silently corrupts the wrong row.

### Affected operations

- **Cell edit** (\handleEditCell\, line 321) — writes \
ewValue\ to the wrong cell
- **Add row** (\handleAddRow\, line 178) — inserts blank row at the wrong position
- **Delete row** (\handleDeleteRow\, line 231) — deletes the wrong row

The corrupted index self-propagates through undo/save/revert because the change log stores the page-local index.

## Fix

Add \(page - 1) * pageSize\ offset to the row index before sending to the backend, converting page-local to global DataFrame index. Column index translation (via \columnOrder\) was already correct — only row indices were missing the offset.

## Verification

- Lint: clean
- Tests: 156/156 passing