### PR TITLE
chore: migrate transform forms to TypeScript and wire TS into the lint toolchain

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,6 +26,7 @@ jobs:
     outputs:
       eslint: ${{ steps.eslint.outcome }}
       prettier: ${{ steps.prettier.outcome }}
+      typecheck: ${{ steps.typecheck.outcome }}
     defaults:
       run:
         working-directory: dataloom-frontend
@@ -44,15 +45,20 @@ jobs:
       - name: ESLint
         id: eslint
         continue-on-error: true
-        run: npx eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0
+        run: npx eslint . --ext js,jsx,ts,tsx --report-unused-disable-directives --max-warnings 0
 
       - name: Prettier
         id: prettier
         continue-on-error: true
         run: npx prettier --check "src/**/*.{js,jsx,ts,tsx,css,md}"
 
+      - name: TypeScript
+        id: typecheck
+        continue-on-error: true
+        run: npx tsc --noEmit
+
       - name: Fail if checks failed
-        if: steps.eslint.outcome == 'failure' || steps.prettier.outcome == 'failure'
+        if: steps.eslint.outcome == 'failure' || steps.prettier.outcome == 'failure' || steps.typecheck.outcome == 'failure'
         run: exit 1
 
   backend-lint:
@@ -128,6 +134,7 @@ jobs:
         env:
           ESLINT: ${{ needs.frontend-lint.outputs.eslint }}
           PRETTIER: ${{ needs.frontend-lint.outputs.prettier }}
+          TYPECHECK: ${{ needs.frontend-lint.outputs.typecheck }}
           RUFF_LINT: ${{ needs.backend-lint.outputs.ruff-lint }}
           RUFF_FORMAT: ${{ needs.backend-lint.outputs.ruff-format }}
           BEHIND_COUNT: ${{ needs.rebase-check.outputs.behind_count }}
@@ -160,10 +167,12 @@ jobs:
 
             const eslintFailed = process.env.ESLINT === 'failure';
             const prettierFailed = process.env.PRETTIER === 'failure';
-            if (eslintFailed || prettierFailed) {
+            const typecheckFailed = process.env.TYPECHECK === 'failure';
+            if (eslintFailed || prettierFailed || typecheckFailed) {
               let s = '### Frontend\n\n';
-              if (eslintFailed) s += '- **ESLint:** Run `npx eslint --fix . --ext js,jsx` in `dataloom-frontend/`\n';
+              if (eslintFailed) s += '- **ESLint:** Run `npx eslint --fix . --ext js,jsx,ts,tsx` in `dataloom-frontend/`\n';
               if (prettierFailed) s += '- **Prettier:** Run `npx prettier --write "src/**/*.{js,jsx,ts,tsx,css,md}"` in `dataloom-frontend/`\n';
+              if (typecheckFailed) s += '- **TypeScript:** Run `npx tsc --noEmit` in `dataloom-frontend/` and fix the reported errors\n';
               sections.push(s);
             }
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ npm install                        # Install dependencies
 npm run dev                        # Start dev server (port 3200)
 npm run build                      # Production build
 npm run test                       # Run all tests (vitest)
-npm run lint                       # ESLint
+npm run lint                       # ESLint (js/jsx/ts/tsx) + TypeScript (tsc --noEmit)
 npm run format                     # Prettier
 ```
 

--- a/dataloom-frontend/.eslintrc.cjs
+++ b/dataloom-frontend/.eslintrc.cjs
@@ -19,9 +19,23 @@ module.exports = {
   },
   overrides: [
     {
-      files: ["**/__tests__/**/*.{js,jsx}", "**/*.test.{js,jsx}"],
+      files: ["**/*.{ts,tsx}"],
+      parser: "@typescript-eslint/parser",
+      rules: {
+        // Covered by tsc (noUnusedLocals); the core rule false-positives on
+        // type-only constructs like interface members and type imports.
+        "no-unused-vars": "off",
+        "no-undef": "off",
+      },
+    },
+    {
+      files: ["**/__tests__/**/*.{js,jsx,ts,tsx}", "**/*.test.{js,jsx,ts,tsx}"],
       env: { jest: true },
       globals: { vi: "readonly" },
+      rules: {
+        // Anonymous wrapper components (testing-library `wrapper:`) don't need names.
+        "react/display-name": "off",
+      },
     },
   ],
 };

--- a/dataloom-frontend/package-lock.json
+++ b/dataloom-frontend/package-lock.json
@@ -24,6 +24,7 @@
         "@testing-library/user-event": "^14.5.2",
         "@types/react": "^18.2.66",
         "@types/react-dom": "^18.2.22",
+        "@typescript-eslint/parser": "^8.63.0",
         "@vitejs/plugin-react": "^4.2.1",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
@@ -35,6 +36,7 @@
         "prettier": "^3.2.5",
         "tailwindcss": "^4.3.1",
         "tw-animate-css": "^1.4.0",
+        "typescript": "^6.0.3",
         "vite": "^5.2.0",
         "vitest": "^1.6.0"
       },
@@ -2032,6 +2034,213 @@
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.63.0.tgz",
+      "integrity": "sha512-gwh4gvvlaVDKKxyfxMG+Gnu1u9X0OQBwyGLkbwB65dIzBKnxeRiJlNFqlI3zwVhNXJIs6qV7mlFCn/BIajlVig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.63.0",
+        "@typescript-eslint/types": "8.63.0",
+        "@typescript-eslint/typescript-estree": "8.63.0",
+        "@typescript-eslint/visitor-keys": "8.63.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.63.0.tgz",
+      "integrity": "sha512-e5dh0/UI0ok53AlZ5wRkXCB32z/f2jUZqPR/ygAw5WYaSw8j9EoJWlS7wQjr/dmOaqWjnPIn2m+HhVPCMWGZVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.63.0",
+        "@typescript-eslint/types": "^8.63.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.63.0.tgz",
+      "integrity": "sha512-uUyfMWCnDSN8bCpcrY8nGP2BLkQ9Xn0GsipcONcpIDWhwhO4ZSyHvyS14U3X75mzxWxL3I2UZIrenTzdzcJO8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.63.0",
+        "@typescript-eslint/visitor-keys": "8.63.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.63.0.tgz",
+      "integrity": "sha512-sUAbkulqBAsncKnbRP3+7CtQFRKicexnj7ZwNC6ddCR7EmrXvjvdCYMJbUIqMd6lwoEriZjwLo08aS5tSjVMHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.63.0.tgz",
+      "integrity": "sha512-xyLtl9DUBBFrcJS4x2pIqGLH68/tC2uOa4Z7pUteW09D3bXnnXUom4dyPikzWgB7llmIc1zoeI3aoUdC4rPK/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.63.0.tgz",
+      "integrity": "sha512-ygBkU+B7ex5UI/gKhaqexWev79uISfIv7XQCRNYO/jmD8rGLPyWLAb3KMRT6nd8Gt9bmUBi9+iX6tBdYfOY81Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.63.0",
+        "@typescript-eslint/tsconfig-utils": "8.63.0",
+        "@typescript-eslint/types": "8.63.0",
+        "@typescript-eslint/visitor-keys": "8.63.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.63.0.tgz",
+      "integrity": "sha512-UexrHGnGTpbuQHct2ExOc2ZcFbGUS9FOesCxxqdBGcpI1BxYu/LZ6U8Aq6/72XtF/qRBk9nhuGHFJIXXMhPMdw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.63.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
@@ -3853,6 +4062,24 @@
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
       }
     },
     "node_modules/file-entry-cache": {
@@ -6005,6 +6232,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/pkg-types": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
@@ -7098,6 +7338,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
     "node_modules/tinypool": {
       "version": "0.8.4",
       "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz",
@@ -7145,6 +7402,19 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
       }
     },
     "node_modules/tw-animate-css": {
@@ -7269,6 +7539,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/ufo": {

--- a/dataloom-frontend/package.json
+++ b/dataloom-frontend/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
+    "lint": "eslint . --ext js,jsx,ts,tsx --report-unused-disable-directives --max-warnings 0 && tsc --noEmit",
     "format": "prettier --write \"src/**/*.{js,jsx,ts,tsx,css,md}\"",
     "preview": "vite preview",
     "test": "vitest run"
@@ -31,6 +31,7 @@
     "@testing-library/user-event": "^14.5.2",
     "@types/react": "^18.2.66",
     "@types/react-dom": "^18.2.22",
+    "@typescript-eslint/parser": "^8.63.0",
     "@vitejs/plugin-react": "^4.2.1",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
@@ -42,6 +43,7 @@
     "prettier": "^3.2.5",
     "tailwindcss": "^4.3.1",
     "tw-animate-css": "^1.4.0",
+    "typescript": "^6.0.3",
     "vite": "^5.2.0",
     "vitest": "^1.6.0"
   }

--- a/dataloom-frontend/src/Components/forms/AdvQueryFilterForm.tsx
+++ b/dataloom-frontend/src/Components/forms/AdvQueryFilterForm.tsx
@@ -1,5 +1,4 @@
-import { useState } from "react";
-import PropTypes from "prop-types";
+import { useState, FormEvent } from "react";
 import { transformProject } from "../../api";
 import { ADV_QUERY_FILTER } from "../../constants/operationTypes";
 import useError from "../../hooks/useError";
@@ -8,7 +7,7 @@ import FormErrorAlert from "../common/FormErrorAlert";
 import { useProjectContext } from "../../context/ProjectContext";
 import Button from "../common/Button";
 
-const AdvQueryFilterForm = ({ projectId, onClose }) => {
+const AdvQueryFilterForm = ({ projectId, onClose }: { projectId: string; onClose: () => void }) => {
   const [query, setQuery] = useState("");
   const [loading, setLoading] = useState(false);
   const { error, clearError, handleError } = useError();
@@ -19,7 +18,7 @@ const AdvQueryFilterForm = ({ projectId, onClose }) => {
     onClose,
   });
 
-  const handleSubmit = async (e) => {
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setLoading(true);
     clearError();
@@ -31,7 +30,7 @@ const AdvQueryFilterForm = ({ projectId, onClose }) => {
       const response = await transformProject(projectId, payload, { preview: true });
       enterPreviewMode(response.columns, response.rows, response.dtypes, { projectId, payload });
     } catch (err) {
-      console.error("Error applying query:", err.message);
+      console.error("Error applying query:", (err as Error).message);
       handleError(err);
     } finally {
       setLoading(false);
@@ -80,11 +79,6 @@ const AdvQueryFilterForm = ({ projectId, onClose }) => {
       </form>
     </div>
   );
-};
-
-AdvQueryFilterForm.propTypes = {
-  projectId: PropTypes.string.isRequired,
-  onClose: PropTypes.func.isRequired,
 };
 
 export default AdvQueryFilterForm;

--- a/dataloom-frontend/src/Components/forms/CastDataTypeForm.tsx
+++ b/dataloom-frontend/src/Components/forms/CastDataTypeForm.tsx
@@ -1,5 +1,4 @@
-import { useState } from "react";
-import PropTypes from "prop-types";
+import { useState, FormEvent } from "react";
 import { transformProject } from "../../api";
 import { CAST_DATA_TYPE } from "../../constants/operationTypes";
 import { useToast } from "../../context/ToastContext";
@@ -19,7 +18,7 @@ const TARGET_TYPES = [
   { value: "datetime", label: "DateTime" },
 ];
 
-const CastDataTypeForm = ({ projectId, onClose }) => {
+const CastDataTypeForm = ({ projectId, onClose }: { projectId: string; onClose: () => void }) => {
   const { showToast } = useToast();
 
   const [column, setColumn] = useState("");
@@ -32,7 +31,7 @@ const CastDataTypeForm = ({ projectId, onClose }) => {
     handleError,
     onClose,
   });
-  const handleSubmit = async (e) => {
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
     clearError();
@@ -61,7 +60,11 @@ const CastDataTypeForm = ({ projectId, onClose }) => {
       });
     } catch (err) {
       console.error("Error casting data type:", err);
-      showToast(err.response?.data?.detail || "Failed to cast data type.", "error");
+      showToast(
+        (err as { response?: { data?: { detail?: string } } }).response?.data?.detail ||
+          "Failed to cast data type.",
+        "error",
+      );
       handleError(err);
     } finally {
       setLoading(false);
@@ -113,11 +116,6 @@ const CastDataTypeForm = ({ projectId, onClose }) => {
       </form>
     </div>
   );
-};
-
-CastDataTypeForm.propTypes = {
-  projectId: PropTypes.string.isRequired,
-  onClose: PropTypes.func.isRequired,
 };
 
 export default CastDataTypeForm;

--- a/dataloom-frontend/src/Components/forms/DropDuplicateForm.tsx
+++ b/dataloom-frontend/src/Components/forms/DropDuplicateForm.tsx
@@ -1,5 +1,4 @@
-import { useState } from "react";
-import PropTypes from "prop-types";
+import { useState, FormEvent } from "react";
 import { transformProject } from "../../api";
 import { DROP_DUPLICATE } from "../../constants/operationTypes";
 import useError from "../../hooks/useError";
@@ -15,8 +14,8 @@ const KEEP_OPTIONS = [
   { value: "last", label: "Last" },
 ];
 
-const DropDuplicateForm = ({ projectId, onClose }) => {
-  const [columns, setColumns] = useState([]);
+const DropDuplicateForm = ({ projectId, onClose }: { projectId: string; onClose: () => void }) => {
+  const [columns, setColumns] = useState<string[]>([]);
   const [keep, setKeep] = useState("first");
   const { error, setError, clearError, handleError } = useError();
   const { isPreviewMode, enterPreviewMode, cancelPreview } = useProjectContext();
@@ -26,7 +25,7 @@ const DropDuplicateForm = ({ projectId, onClose }) => {
     onClose,
   });
 
-  const handleSubmit = async (e) => {
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     clearError();
 
@@ -93,11 +92,6 @@ const DropDuplicateForm = ({ projectId, onClose }) => {
       </form>
     </div>
   );
-};
-
-DropDuplicateForm.propTypes = {
-  projectId: PropTypes.string.isRequired,
-  onClose: PropTypes.func.isRequired,
 };
 
 export default DropDuplicateForm;

--- a/dataloom-frontend/src/Components/forms/FilterForm.tsx
+++ b/dataloom-frontend/src/Components/forms/FilterForm.tsx
@@ -1,5 +1,4 @@
-import { useState } from "react";
-import PropTypes from "prop-types";
+import { useState, ChangeEvent, FormEvent } from "react";
 import { transformProject } from "../../api";
 import { FILTER } from "../../constants/operationTypes";
 import useError from "../../hooks/useError";
@@ -20,7 +19,7 @@ const CONDITIONS = [
   { value: "contains", label: "contains" },
 ];
 
-const FilterForm = ({ projectId, onClose }) => {
+const FilterForm = ({ projectId, onClose }: { projectId: string; onClose: () => void }) => {
   const [filterParams, setFilterParams] = useState({
     column: "",
     condition: "=",
@@ -35,14 +34,14 @@ const FilterForm = ({ projectId, onClose }) => {
     onClose,
   });
 
-  const handleInputChange = (e) => {
+  const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
     setFilterParams({
       ...filterParams,
       [e.target.name]: e.target.value,
     });
   };
 
-  const handleSubmit = async (e) => {
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     clearError();
 
@@ -65,7 +64,8 @@ const FilterForm = ({ projectId, onClose }) => {
         payload,
       });
     } catch (err) {
-      console.error("Error applying filter:", err.response?.data || err.message);
+      const e = err as { response?: { data?: unknown }; message?: string };
+      console.error("Error applying filter:", e.response?.data || e.message);
       handleError(err);
     } finally {
       setLoading(false);
@@ -132,11 +132,6 @@ const FilterForm = ({ projectId, onClose }) => {
       </form>
     </div>
   );
-};
-
-FilterForm.propTypes = {
-  projectId: PropTypes.string.isRequired,
-  onClose: PropTypes.func.isRequired,
 };
 
 export default FilterForm;

--- a/dataloom-frontend/src/Components/forms/GroupByForm.tsx
+++ b/dataloom-frontend/src/Components/forms/GroupByForm.tsx
@@ -1,5 +1,4 @@
-import { useState, useRef, useEffect } from "react";
-import PropTypes from "prop-types";
+import { useState, useRef, useEffect, FormEvent } from "react";
 import { transformProject } from "../../api";
 import { GROUPBY } from "../../constants/operationTypes";
 import useError from "../../hooks/useError";
@@ -12,14 +11,14 @@ import Select from "../common/Select";
 import Button from "../common/Button";
 import { AGG_FUNCTIONS } from "../../constants/aggregations";
 
-const GroupByForm = ({ projectId, onClose }) => {
+const GroupByForm = ({ projectId, onClose }: { projectId: string; onClose: () => void }) => {
   const {
     columns: availableColumns,
     isPreviewMode,
     enterPreviewMode,
     cancelPreview,
   } = useProjectContext();
-  const [selectedColumns, setSelectedColumns] = useState([]);
+  const [selectedColumns, setSelectedColumns] = useState<string[]>([]);
   const [aggColumn, setAggColumn] = useState("");
   const [aggFunction, setAggFunction] = useState("sum");
   const [loading, setLoading] = useState(false);
@@ -40,7 +39,7 @@ const GroupByForm = ({ projectId, onClose }) => {
     };
   }, []);
 
-  const handleSubmit = async (e) => {
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (selectedColumns.length === 0) return;
     if (!aggColumn) return;
@@ -95,7 +94,7 @@ const GroupByForm = ({ projectId, onClose }) => {
           <ColumnSelect
             value={aggColumn}
             onChange={setAggColumn}
-            options={availableColumns.filter((col) => !selectedColumns.includes(col))}
+            options={availableColumns.filter((col: string) => !selectedColumns.includes(col))}
             required
             data-testid="groupby-agg-column"
           />
@@ -133,11 +132,6 @@ const GroupByForm = ({ projectId, onClose }) => {
       </form>
     </div>
   );
-};
-
-GroupByForm.propTypes = {
-  projectId: PropTypes.string.isRequired,
-  onClose: PropTypes.func.isRequired,
 };
 
 export default GroupByForm;

--- a/dataloom-frontend/src/Components/forms/MeltForm.tsx
+++ b/dataloom-frontend/src/Components/forms/MeltForm.tsx
@@ -1,23 +1,23 @@
-import { useState, useEffect } from "react";
-import PropTypes from "prop-types";
+import { useState, useEffect, FormEvent } from "react";
 import { transformProject, getProjectDetails } from "../../api";
 import { useProjectContext } from "../../context/ProjectContext";
 import usePreviewSave from "../../hooks/usePreviewSave";
 import ColumnMultiSelect from "../common/ColumnMultiSelect";
 import Button from "../common/Button";
 
-const MeltForm = ({ projectId, onClose }) => {
-  const [columns, setColumns] = useState([]);
-  const [idVars, setIdVars] = useState([]);
-  const [valueVars, setValueVars] = useState([]);
+const MeltForm = ({ projectId, onClose }: { projectId: string; onClose: () => void }) => {
+  const [columns, setColumns] = useState<string[]>([]);
+  const [idVars, setIdVars] = useState<string[]>([]);
+  const [valueVars, setValueVars] = useState<string[]>([]);
   const [varName, setVarName] = useState("variable");
   const [valueName, setValueName] = useState("value");
-  const [error, setError] = useState(null);
+  const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const { isPreviewMode, enterPreviewMode, cancelPreview } = useProjectContext();
   const { saving, handleSave } = usePreviewSave({
     clearError: () => setError(null),
-    handleError: (err) => setError(err.response?.data?.detail || err.message),
+    handleError: (err: { response?: { data?: { detail?: string } }; message?: string }) =>
+      setError(err.response?.data?.detail || err.message || null),
     onClose,
   });
 
@@ -42,7 +42,7 @@ const MeltForm = ({ projectId, onClose }) => {
     }
   };
 
-  const handleSubmit = async (e) => {
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setLoading(true);
     setError(null);
@@ -80,7 +80,8 @@ const MeltForm = ({ projectId, onClose }) => {
       const response = await transformProject(projectId, payload, { preview: true });
       enterPreviewMode(response.columns, response.rows, response.dtypes, { projectId, payload });
     } catch (err) {
-      setError(err.response?.data?.detail || err.message);
+      const e = err as { response?: { data?: { detail?: string } }; message?: string };
+      setError(e.response?.data?.detail || e.message || null);
     } finally {
       setLoading(false);
     }
@@ -156,11 +157,6 @@ const MeltForm = ({ projectId, onClose }) => {
       </form>
     </div>
   );
-};
-
-MeltForm.propTypes = {
-  projectId: PropTypes.string.isRequired,
-  onClose: PropTypes.func.isRequired,
 };
 
 export default MeltForm;

--- a/dataloom-frontend/src/Components/forms/PivotTableForm.tsx
+++ b/dataloom-frontend/src/Components/forms/PivotTableForm.tsx
@@ -1,5 +1,4 @@
-import { useState } from "react";
-import PropTypes from "prop-types";
+import { useState, FormEvent } from "react";
 import useError from "../../hooks/useError";
 import { transformProject } from "../../api";
 import { PIVOT_TABLES } from "../../constants/operationTypes";
@@ -12,8 +11,8 @@ import usePreviewSave from "../../hooks/usePreviewSave";
 import Button from "../common/Button";
 import { AGG_FUNCTIONS } from "../../constants/aggregations";
 
-const PivotTableForm = ({ projectId, onClose }) => {
-  const [index, setIndex] = useState([]);
+const PivotTableForm = ({ projectId, onClose }: { projectId: string; onClose: () => void }) => {
+  const [index, setIndex] = useState<string[]>([]);
   const [column, setColumn] = useState("");
   const [value, setValue] = useState("");
   const [aggfun, setAggfun] = useState("sum");
@@ -22,7 +21,7 @@ const PivotTableForm = ({ projectId, onClose }) => {
   const { isPreviewMode, enterPreviewMode, cancelPreview } = useProjectContext();
   const { saving, handleSave } = usePreviewSave({ clearError, handleError, onClose });
 
-  const handleSubmit = async (e) => {
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     clearError();
 
@@ -45,7 +44,7 @@ const PivotTableForm = ({ projectId, onClose }) => {
       const response = await transformProject(projectId, payload, { preview: true });
       enterPreviewMode(response.columns, response.rows, response.dtypes, { projectId, payload });
     } catch (err) {
-      console.error("Error applying pivot table:", err.message);
+      console.error("Error applying pivot table:", (err as Error).message);
       handleError(err);
     } finally {
       setLoading(false);
@@ -106,11 +105,6 @@ const PivotTableForm = ({ projectId, onClose }) => {
       </form>
     </div>
   );
-};
-
-PivotTableForm.propTypes = {
-  projectId: PropTypes.string.isRequired,
-  onClose: PropTypes.func.isRequired,
 };
 
 export default PivotTableForm;

--- a/dataloom-frontend/src/Components/forms/SampleRowsForm.tsx
+++ b/dataloom-frontend/src/Components/forms/SampleRowsForm.tsx
@@ -1,5 +1,4 @@
-import { useState } from "react";
-import PropTypes from "prop-types";
+import { useState, FormEvent } from "react";
 import { transformProject } from "../../api";
 import { SAMPLE_ROWS } from "../../constants/operationTypes";
 import useError from "../../hooks/useError";
@@ -8,7 +7,7 @@ import FormErrorAlert from "../common/FormErrorAlert";
 import { useProjectContext } from "../../context/ProjectContext";
 import Button from "../common/Button";
 
-const SampleRowsForm = ({ projectId, onClose }) => {
+const SampleRowsForm = ({ projectId, onClose }: { projectId: string; onClose: () => void }) => {
   const { isPreviewMode, enterPreviewMode, cancelPreview } = useProjectContext();
   const [sampleSize, setSampleSize] = useState("");
   const [randomSeed, setRandomSeed] = useState("");
@@ -20,7 +19,7 @@ const SampleRowsForm = ({ projectId, onClose }) => {
     onClose,
   });
 
-  const handleSubmit = async (e) => {
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const size = parseInt(sampleSize, 10);
 
@@ -32,7 +31,7 @@ const SampleRowsForm = ({ projectId, onClose }) => {
     setLoading(true);
     clearError();
     try {
-      const params = { sample_size: size };
+      const params: { sample_size: number; random_seed?: number } = { sample_size: size };
 
       if (randomSeed) {
         const seed = parseInt(randomSeed, 10);
@@ -122,11 +121,6 @@ const SampleRowsForm = ({ projectId, onClose }) => {
       </form>
     </div>
   );
-};
-
-SampleRowsForm.propTypes = {
-  projectId: PropTypes.string.isRequired,
-  onClose: PropTypes.func.isRequired,
 };
 
 export default SampleRowsForm;

--- a/dataloom-frontend/src/Components/forms/SortForm.tsx
+++ b/dataloom-frontend/src/Components/forms/SortForm.tsx
@@ -1,5 +1,4 @@
-import { useState, useCallback } from "react";
-import PropTypes from "prop-types";
+import { useState, useCallback, FormEvent } from "react";
 import { transformProject } from "../../api";
 import { SORT } from "../../constants/operationTypes";
 import useError from "../../hooks/useError";
@@ -15,13 +14,21 @@ const ORDER_OPTIONS = [
   { value: "false", label: "Descending" },
 ];
 
+interface SortCriterion {
+  id: number;
+  column: string;
+  ascending: boolean;
+}
+
 /**
  * SortForm component for multi-column sorting.
  * Allows users to add, remove, and reorder multiple sort criteria.
  */
-const SortForm = ({ projectId, onClose }) => {
+const SortForm = ({ projectId, onClose }: { projectId: string; onClose: () => void }) => {
   const { isPreviewMode, enterPreviewMode, cancelPreview } = useProjectContext();
-  const [criteria, setCriteria] = useState([{ id: 1, column: "", ascending: true }]);
+  const [criteria, setCriteria] = useState<SortCriterion[]>([
+    { id: 1, column: "", ascending: true },
+  ]);
   const [nextId, setNextId] = useState(2);
   const [loading, setLoading] = useState(false);
   const { error, setError, clearError, handleError } = useError();
@@ -32,7 +39,7 @@ const SortForm = ({ projectId, onClose }) => {
     setNextId((prev) => prev + 1);
   }, [nextId]);
 
-  const removeCriterion = useCallback((id) => {
+  const removeCriterion = useCallback((id: number) => {
     setCriteria((prev) => {
       if (prev.length <= 1) {
         return prev.map((c) => (c.id === id ? { ...c, column: "" } : c));
@@ -41,28 +48,36 @@ const SortForm = ({ projectId, onClose }) => {
     });
   }, []);
 
-  const updateCriterionColumn = useCallback((id, column) => {
+  const updateCriterionColumn = useCallback((id: number, column: string) => {
     setCriteria((prev) => prev.map((c) => (c.id === id ? { ...c, column } : c)));
   }, []);
 
-  const updateCriterionOrder = useCallback((id, ascending) => {
+  const updateCriterionOrder = useCallback((id: number, ascending: boolean) => {
     setCriteria((prev) => prev.map((c) => (c.id === id ? { ...c, ascending } : c)));
   }, []);
 
-  const moveUp = useCallback((index) => {
+  const moveUp = useCallback((index: number) => {
     if (index === 0) return;
     setCriteria((prev) => {
+      const above = prev[index - 1];
+      const current = prev[index];
+      if (above === undefined || current === undefined) return prev;
       const newCriteria = [...prev];
-      [newCriteria[index - 1], newCriteria[index]] = [newCriteria[index], newCriteria[index - 1]];
+      newCriteria[index - 1] = current;
+      newCriteria[index] = above;
       return newCriteria;
     });
   }, []);
 
-  const moveDown = useCallback((index) => {
+  const moveDown = useCallback((index: number) => {
     setCriteria((prev) => {
       if (index >= prev.length - 1) return prev;
+      const current = prev[index];
+      const below = prev[index + 1];
+      if (current === undefined || below === undefined) return prev;
       const newCriteria = [...prev];
-      [newCriteria[index], newCriteria[index + 1]] = [newCriteria[index + 1], newCriteria[index]];
+      newCriteria[index] = below;
+      newCriteria[index + 1] = current;
       return newCriteria;
     });
   }, []);
@@ -75,7 +90,7 @@ const SortForm = ({ projectId, onClose }) => {
     return null;
   }, [criteria]);
 
-  const handleSubmit = async (e) => {
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const validationError = validateCriteria();
     if (validationError) {
@@ -224,11 +239,6 @@ const SortForm = ({ projectId, onClose }) => {
       </form>
     </div>
   );
-};
-
-SortForm.propTypes = {
-  projectId: PropTypes.string.isRequired,
-  onClose: PropTypes.func.isRequired,
 };
 
 export default SortForm;

--- a/dataloom-frontend/src/Components/forms/StringReplaceForm.tsx
+++ b/dataloom-frontend/src/Components/forms/StringReplaceForm.tsx
@@ -1,22 +1,24 @@
-import { useState } from "react";
-import PropTypes from "prop-types";
+import { useState, FormEvent } from "react";
 import { transformProject } from "../../api";
-import { TRIM_WHITESPACE } from "../../constants/operationTypes";
 import { useProjectContext } from "../../context/ProjectContext";
 import usePreviewSave from "../../hooks/usePreviewSave";
+import { STRING_REPLACE } from "../../constants/operationTypes";
 import useError from "../../hooks/useError";
 import FormErrorAlert from "../common/FormErrorAlert";
 import ColumnSelect from "../common/ColumnSelect";
 import Button from "../common/Button";
-const TrimWhitespaceForm = ({ projectId, onClose }) => {
-  const { columns, isPreviewMode, enterPreviewMode, cancelPreview } = useProjectContext();
+
+const StringReplaceForm = ({ projectId, onClose }: { projectId: string; onClose: () => void }) => {
+  const { isPreviewMode, enterPreviewMode, cancelPreview } = useProjectContext();
 
   const [column, setColumn] = useState("");
+  const [findValue, setFindValue] = useState("");
+  const [replaceValue, setReplaceValue] = useState("");
   const [loading, setLoading] = useState(false);
   const { error, setError, clearError, handleError } = useError();
   const { saving, handleSave } = usePreviewSave({ clearError, handleError, onClose });
 
-  const handleSubmit = async (e) => {
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
     clearError();
@@ -27,12 +29,13 @@ const TrimWhitespaceForm = ({ projectId, onClose }) => {
     }
 
     setLoading(true);
-
     try {
       const payload = {
-        operation_type: TRIM_WHITESPACE,
-        trim_whitespace_params: {
+        operation_type: STRING_REPLACE,
+        string_replace_params: {
           column,
+          find_value: findValue,
+          replace_value: replaceValue,
         },
       };
       const response = await transformProject(projectId, payload, { preview: true });
@@ -57,11 +60,35 @@ const TrimWhitespaceForm = ({ projectId, onClose }) => {
       <form onSubmit={handleSubmit}>
         <div className="mb-4">
           <label className="block text-sm font-medium text-foreground">Column:</label>
-          <ColumnSelect
-            value={column}
-            onChange={setColumn}
-            options={["All string columns", ...columns]}
+          <ColumnSelect value={column} onChange={setColumn} required />
+        </div>
+
+        <div className="mb-4">
+          <label htmlFor="find-value" className="block text-sm font-medium text-foreground">
+            Find:
+          </label>
+          <input
+            id="find-value"
+            type="text"
+            placeholder="Text to find"
+            value={findValue}
+            onChange={(e) => setFindValue(e.target.value)}
+            className="border border-app-border rounded-md w-full px-3 py-2 bg-surface text-foreground focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none"
             required
+          />
+        </div>
+
+        <div className="mb-4">
+          <label htmlFor="replace-value" className="block text-sm font-medium text-foreground">
+            Replace with:
+          </label>
+          <input
+            id="replace-value"
+            type="text"
+            placeholder="Replacement text"
+            value={replaceValue}
+            onChange={(e) => setReplaceValue(e.target.value)}
+            className="border border-app-border rounded-md w-full px-3 py-2 bg-surface text-foreground focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none"
           />
         </div>
 
@@ -87,9 +114,4 @@ const TrimWhitespaceForm = ({ projectId, onClose }) => {
   );
 };
 
-TrimWhitespaceForm.propTypes = {
-  projectId: PropTypes.string.isRequired,
-  onClose: PropTypes.func.isRequired,
-};
-
-export default TrimWhitespaceForm;
+export default StringReplaceForm;

--- a/dataloom-frontend/src/Components/forms/TrimWhitespaceForm.tsx
+++ b/dataloom-frontend/src/Components/forms/TrimWhitespaceForm.tsx
@@ -1,25 +1,21 @@
-import { useState } from "react";
-import PropTypes from "prop-types";
+import { useState, FormEvent } from "react";
 import { transformProject } from "../../api";
+import { TRIM_WHITESPACE } from "../../constants/operationTypes";
 import { useProjectContext } from "../../context/ProjectContext";
 import usePreviewSave from "../../hooks/usePreviewSave";
-import { STRING_REPLACE } from "../../constants/operationTypes";
 import useError from "../../hooks/useError";
 import FormErrorAlert from "../common/FormErrorAlert";
 import ColumnSelect from "../common/ColumnSelect";
 import Button from "../common/Button";
-
-const StringReplaceForm = ({ projectId, onClose }) => {
-  const { isPreviewMode, enterPreviewMode, cancelPreview } = useProjectContext();
+const TrimWhitespaceForm = ({ projectId, onClose }: { projectId: string; onClose: () => void }) => {
+  const { columns, isPreviewMode, enterPreviewMode, cancelPreview } = useProjectContext();
 
   const [column, setColumn] = useState("");
-  const [findValue, setFindValue] = useState("");
-  const [replaceValue, setReplaceValue] = useState("");
   const [loading, setLoading] = useState(false);
   const { error, setError, clearError, handleError } = useError();
   const { saving, handleSave } = usePreviewSave({ clearError, handleError, onClose });
 
-  const handleSubmit = async (e) => {
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
     clearError();
@@ -30,13 +26,12 @@ const StringReplaceForm = ({ projectId, onClose }) => {
     }
 
     setLoading(true);
+
     try {
       const payload = {
-        operation_type: STRING_REPLACE,
-        string_replace_params: {
+        operation_type: TRIM_WHITESPACE,
+        trim_whitespace_params: {
           column,
-          find_value: findValue,
-          replace_value: replaceValue,
         },
       };
       const response = await transformProject(projectId, payload, { preview: true });
@@ -61,35 +56,11 @@ const StringReplaceForm = ({ projectId, onClose }) => {
       <form onSubmit={handleSubmit}>
         <div className="mb-4">
           <label className="block text-sm font-medium text-foreground">Column:</label>
-          <ColumnSelect value={column} onChange={setColumn} required />
-        </div>
-
-        <div className="mb-4">
-          <label htmlFor="find-value" className="block text-sm font-medium text-foreground">
-            Find:
-          </label>
-          <input
-            id="find-value"
-            type="text"
-            placeholder="Text to find"
-            value={findValue}
-            onChange={(e) => setFindValue(e.target.value)}
-            className="border border-app-border rounded-md w-full px-3 py-2 bg-surface text-foreground focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none"
+          <ColumnSelect
+            value={column}
+            onChange={setColumn}
+            options={["All string columns", ...columns]}
             required
-          />
-        </div>
-
-        <div className="mb-4">
-          <label htmlFor="replace-value" className="block text-sm font-medium text-foreground">
-            Replace with:
-          </label>
-          <input
-            id="replace-value"
-            type="text"
-            placeholder="Replacement text"
-            value={replaceValue}
-            onChange={(e) => setReplaceValue(e.target.value)}
-            className="border border-app-border rounded-md w-full px-3 py-2 bg-surface text-foreground focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none"
           />
         </div>
 
@@ -115,9 +86,4 @@ const StringReplaceForm = ({ projectId, onClose }) => {
   );
 };
 
-StringReplaceForm.propTypes = {
-  projectId: PropTypes.string.isRequired,
-  onClose: PropTypes.func.isRequired,
-};
-
-export default StringReplaceForm;
+export default TrimWhitespaceForm;

--- a/dataloom-frontend/src/Components/workspace/ChartsTab.tsx
+++ b/dataloom-frontend/src/Components/workspace/ChartsTab.tsx
@@ -141,6 +141,7 @@ function EmptyState() {
   );
 }
 
+// eslint-disable-next-line react-refresh/only-export-components
 export const CHARTS_TAB: WorkspaceTab = {
   id: "charts",
   title: "Charts",

--- a/dataloom-frontend/src/Components/workspace/DataSetTab.tsx
+++ b/dataloom-frontend/src/Components/workspace/DataSetTab.tsx
@@ -8,6 +8,7 @@ import Table from "../Table";
  * here next to the component so both DataScreen (initial tab, "+") and the
  * Profiling menu (focusing the table) share one definition.
  */
+// eslint-disable-next-line react-refresh/only-export-components
 export const DATASET_TAB: WorkspaceTab = {
   id: "dataset",
   title: "DataSet",

--- a/dataloom-frontend/src/Components/workspace/QualityTab.tsx
+++ b/dataloom-frontend/src/Components/workspace/QualityTab.tsx
@@ -60,6 +60,7 @@ export function QualityTab() {
   );
 }
 
+// eslint-disable-next-line react-refresh/only-export-components
 export const QUALITY_TAB: WorkspaceTab = {
   id: "quality",
   title: "Quality",

--- a/dataloom-frontend/src/api/projects.js
+++ b/dataloom-frontend/src/api/projects.js
@@ -23,9 +23,9 @@ export const uploadProject = async (file, projectName, projectDescription) => {
 /**
  * Fetch full project details including rows and columns.
  * @param {string} projectId - The project ID.
- * @param {number} page - Current Page
- * @param {number} pageSize - Elements per page
- * @returns {Promise<Object>} Project details with columns and rows.
+ * @param {number} [page] - Current Page
+ * @param {number} [pageSize] - Elements per page
+ * @returns {Promise<{ project_id: string, filename: string, columns: string[], rows: Array<Array<*>>, dtypes: Object.<string, string>, total_rows: number, total_pages: number, page: number, page_size: number }>} Project details with columns and rows.
  */
 export const getProjectDetails = async (projectId, page, pageSize) => {
   const response = await client.get(`/projects/get/${projectId}`, {

--- a/dataloom-frontend/src/api/transforms.js
+++ b/dataloom-frontend/src/api/transforms.js
@@ -5,12 +5,19 @@
 import client from "./client";
 
 /**
+ * @typedef {Object} TransformResult
+ * @property {string[]} columns - Column names after the transformation.
+ * @property {Array<Array<*>>} rows - Row data after the transformation.
+ * @property {Object.<string, string>} dtypes - Column name to pandas dtype mapping.
+ */
+
+/**
  * Apply a transformation (filter, sort, add/delete row/column, pivot, etc).
  * @param {string} projectId - The project ID.
  * @param {Object} transformationInput - The transformation parameters including operation_type.
  * @param {Object} options - Request options.
  * @param {boolean} options.preview - If true, return transformed data without persisting.
- * @returns {Promise<Object>} Transformation result with updated rows and columns.
+ * @returns {Promise<TransformResult>} Transformation result with updated rows and columns.
  */
 export const transformProject = async (
   projectId,

--- a/dataloom-frontend/src/context/ProjectContext.jsx
+++ b/dataloom-frontend/src/context/ProjectContext.jsx
@@ -5,7 +5,7 @@ const ProjectContext = createContext(null);
 
 /**
  * Hook to access project state and actions.
- * @returns {{ projectId: string, columns: string[], rows: Array[], dtypes: Object.<string, string>, loading: boolean, error: string|null, dataVersion: number, projectName: string, totalRows: number, totalPages: number, page: number, pageSize: number, refreshProject: Function, updateData: Function, setProjectInfo: Function, setPaginationData: Function, updatePageSizePreference: Function }}
+ * @returns {{ projectId: string, columns: string[], rows: Array[], dtypes: Object.<string, string>, columnOrder: number[], setColumnOrder: Function, deleteProjectOrder: Function, loading: boolean, error: string|null, dataVersion: number, projectName: string, totalRows: number, totalPages: number, page: number, pageSize: number, refreshProject: Function, updateData: Function, setProjectInfo: Function, setPaginationData: Function, updatePageSizePreference: Function, isPreviewMode: boolean, previewSnapshot: Object|null, pendingTransform: Object|null, setIsPreviewMode: Function, setPreviewSnapshot: Function, setPendingTransform: Function, enterPreviewMode: Function, cancelPreview: Function, confirmPreview: Function }}
  */
 // eslint-disable-next-line react-refresh/only-export-components
 export function useProjectContext() {

--- a/dataloom-frontend/src/hooks/useError.js
+++ b/dataloom-frontend/src/hooks/useError.js
@@ -1,7 +1,7 @@
 import { useState } from "react";
 
 const useError = () => {
-  const [error, setError] = useState(null);
+  const [error, setError] = useState(/** @type {string | null} */ (null));
 
   const clearError = () => setError(null);
 

--- a/dataloom-frontend/tsconfig.json
+++ b/dataloom-frontend/tsconfig.json
@@ -10,15 +10,15 @@
     "moduleDetection": "force",
     "moduleResolution": "Bundler",
     "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true,
     "target": "ES2022",
     "jsx": "react-jsx",
     "allowJs": true,
-    "noEmit": true,
-    "baseUrl": ".",
-    "paths": { "@/*": ["src/*"] }
+    "noEmit": true
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Description

Migrates the 11 remaining `.jsx` transform forms in `Components/forms/` to TypeScript, following the idiom already established by `FillEmptyForm.tsx` (inline prop types, typed `FormEvent`/`ChangeEvent` handlers, static types instead of runtime PropTypes). Stale JSDoc on the forms' JS dependencies (`ProjectContext`, `useError`, the API layer) is corrected so the whole project passes `tsc --noEmit` under strict mode — including 6 pre-existing type errors in `FillEmptyForm.tsx` that nothing previously caught.

The second commit closes the tooling gap that let those errors slip through: until now, `.ts`/`.tsx` files were neither linted (`eslint --ext js,jsx`) nor type-checked (no `typescript` dependency; esbuild strips types without checking). `tsc --noEmit` is folded into `npm run lint` (no new command), TS files are linted with the existing react/react-hooks rules via `@typescript-eslint/parser`, and CI enforces both. Only two dev-only dependencies were added (`typescript`, `@typescript-eslint/parser`) — no new rule ecosystems.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

Refactor + tooling — no user-facing behavior change.

## How Has This Been Tested?

- `npm run lint` — ESLint (`js,jsx,ts,tsx`, `--max-warnings 0`) + `tsc --noEmit` (strict, `noUncheckedIndexedAccess`, `noUnusedLocals`): clean
- `npm run test` — 161/161 tests across 31 files pass
- `npm run build` — production build succeeds
- `npx prettier --check` on all changed files: clean

- [x] Existing tests pass
- [ ] New tests added
- [ ] Manual testing

## Screenshots (if applicable)

N/A — no visual changes.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally