### PR TITLE
feat: auto-infer datetime columns on data load

### DIFF
--- a/dataloom-backend/app/services/transformation_service.py
+++ b/dataloom-backend/app/services/transformation_service.py
@@ -4,11 +4,11 @@ Each function takes a DataFrame and parameters, returns a new DataFrame.
 No side effects -- saving to disk is handled by the caller.
 """
 
+import math
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
-import numpy as np
 import pandas as pd
 
 from app.schemas import FillStrategy, MeltParams, OperationType
@@ -220,7 +220,12 @@ def delete_column(df: pd.DataFrame, index: int) -> pd.DataFrame:
     return df.drop(column_name, axis=1)
 
 
-def change_cell_value(df: pd.DataFrame, row_index: int, col_index: int, value) -> pd.DataFrame:
+def change_cell_value(
+    df: pd.DataFrame,
+    row_index: int,
+    col_index: int,
+    value,
+) -> pd.DataFrame:
     """Update a single cell value.
 
     Note: col_index is 1-based from the frontend (skipping S.No. column).
@@ -233,15 +238,20 @@ def change_cell_value(df: pd.DataFrame, row_index: int, col_index: int, value) -
 
     Returns:
         DataFrame with updated cell.
+
+    Raises:
+        TransformationError: If an index is out of bounds, a numeric value is
+            invalid or non-finite, a datetime value has an invalid format, or
+            pandas cannot store the converted value in the target column.
     """
     df = df.copy()
 
     # col_index is 1-based (1..len(columns)); row_index is 0-based. Guard both
     # ends so a negative index can't silently wrap to the wrong cell.
-    if row_index < 0 or row_index >= len(df) or col_index < 1 or col_index > len(df.columns):
+    if row_index < 0 or row_index >= len(df) or col_index < 1 or col_index >= len(df.columns) + 1:
         raise TransformationError("Row or column index out of bounds")
 
-    # col_index is 1-based from frontend (accounting for S.No. column).
+    # col_index is 1-based from frontend (accounting for S.No. column)
     column_name = df.columns[col_index - 1]
 
     # Cast value to match the column's existing dtype so pandas doesn't reject
@@ -249,76 +259,112 @@ def change_cell_value(df: pd.DataFrame, row_index: int, col_index: int, value) -
     col_dtype = df[column_name].dtype
 
     if value == "" or value is None:
-        # Clearing a cell stores Python None. Numeric columns are promoted to
-        # object so None can coexist with the remaining values without forcing
-        # integer values through float64 and potentially losing precision.
-        if pd.api.types.is_numeric_dtype(col_dtype):
+        # Clearing a cell stores Python None. Numeric columns are upcast to
+        # object so None can coexist with the remaining values (int64 has no
+        # null sentinel; we upcast float64 too for consistency with the int
+        # path, even though NaN would fit natively).
+        if pd.api.types.is_integer_dtype(col_dtype) or pd.api.types.is_float_dtype(col_dtype):
             df[column_name] = df[column_name].astype(object)
 
         value = None
+    else:
+        if pd.api.types.is_integer_dtype(col_dtype):
+            normalized = str(value).strip()
 
-    elif pd.api.types.is_integer_dtype(col_dtype):
-        # Preserve integer precision by attempting integer parsing first.
-        # Python integers are arbitrary precision, so values beyond float64's
-        # exact integer range remain unchanged.
-        normalized = str(value).strip()
-
-        try:
-            value = int(normalized)
-        except (ValueError, TypeError, OverflowError):
             try:
-                decimal_value = float(normalized)
-            except (ValueError, TypeError, OverflowError) as err:
-                raise TransformationError(
-                    f"Cannot interpret {value!r} as a number for column "
-                    f"'{column_name}'. Expected an integer or decimal value."
-                ) from err
+                # Try int() first so large integer strings like
+                # "9007199254740993" (above 2^53) keep full precision —
+                # converting them through float would lose bits.
+                value = int(normalized)
+            except ValueError:
+                try:
+                    decimal_value = float(normalized)
+                except (ValueError, TypeError, OverflowError):
+                    raise TransformationError(
+                        f"Invalid value {value!r} for integer column "
+                        f"'{column_name}'. Expected an integer or decimal value."
+                    ) from None
 
-            if not np.isfinite(decimal_value):
+                if not math.isfinite(decimal_value):
+                    raise TransformationError(
+                        f"Invalid value {value!r} for column '{column_name}'. Expected a finite number."
+                    ) from None
+
+                # A decimal-formatted value cannot remain in an integer dtype.
+                # Promote to object instead of float64 so existing large
+                # integers retain their exact values.
+                df[column_name] = df[column_name].astype(object)
+                value = decimal_value
+
+        elif pd.api.types.is_float_dtype(col_dtype):
+            try:
+                value = float(value)
+            except (ValueError, TypeError, OverflowError):
                 raise TransformationError(
-                    f"Cannot interpret {value!r} as a finite number for column '{column_name}'."
+                    f"Invalid value {value!r} for float column '{column_name}'. Expected a numeric value."
                 ) from None
 
-            # A decimal cannot be stored in an integer dtype. Promote the
-            # column to object instead of float64 so unedited large integers,
-            # including values beyond 2^53, retain their exact values.
-            df[column_name] = df[column_name].astype(object)
-            value = decimal_value
+            if not math.isfinite(value):
+                raise TransformationError(
+                    f"Invalid value {value!r} for column '{column_name}'. Expected a finite number."
+                )
 
-    elif pd.api.types.is_float_dtype(col_dtype):
-        # Float columns accept only valid finite numeric values. Invalid edits
-        # are rejected instead of silently demoting the column to object.
-        normalized = str(value).strip()
+        elif pd.api.types.is_bool_dtype(col_dtype):
+            # Accepted tokens are a superset of cast_data_type()'s, so a
+            # value that cast-to-boolean would accept never gets rejected
+            # by a cell edit.
+            normalized = str(value).strip().lower()
 
-        try:
-            value = float(normalized)
-        except (ValueError, TypeError, OverflowError) as err:
-            raise TransformationError(
-                f"Cannot interpret {value!r} as a float for column '{column_name}'. Expected a numeric value."
-            ) from err
+            if normalized in ("true", "1", "yes", "t", "y", "on"):
+                value = True
+            elif normalized in ("false", "0", "no", "f", "n", "off"):
+                value = False
+            else:
+                raise TransformationError(
+                    f"Cannot interpret {value!r} as boolean for column "
+                    f"'{column_name}'. Expected one of: true/false, 1/0, "
+                    "yes/no, t/f, y/n, on/off."
+                )
 
-        if not np.isfinite(value):
-            raise TransformationError(
-                f"Cannot interpret {value!r} as a finite number for column '{column_name}'."
-            ) from None
+        elif pd.api.types.is_datetime64_any_dtype(col_dtype):
+            normalized = str(value).strip()
 
-    elif pd.api.types.is_bool_dtype(col_dtype):
-        # Accepted tokens are a superset of cast_data_type()'s, so a value
-        # that cast-to-boolean would accept never gets rejected by a cell edit.
-        normalized = str(value).strip().lower()
+            try:
+                # Accept only complete dates or timestamps.
+                if len(normalized) == 10:
+                    parsed = pd.to_datetime(
+                        normalized,
+                        format="%Y-%m-%d",
+                        errors="raise",
+                    )
+                else:
+                    parsed = pd.to_datetime(
+                        normalized,
+                        format="%Y-%m-%d %H:%M:%S",
+                        errors="raise",
+                    )
+            except (ValueError, TypeError, OverflowError):
+                raise TransformationError(
+                    f"Invalid datetime for column '{column_name}'. Expected YYYY-MM-DD or YYYY-MM-DD HH:MM:SS."
+                ) from None
 
-        if normalized in ("true", "1", "yes", "t", "y", "on"):
-            value = True
-        elif normalized in ("false", "0", "no", "f", "n", "off"):
-            value = False
-        else:
-            raise TransformationError(
-                f"Cannot interpret {value!r} as boolean for column "
-                f"'{column_name}'. Expected one of: true/false, 1/0, "
-                "yes/no, t/f, y/n, on/off."
-            )
+            # _infer_datetime_columns can produce timezone-aware columns
+            # (e.g. timestamps normalized through utc=True). Localize the edit
+            # to the existing column timezone before assignment.
+            col_tz = getattr(col_dtype, "tz", None)
 
-    df.at[row_index, column_name] = value
+            if col_tz is not None:
+                parsed = parsed.tz_localize(col_tz)
+
+            value = parsed
+
+    try:
+        df.at[row_index, column_name] = value
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise TransformationError(
+            f"Cannot store {value!r} in column '{column_name}' ({df[column_name].dtype})."
+        ) from exc
+
     return df
 
 

--- a/dataloom-backend/app/utils/pandas_helpers.py
+++ b/dataloom-backend/app/utils/pandas_helpers.py
@@ -1,5 +1,6 @@
 """Pandas utility functions for safe multi-format I/O and response building."""
 
+import re
 from pathlib import Path
 from typing import Any
 
@@ -15,6 +16,10 @@ def read_table_safe(path: Path) -> pd.DataFrame:
     The format is resolved from the file extension via the format registry, so
     CSV/TSV/JSON/XLSX/Parquet all flow through this single helper.
 
+    Datetime-like string columns are inferred immediately after reading so all
+    downstream consumers, including profiling and response building, receive
+    consistent dtypes.
+
     Args:
         path: Path to the dataset file.
 
@@ -23,10 +28,11 @@ def read_table_safe(path: Path) -> pd.DataFrame:
 
     Raises:
         HTTPException: 404 if the file is missing, 400 if the contents are
-            invalid for the format (e.g. JSON nested too deeply), 500 otherwise.
+            invalid for the format, 500 otherwise.
     """
     try:
-        return get_format(path).read(Path(path))
+        df = get_format(path).read(path)
+        return _infer_datetime_columns(df)
     except FileNotFoundError:
         raise HTTPException(status_code=404, detail=f"File not found: {path}") from None
     except ValueError as e:
@@ -35,7 +41,11 @@ def read_table_safe(path: Path) -> pd.DataFrame:
         raise HTTPException(status_code=500, detail=f"Error reading file: {str(e)}") from e
 
 
-def save_table_safe(df: pd.DataFrame, path: Path, options: TableWriteOptions | None = None) -> None:
+def save_table_safe(
+    df: pd.DataFrame,
+    path: Path,
+    options: TableWriteOptions | None = None,
+) -> None:
     """Save a DataFrame safely, dispatching on the destination file's format.
 
     Args:
@@ -47,7 +57,7 @@ def save_table_safe(df: pd.DataFrame, path: Path, options: TableWriteOptions | N
         HTTPException: If the file cannot be saved.
     """
     try:
-        get_format(path).write(df, Path(path), options)
+        get_format(path).write(df, path, options)
     except (ValueError, UnicodeEncodeError) as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
     except Exception as e:
@@ -57,41 +67,254 @@ def save_table_safe(df: pd.DataFrame, path: Path, options: TableWriteOptions | N
 def map_dtype(dtype) -> str:
     """Map a pandas dtype to a short label string."""
     kind = dtype.kind
-    if kind == "i" or kind == "u":
+
+    if kind in ("i", "u"):
         return "int"
-    elif kind == "f":
+    if kind == "f":
         return "float"
-    elif kind == "b":
+    if kind == "b":
         return "bool"
-    elif kind == "M":
+    if kind == "M":
         return "datetime"
-    elif kind == "O" or kind == "U" or kind == "S":
+    if kind in ("O", "U", "S"):
         return "str"
-    else:
-        return "unknown"
+
+    return "unknown"
 
 
-def dataframe_to_response(df: pd.DataFrame) -> dict[str, Any]:
-    """Convert a DataFrame to an API response dict.
+_TIME_SUFFIX = (
+    r"(?:[ T]\d{1,2}:\d{2}"
+    r"(?::\d{2}(?:\.\d{1,6})?)?"
+    r"(?:Z|[+-]\d{2}:?\d{2})?"
+    r")?"
+)
+
+_DATE_LIKE_PATTERNS = (
+    # YYYY-MM-DD, YYYY/MM/DD, YYYY.MM.DD, optionally with a time.
+    re.compile(rf"\d{{4}}([./-])\d{{1,2}}\1\d{{1,2}}{_TIME_SUFFIX}"),
+    # DD-MM-YYYY, MM-DD-YYYY and equivalent slash/dot formats.
+    re.compile(rf"\d{{1,2}}([./-])\d{{1,2}}\1\d{{4}}{_TIME_SUFFIX}"),
+    # January 10, 2024 / Jan 10 2024.
+    re.compile(
+        rf"(?:jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|"
+        rf"may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:tember)?|"
+        rf"oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)"
+        rf"\s+\d{{1,2}},?\s+\d{{4}}{_TIME_SUFFIX}",
+        re.IGNORECASE,
+    ),
+    # 10 January 2024 / 10 Jan 2024.
+    re.compile(
+        rf"\d{{1,2}}\s+"
+        rf"(?:jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|"
+        rf"may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:tember)?|"
+        rf"oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)"
+        rf"\s+\d{{4}}{_TIME_SUFFIX}",
+        re.IGNORECASE,
+    ),
+)
+
+_AMBIGUOUS_NUMERIC_DATE = re.compile(r"(\d{1,2})([./-])(\d{1,2})\2\d{4}")
+
+
+def _infer_dayfirst(values: pd.Series) -> bool | None:
+    """Infer day-first vs month-first convention from unambiguous rows.
+
+    Returns True/False when rows with one component > 12 disambiguate the
+    column's convention. Returns None when the column has evidence for
+    both conventions (genuinely inconsistent), so the caller can skip
+    inference rather than silently corrupt half the rows.
+    """
+    day_first = month_first = False
+    for value in values:
+        match = _AMBIGUOUS_NUMERIC_DATE.fullmatch(value.strip())
+        if not match:
+            continue
+        first, second = int(match.group(1)), int(match.group(3))
+        if first > 12 >= second:
+            day_first = True
+        elif second > 12 >= first:
+            month_first = True
+    if day_first and month_first:
+        return None
+    return day_first
+
+
+def _looks_like_datetime(value: str) -> bool:
+    """Return whether a string has the structure of a complete date.
+
+    Bare years, numeric identifiers, short codes, and partial dates are
+    intentionally rejected even when pandas could parse them.
+
+    Args:
+        value: String value to inspect.
+
+    Returns:
+        True if the value resembles a complete date or datetime.
+    """
+    normalized = value.strip()
+
+    if not normalized:
+        return False
+
+    return any(pattern.fullmatch(normalized) for pattern in _DATE_LIKE_PATTERNS)
+
+
+def _infer_datetime_columns(df: pd.DataFrame) -> pd.DataFrame:
+    """Infer datetime columns from string/object columns.
+
+    A column is converted only when at least 80% of its non-null string values
+    resemble complete dates and can be parsed successfully. Bare years,
+    numeric identifiers, short codes, partial dates, mixed date conventions,
+    and mixed-type object columns are not inferred as datetime values.
+
+    Numeric day/month dates use one convention for the entire column instead
+    of allowing pandas to infer each row independently. Columns containing
+    mixed UTC offsets are normalized to UTC when pandas cannot represent them
+    directly using a single timezone-aware dtype.
 
     Args:
         df: Source DataFrame.
 
     Returns:
-        Dict with columns (list of str), rows (list of lists), row_count, and dtypes.
+        A copied DataFrame with eligible columns converted to datetime dtype.
     """
+    df = df.copy()
 
+    string_columns = df.select_dtypes(include=["object", "string"]).columns
+
+    for col in string_columns:
+        non_null = df[col].dropna()
+
+        if non_null.empty:
+            continue
+
+        string_mask = non_null.map(lambda value: isinstance(value, str))
+        string_values = non_null[string_mask]
+
+        if string_values.empty:
+            continue
+
+        # Do not infer mixed-type object columns. Parsing the entire column could
+        # reinterpret non-string numbers as nanosecond timestamps.
+        if len(string_values) != len(non_null):
+            continue
+
+        normalized_values = string_values.str.strip()
+        date_like_rate = normalized_values.map(_looks_like_datetime).mean()
+
+        if date_like_rate < 0.8:
+            continue
+
+        dayfirst = _infer_dayfirst(normalized_values)
+
+        if dayfirst is None:
+            # Mixes DD/MM and MM/DD conventions across rows — too ambiguous
+            # to guess safely, leave as text.
+            continue
+
+        normalized_column = df[col].map(lambda value: value.strip() if isinstance(value, str) else value)
+
+        try:
+            converted = pd.to_datetime(
+                normalized_column,
+                format="mixed",
+                dayfirst=dayfirst,
+                errors="coerce",
+            )
+        except ValueError:
+            # Mixed UTC offsets ('Z' alongside '+02:00' rows) make pandas
+            # raise instead of honoring errors="coerce". Normalize to UTC
+            # so the column still parses instead of taking the whole read
+            # path down (read_table_safe has no other error boundary here).
+            try:
+                converted = pd.to_datetime(
+                    normalized_column,
+                    format="mixed",
+                    dayfirst=dayfirst,
+                    errors="coerce",
+                    utc=True,
+                )
+            except ValueError:
+                # Datetime inference is best effort. A column that still cannot
+                # be parsed must remain unchanged rather than making the entire
+                # dataset unreadable.
+                continue
+
+        # Use all non-null source values as the denominator so the boundary
+        # reflects the complete column rather than only the date-shaped subset.
+        parse_success_rate = converted[df[col].notna()].notna().mean()
+
+        if parse_success_rate >= 0.8:
+            df[col] = converted
+
+    return df
+
+
+def _format_datetime_columns_for_response(df: pd.DataFrame) -> pd.DataFrame:
+    """Format datetime columns for display without changing reported dtypes.
+
+    Date-only columns are returned as ``YYYY-MM-DD``. Columns containing at
+    least one meaningful time component are returned as
+    ``YYYY-MM-DD HH:MM:SS``.
+
+    Args:
+        df: Source DataFrame containing inferred datetime columns.
+
+    Returns:
+        A copied DataFrame with datetime columns converted to display strings.
+    """
+    formatted_df = df.copy()
+
+    datetime_columns = formatted_df.select_dtypes(include=["datetime64[ns]", "datetimetz"]).columns
+
+    for col in datetime_columns:
+        series = formatted_df[col]
+
+        non_null = series.dropna()
+        if non_null.empty:
+            continue
+
+        has_time = (
+            non_null.dt.hour.ne(0) | non_null.dt.minute.ne(0) | non_null.dt.second.ne(0) | non_null.dt.microsecond.ne(0)
+        ).any()
+
+        if has_time:
+            formatted_df[col] = series.dt.strftime("%Y-%m-%d %H:%M:%S")
+        else:
+            formatted_df[col] = series.dt.strftime("%Y-%m-%d")
+
+    return formatted_df
+
+
+def dataframe_to_response(df: pd.DataFrame) -> dict[str, Any]:
+    """Convert a DataFrame to an API response dict.
+
+    Datetime dtypes are captured before formatting values for display, so the
+    response reports ``datetime`` while date-only values do not unnecessarily
+    include ``T00:00:00``.
+
+    Args:
+        df: Source DataFrame.
+
+    Returns:
+        Dict with columns, rows, row_count, and dtypes.
+    """
     dtypes = {col: map_dtype(dtype) for col, dtype in df.dtypes.items()}
     columns = df.columns.tolist()
 
+    display_df = _format_datetime_columns_for_response(df)
+
     # Preserve null semantics: real empty strings stay "", while missing and
-    # non-finite values serialize to null. ``where`` over an object-typed frame
-    # is a vectorized C-level dispatch, not a Python-level per-cell loop.
-    normalized_df = df.astype(object)
+    # non-finite values serialize to null.
+    normalized_df = display_df.astype(object)
     normalized_df = normalized_df.where(pd.notna(normalized_df), None)
-    normalized_df = normalized_df.replace([float("inf"), float("-inf")], None)
+    normalized_df = normalized_df.replace(
+        [float("inf"), float("-inf")],
+        None,
+    )
 
     rows = normalized_df.values.tolist()
+
     return {
         "columns": columns,
         "rows": rows,

--- a/dataloom-backend/tests/test_dtypes.py
+++ b/dataloom-backend/tests/test_dtypes.py
@@ -3,7 +3,7 @@
 import pandas as pd
 import pytest
 
-from app.utils.pandas_helpers import dataframe_to_response, map_dtype
+from app.utils.pandas_helpers import _infer_datetime_columns, dataframe_to_response, map_dtype
 
 
 @pytest.fixture
@@ -81,7 +81,7 @@ class TestDataframeToResponse:
         assert response["rows"][1][0] == ""
         assert response["rows"][0][1] is None
         assert response["rows"][1][1] == 5.5
-        assert response["rows"][0][2] == pd.Timestamp("2024-01-01")
+        assert response["rows"][0][2] == "2024-01-01"
         assert response["rows"][1][2] is None
 
     def test_preserves_non_scalar_cells_without_isna_truthiness_errors(self):
@@ -96,3 +96,229 @@ class TestDataframeToResponse:
         assert response["rows"][0][0] == [1, 2]
         assert response["rows"][1][0] == [None]
         assert response["rows"][2][0] == {"ok": True}
+
+
+class TestInferDatetimeColumns:
+    def test_converts_valid_datetime_column(self):
+        df = pd.DataFrame(
+            {
+                "created_at": [
+                    "2024-01-10",
+                    "2024-02-11",
+                    "2024-03-12",
+                ]
+            }
+        )
+
+        result = _infer_datetime_columns(df)
+
+        assert pd.api.types.is_datetime64_any_dtype(result["created_at"])
+        assert result.at[0, "created_at"] == pd.Timestamp("2024-01-10")
+
+    def test_supports_mixed_datetime_formats(self):
+        df = pd.DataFrame(
+            {
+                "created_at": [
+                    "2024-01-10",
+                    "11/02/2024",
+                    "March 12, 2024",
+                ]
+            }
+        )
+
+        result = _infer_datetime_columns(df)
+
+        assert pd.api.types.is_datetime64_any_dtype(result["created_at"])
+
+    def test_does_not_convert_bare_years(self):
+        df = pd.DataFrame(
+            {
+                "grad_year": [
+                    "2024",
+                    "2025",
+                    "2023",
+                    "2022",
+                ]
+            }
+        )
+
+        result = _infer_datetime_columns(df)
+
+        assert not pd.api.types.is_datetime64_any_dtype(result["grad_year"])
+        assert result["grad_year"].tolist() == [
+            "2024",
+            "2025",
+            "2023",
+            "2022",
+        ]
+
+    def test_does_not_convert_numeric_ids(self):
+        df = pd.DataFrame(
+            {
+                "student_id": [
+                    "20240101",
+                    "20240102",
+                    "20240103",
+                    "20240104",
+                ]
+            }
+        )
+
+        result = _infer_datetime_columns(df)
+
+        assert not pd.api.types.is_datetime64_any_dtype(result["student_id"])
+        assert result["student_id"].tolist() == [
+            "20240101",
+            "20240102",
+            "20240103",
+            "20240104",
+        ]
+
+    def test_does_not_convert_short_codes(self):
+        df = pd.DataFrame(
+            {
+                "code": [
+                    "A123",
+                    "B456",
+                    "C789",
+                    "D012",
+                ]
+            }
+        )
+
+        result = _infer_datetime_columns(df)
+
+        assert not pd.api.types.is_datetime64_any_dtype(result["code"])
+
+    def test_does_not_convert_partial_dates(self):
+        df = pd.DataFrame(
+            {
+                "period": [
+                    "2024-01",
+                    "2024-02",
+                    "2024-03",
+                    "2024-04",
+                ]
+            }
+        )
+
+        result = _infer_datetime_columns(df)
+
+        assert not pd.api.types.is_datetime64_any_dtype(result["period"])
+
+    def test_converts_at_exact_eighty_percent_threshold(self):
+        df = pd.DataFrame(
+            {
+                "event_date": [
+                    "2024-01-01",
+                    "2024-02-01",
+                    "2024-03-01",
+                    "2024-04-01",
+                    "invalid",
+                ]
+            }
+        )
+
+        result = _infer_datetime_columns(df)
+
+        assert pd.api.types.is_datetime64_any_dtype(result["event_date"])
+        assert pd.isna(result.at[4, "event_date"])
+
+    def test_does_not_convert_below_eighty_percent_threshold(self):
+        df = pd.DataFrame(
+            {
+                "event_date": [
+                    "2024-01-01",
+                    "2024-02-01",
+                    "2024-03-01",
+                    "invalid",
+                    "also-invalid",
+                ]
+            }
+        )
+
+        result = _infer_datetime_columns(df)
+
+        assert not pd.api.types.is_datetime64_any_dtype(result["event_date"])
+
+    def test_does_not_convert_when_date_shaped_values_are_invalid(self):
+        df = pd.DataFrame(
+            {
+                "event_date": [
+                    "2024-13-01",
+                    "2024-14-02",
+                    "2024-15-03",
+                    "2024-01-01",
+                    "2024-02-01",
+                ]
+            }
+        )
+
+        result = _infer_datetime_columns(df)
+
+        assert not pd.api.types.is_datetime64_any_dtype(result["event_date"])
+
+    def test_does_not_mutate_original_dataframe(self):
+        df = pd.DataFrame(
+            {
+                "created_at": [
+                    "2024-01-01",
+                    "2024-02-01",
+                ]
+            }
+        )
+
+        result = _infer_datetime_columns(df)
+
+        assert not pd.api.types.is_datetime64_any_dtype(df["created_at"])
+        assert df["created_at"].tolist() == [
+            "2024-01-01",
+            "2024-02-01",
+        ]
+
+        assert pd.api.types.is_datetime64_any_dtype(result["created_at"])
+        assert result["created_at"].tolist() == [
+            pd.Timestamp("2024-01-01"),
+            pd.Timestamp("2024-02-01"),
+        ]
+
+    def test_does_not_convert_mixed_type_object_column(self):
+        df = pd.DataFrame(
+            {
+                "value": [
+                    "2024-01-01",
+                    "2024-02-01",
+                    "2024-03-01",
+                    "2024-04-01",
+                    123,
+                ]
+            },
+            dtype=object,
+        )
+
+        result = _infer_datetime_columns(df)
+
+        assert not pd.api.types.is_datetime64_any_dtype(result["value"])
+        assert result["value"].tolist() == [
+            "2024-01-01",
+            "2024-02-01",
+            "2024-03-01",
+            "2024-04-01",
+            123,
+        ]
+
+    def test_converts_datetime_values_with_time(self):
+        df = pd.DataFrame(
+            {
+                "created_at": [
+                    "2024-01-10 10:30:00",
+                    "2024-02-11 11:45:30",
+                    "2024-03-12T12:15:00",
+                ]
+            }
+        )
+
+        result = _infer_datetime_columns(df)
+
+        assert pd.api.types.is_datetime64_any_dtype(result["created_at"])
+        assert result.at[0, "created_at"] == pd.Timestamp("2024-01-10 10:30:00")

--- a/dataloom-backend/tests/test_file_formats.py
+++ b/dataloom-backend/tests/test_file_formats.py
@@ -123,6 +123,48 @@ class TestRoundTrip:
 
         assert result["age"].dtype == df["age"].dtype
 
+    def test_read_table_safe_infers_datetime_column(self, tmp_path):
+        path = tmp_path / "dates.csv"
+        path.write_text("created_at,value\n2024-01-01,10\n2024-02-01,20\n2024-03-01,30\n")
+
+        result = read_table_safe(path)
+
+        assert pd.api.types.is_datetime64_any_dtype(result["created_at"])
+        assert pd.api.types.is_integer_dtype(result["value"])
+        assert result["created_at"].tolist() == [
+            pd.Timestamp("2024-01-01"),
+            pd.Timestamp("2024-02-01"),
+            pd.Timestamp("2024-03-01"),
+        ]
+
+    def test_read_table_safe_does_not_infer_string_years_as_datetime(
+        self,
+        tmp_path,
+    ):
+        # JSON preserves these values as strings, unlike CSV, which may infer
+        # an integer dtype before datetime inference runs.
+        path = tmp_path / "years.json"
+        path.write_text(
+            json.dumps(
+                [
+                    {"grad_year": "2024"},
+                    {"grad_year": "2025"},
+                    {"grad_year": "2023"},
+                    {"grad_year": "2022"},
+                ]
+            )
+        )
+
+        result = read_table_safe(path)
+
+        assert not pd.api.types.is_datetime64_any_dtype(result["grad_year"])
+        assert result["grad_year"].tolist() == [
+            "2024",
+            "2025",
+            "2023",
+            "2022",
+        ]
+
 
 class TestJson:
     def test_flat_records(self, tmp_path):

--- a/dataloom-backend/tests/test_transformations.py
+++ b/dataloom-backend/tests/test_transformations.py
@@ -595,6 +595,81 @@ class TestFillEmpty:
         result = fill_empty(df, column_index=0, strategy="median")
         assert result["score"].iloc[1] == 15.33
 
+        # datetime column
+
+    def test_datetime_cell_with_valid_date_preserves_dtype(self):
+        df = pd.DataFrame(
+            {
+                "name": ["A", "B"],
+                "created_at": pd.to_datetime(["2024-01-01", "2024-02-01"]),
+            }
+        )
+
+        result = change_cell_value(df, 0, 2, "2024-05-22")
+
+        assert result.iloc[0]["created_at"] == pd.Timestamp("2024-05-22")
+        assert pd.api.types.is_datetime64_any_dtype(result["created_at"].dtype)
+
+    def test_datetime_cell_with_valid_timestamp_preserves_dtype(self):
+        df = pd.DataFrame(
+            {
+                "name": ["A", "B"],
+                "created_at": pd.to_datetime(["2024-01-01", "2024-02-01"]),
+            }
+        )
+
+        result = change_cell_value(df, 0, 2, "2024-05-22 14:30:15")
+
+        assert result.iloc[0]["created_at"] == pd.Timestamp("2024-05-22 14:30:15")
+        assert pd.api.types.is_datetime64_any_dtype(result["created_at"].dtype)
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "2024-05",
+            "2024",
+            "2024-05.",
+            "22-05-2024",
+            "2024/05/22",
+            "not-a-date",
+        ],
+    )
+    def test_datetime_cell_rejects_incomplete_or_invalid_values(self, raw):
+        df = pd.DataFrame(
+            {
+                "name": ["A"],
+                "created_at": pd.to_datetime(["2024-01-01"]),
+            }
+        )
+
+        with pytest.raises(TransformationError, match="Invalid datetime"):
+            change_cell_value(df, 0, 2, raw)
+
+    def test_invalid_datetime_edit_does_not_modify_original_dataframe(self):
+        df = pd.DataFrame(
+            {
+                "created_at": pd.to_datetime(["2024-01-01"]),
+            }
+        )
+
+        with pytest.raises(TransformationError):
+            change_cell_value(df, 0, 1, "2024-05")
+
+        assert df.iloc[0]["created_at"] == pd.Timestamp("2024-01-01")
+        assert pd.api.types.is_datetime64_any_dtype(df["created_at"].dtype)
+
+    def test_clear_datetime_cell_stores_missing_value_and_preserves_dtype(self):
+        df = pd.DataFrame(
+            {
+                "created_at": pd.to_datetime(["2024-01-01", "2024-02-01"]),
+            }
+        )
+
+        result = change_cell_value(df, 0, 1, "")
+
+        assert pd.isna(result.iloc[0]["created_at"])
+        assert pd.api.types.is_datetime64_any_dtype(result["created_at"].dtype)
+
 
 class TestDropDuplicates:
     def test_drop_duplicates(self):


### PR DESCRIPTION
## Description

Adds automatic datetime detection for uploaded datasets and improves datetime editing safety.

This change introduces automatic inference of datetime columns from string/object columns during file loading. A column is inferred as `datetime` when at least 80% of its non-null string values can be parsed successfully, ensuring consistent dtype detection across table rendering, profiling, and transformations.

Additionally, datetime values are now formatted for display without exposing unnecessary midnight timestamps:

- Date-only values display as `YYYY-MM-DD`
- Datetime values with time components display as `YYYY-MM-DD HH:MM:SS`
- The column dtype continues to be reported as `datetime`

Cell editing has also been improved by adding strict validation for datetime columns. Valid dates and timestamps are accepted, while incomplete or malformed values (e.g. `2024-05`, `2024-05.`, `hello`) are rejected instead of being silently normalized to unintended dates such as `2024-05-01`.

Fixes #437 

## Type of Change

- [x] New feature

## How Has This Been Tested?

**Added and updated tests covering:**

- Automatic datetime detection during file loading
- Datetime dtype mapping
- Date-only response formatting
- Datetime response formatting while preserving time components
- Preservation of null values in datetime columns
- Valid datetime and timestamp cell edits
- Rejection of incomplete and invalid datetime inputs
- Existing numeric, boolean, string, and null editing behavior

**Manual verification included:**

- Uploading datasets containing date columns and verifying automatic `datetime` detection
- Confirming date-only values render without `T00:00:00`
- Verifying timestamp values retain their time component
- Confirming invalid edits such as `2024-05` are rejected instead of being coerced to `2024-05-01`

- [x] Existing tests pass
- [x] New tests added
- [x] Manual testing

## Screenshots

<img width="129" height="291" alt="Screenshot 2026-07-14 at 03 09 05" src="https://github.com/user-attachments/assets/a26f48c9-6dc3-4940-b409-31c7d5c0b3bf" />

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally