### PR TITLE
fix: prevent unchanged cell edits from being persisted

### DIFF
--- a/dataloom-backend/app/api/endpoints/transformations.py
+++ b/dataloom-backend/app/api/endpoints/transformations.py
@@ -122,7 +122,13 @@ async def transform_project(
 
         result_df = _dispatch_transform(df, transformation_input)
 
-        if not preview:
+        # A cell edit that produces the same DataFrame is a no-op. Return the current
+        # data without rewriting the file or creating a transformation log.
+        is_noop_cell_edit = (
+            transformation_input.operation_type == schemas.OperationType.changeCellValue and result_df.equals(df)
+        )
+
+        if not preview and not is_noop_cell_edit:
             save_table_safe(result_df, project.file_path)
             try:
                 log_transformation(db, project_id, operation_type, transformation_input.dict())

--- a/dataloom-frontend/src/Components/Table.tsx
+++ b/dataloom-frontend/src/Components/Table.tsx
@@ -305,7 +305,21 @@ const Table = ({ projectId, showColumnProfiles = false }: TableProps) => {
     }
   };
 
+  const stopEditing = () => {
+    setEditingCell(null);
+    setEditValue("");
+  };
+
   const handleEditCell = async (rowIndex: number, cellIndex: number, newValue: string) => {
+    const currentValue = data[rowIndex]?.[cellIndex];
+    const normalizedCurrentValue = currentValue == null ? "" : String(currentValue);
+
+    // Do not send a transformation request when the value was not changed.
+    if (newValue === normalizedCurrentValue) {
+      stopEditing();
+      return;
+    }
+
     try {
       const backendColIndex =
         cellIndex === 0
@@ -322,10 +336,10 @@ const Table = ({ projectId, showColumnProfiles = false }: TableProps) => {
           fill_value: newValue,
         },
       });
+
       updateTableData(response);
       refreshProject(projectId, 1, pageSize);
-      setEditingCell(null);
-      setEditValue("");
+      stopEditing();
     } catch {
       setToast({
         message: "Failed to edit cell. Please try again.",
@@ -344,6 +358,7 @@ const Table = ({ projectId, showColumnProfiles = false }: TableProps) => {
     } else if (e.key === "Escape") {
       setEditingCell(null);
       setEditValue("");
+      stopEditing();
     }
   };
 
@@ -659,7 +674,7 @@ export function TablePagination({
 
   return (
     <div className="flex min-h-9 shrink-0 flex-wrap items-center justify-center md:justify-between gap-x-4 gap-y-2 px-4 py-1.5 bg-white text-xs sm:px-6">
-  <div className="flex items-center gap-x-5 gap-y-1.5 text-gray-600 flex-wrap">
+      <div className="flex items-center gap-x-5 gap-y-1.5 text-gray-600 flex-wrap">
         <div className="flex items-center gap-1.5">
           <span className="text-gray-500">Total Rows:</span>
           <span className="text-gray-900">{totalRows}</span>


### PR DESCRIPTION
## Description

Prevents unchanged cell edits from being processed as transformations.

Previously, clicking a cell and pressing `Enter` without modifying its value still sent a request to the backend. The backend then rewrote the project file and created a transformation log even though the data remained unchanged.

This change adds safeguards at both levels:

- The frontend compares the edited value with the original cell value and skips the request when they are equal.
- The backend detects no-op cell transformations and skips file persistence and change-log creation.

This avoids unnecessary network requests, file writes, misleading transformation history, and incorrect project modification updates.

Fixes #440 

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

Manually verified the following scenarios:

- Clicking a cell and pressing `Enter` without changing the value does not send a request.
- No change log is created for an unchanged cell value.
- The project file is not rewritten for a no-op edit.
- Changing a cell value still sends one transformation request.
- A valid cell edit still updates the table and creates a change log.
- Changing a value and then restoring the original value before pressing `Enter` is treated as a no-op.
- Pressing `Escape` exits edit mode without sending a request.

- [x] Existing tests pass
- [x] Manual testing

## Screenshots (if applicable)

Not applicable.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally