### PR TITLE
perf: run blocking data endpoints in a threadpool, not on the event loop

### DIFF
--- a/dataloom-backend/app/api/dependencies.py
+++ b/dataloom-backend/app/api/dependencies.py
@@ -13,7 +13,7 @@ from app.config import get_settings
 from app.services import auth_service
 from app.utils.logging import get_logger
 from app.utils.pandas_helpers import read_table_safe
-from app.utils.project_locks import project_write_lock
+from app.utils.project_locks import project_read_lock
 from app.utils.rate_limiter import RateLimiter
 
 logger = get_logger(__name__)
@@ -159,18 +159,36 @@ def get_project_or_404(
     return fetch_owned_project(db, project_id, current_user)
 
 
-def load_project_df(project: models.Project) -> pd.DataFrame:
+def read_project_df(project: models.Project) -> pd.DataFrame:
     """Read a project's working copy, redacting any path from error details.
 
     ``read_table_safe`` embeds the absolute file path in its 404/500 details;
     surface a generic message to the client instead, matching the transform
-    endpoint's handling. Shared by the profiling and visualization endpoints.
+    endpoint's handling.
+
+    Takes no project lock, so it is safe to call from code already holding
+    :func:`app.utils.project_locks.project_write_lock` (which is not reentrant).
+    Unlocked callers should use :func:`load_project_df` instead.
     """
     try:
-        with project_write_lock(project.project_id):
-            return read_table_safe(project.file_path)
+        return read_table_safe(project.file_path)
     except HTTPException as e:
         if e.status_code == 404:
             raise HTTPException(status_code=404, detail="Project data file not found") from e
         logger.warning("Failed to read project file project_id=%s status=%s", project.project_id, e.status_code)
         raise HTTPException(status_code=e.status_code, detail="Could not read project data") from e
+
+
+def load_project_df(project: models.Project) -> pd.DataFrame:
+    """Read a project's working copy under the shared project read lock.
+
+    The lock keeps the read from landing mid-write while a save, transform,
+    revert, undo, append or pipeline run rewrites the file in place. It is
+    shared, so concurrent readers of the same project still overlap.
+
+    Blocks the calling thread, so callers must be plain ``def`` path operations
+    (run in FastAPI's threadpool) rather than ``async def`` ones. Shared by the
+    profiling, visualization, reporting, quality, pipeline and append endpoints.
+    """
+    with project_read_lock(project.project_id):
+        return read_project_df(project)

--- a/dataloom-backend/app/api/dependencies.py
+++ b/dataloom-backend/app/api/dependencies.py
@@ -13,6 +13,7 @@ from app.config import get_settings
 from app.services import auth_service
 from app.utils.logging import get_logger
 from app.utils.pandas_helpers import read_table_safe
+from app.utils.project_locks import project_write_lock
 from app.utils.rate_limiter import RateLimiter
 
 logger = get_logger(__name__)
@@ -166,7 +167,8 @@ def load_project_df(project: models.Project) -> pd.DataFrame:
     endpoint's handling. Shared by the profiling and visualization endpoints.
     """
     try:
-        return read_table_safe(project.file_path)
+        with project_write_lock(project.project_id):
+            return read_table_safe(project.file_path)
     except HTTPException as e:
         if e.status_code == 404:
             raise HTTPException(status_code=404, detail="Project data file not found") from e

--- a/dataloom-backend/app/api/endpoints/pipelines.py
+++ b/dataloom-backend/app/api/endpoints/pipelines.py
@@ -12,10 +12,12 @@ from app.api.dependencies import (
     fetch_owned_project,
     get_current_user,
     load_project_df,
+    read_project_df,
 )
 from app.services import pipeline_service
 from app.services.transformation_service import TransformationError
 from app.utils.pandas_helpers import dataframe_to_response
+from app.utils.project_locks import project_write_lock
 from app.utils.security import safe_transformation_error_detail
 
 router = APIRouter()
@@ -99,9 +101,14 @@ def apply_pipeline(
     pipeline = fetch_owned_pipeline(db, pipeline_id, current_user)
     project = fetch_owned_project(db, body.project_id, current_user)
 
-    df = load_project_df(project)
+    # Applying a pipeline is a read-modify-write of the working copy, so the read
+    # and the write share one exclusive lock; splitting them would let a
+    # concurrent transform slip in between and lose an update. The write lock is
+    # not reentrant, hence read_project_df rather than load_project_df.
     try:
-        result_df = pipeline_service.apply_pipeline_to_project(db, project, pipeline, df)
+        with project_write_lock(project.project_id):
+            df = read_project_df(project)
+            result_df = pipeline_service.apply_pipeline_to_project(db, project, pipeline, df)
     except TransformationError as e:
         raise HTTPException(status_code=400, detail=safe_transformation_error_detail(e)) from e
 

--- a/dataloom-backend/app/api/endpoints/profiling.py
+++ b/dataloom-backend/app/api/endpoints/profiling.py
@@ -17,7 +17,7 @@ router = APIRouter()
 
 
 @router.get("/{project_id}/profile/summary", response_model=schemas.DatasetSummaryResponse)
-async def get_dataset_summary(
+def get_dataset_summary(
     project_id: uuid.UUID,
     project: models.Project = Depends(get_project_or_404),
 ):
@@ -27,7 +27,7 @@ async def get_dataset_summary(
 
 
 @router.get("/{project_id}/profile/column", response_model=schemas.ColumnProfileResponse)
-async def get_column_profile(
+def get_column_profile(
     project_id: uuid.UUID,
     column_name: str = Query(..., description="Name of the column to profile"),
     project: models.Project = Depends(get_project_or_404),
@@ -47,7 +47,7 @@ async def get_column_profile(
 
 
 @router.get("/{project_id}/profile/columns", response_model=schemas.ColumnProfilesResponse)
-async def get_all_column_profiles(
+def get_all_column_profiles(
     project_id: uuid.UUID,
     project: models.Project = Depends(get_project_or_404),
 ):
@@ -62,7 +62,7 @@ async def get_all_column_profiles(
 
 
 @router.get("/{project_id}/profile/correlation", response_model=schemas.CorrelationResponse)
-async def get_correlation_matrix(
+def get_correlation_matrix(
     project_id: uuid.UUID,
     project: models.Project = Depends(get_project_or_404),
 ):

--- a/dataloom-backend/app/api/endpoints/project_files.py
+++ b/dataloom-backend/app/api/endpoints/project_files.py
@@ -19,9 +19,10 @@ from pathlib import Path
 
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
 from sqlmodel import Session
+from starlette.concurrency import run_in_threadpool
 
 from app import database, models, schemas
-from app.api.dependencies import get_project_or_404, load_project_df
+from app.api.dependencies import get_project_or_404, load_project_df, read_project_df
 from app.services.append_service import analyze_append, append_dataframes
 from app.services.file_service import store_added_file
 from app.services.project_service import (
@@ -32,6 +33,7 @@ from app.services.project_service import (
 )
 from app.utils.logging import get_logger
 from app.utils.pandas_helpers import dataframe_to_response, read_table_safe, save_table_safe
+from app.utils.project_locks import project_write_lock
 from app.utils.security import validate_upload_file
 
 logger = get_logger(__name__)
@@ -72,10 +74,28 @@ def _append_and_log(
     written first, and if audit logging fails the file is restored so state
     never diverges from the log chain.
 
+    This is a read-modify-write of ``project.file_path``, so it runs under the
+    exclusive project lock: without it a concurrent transform or save could
+    interleave and lose one of the two updates, and a concurrent reader could
+    parse the file mid-write. The read inside uses ``read_project_df`` rather
+    than ``load_project_df`` because the write lock is not reentrant.
+
     Returns:
         The ProjectResponse payload for the combined data.
     """
-    df = load_project_df(project)
+    with project_write_lock(project.project_id):
+        return _append_and_log_locked(db, project, stored_path, original_filename, project_file_id)
+
+
+def _append_and_log_locked(
+    db: Session,
+    project: models.Project,
+    stored_path: str,
+    original_filename: str,
+    project_file_id: uuid.UUID,
+) -> dict:
+    """Body of :func:`_append_and_log`; assumes the project write lock is held."""
+    df = read_project_df(project)
     new_df = read_table_safe(Path(stored_path))
     combined = append_dataframes(df, new_df)
 
@@ -117,6 +137,18 @@ def _append_and_log(
     }
 
 
+def _preview_append(file: UploadFile, project: models.Project) -> dict:
+    """Parse an upload and describe how it would align with the working copy.
+
+    Blocking throughout: it parses the upload, waits on the project read lock,
+    reads the working copy, and compares the two frames. Callers on the event
+    loop must offload it.
+    """
+    new_df = _read_upload_df(file)
+    df = load_project_df(project)
+    return analyze_append(df, new_df)
+
+
 @router.post("/{project_id}/files/preview", response_model=schemas.AppendPreviewResponse)
 async def preview_add_file(
     file: UploadFile = File(...),
@@ -128,9 +160,7 @@ async def preview_add_file(
     until the client confirms via ``POST /{project_id}/files``.
     """
     await validate_upload_file(file)
-    new_df = _read_upload_df(file)
-    df = load_project_df(project)
-    return analyze_append(df, new_df)
+    return await run_in_threadpool(_preview_append, file, project)
 
 
 @router.post("/{project_id}/files", response_model=schemas.ProjectResponse)
@@ -149,13 +179,13 @@ async def add_file(
     await validate_upload_file(file)
 
     try:
-        stored_path = store_added_file(file)
+        stored_path = await run_in_threadpool(store_added_file, file)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
 
     # Validate the stored file parses before recording anything.
     try:
-        read_table_safe(stored_path)
+        await run_in_threadpool(read_table_safe, stored_path)
     except HTTPException as e:
         with suppress(FileNotFoundError):
             stored_path.unlink()
@@ -165,7 +195,9 @@ async def add_file(
         raise
 
     project_file = create_project_file(db, project.project_id, str(stored_path), file.filename)
-    return _append_and_log(db, project, str(stored_path), file.filename, project_file.id)
+    # _append_and_log blocks on the project write lock and rewrites the working
+    # copy; keep it off the event loop.
+    return await run_in_threadpool(_append_and_log, db, project, str(stored_path), file.filename, project_file.id)
 
 
 @router.get("/{project_id}/files", response_model=list[schemas.ProjectFileResponse])
@@ -178,7 +210,7 @@ async def list_project_files(
 
 
 @router.post("/{project_id}/files/{file_id}/append", response_model=schemas.ProjectResponse)
-async def reappend_project_file(
+def reappend_project_file(
     file_id: uuid.UUID,
     db: Session = Depends(database.get_db),
     project: models.Project = Depends(get_project_or_404),

--- a/dataloom-backend/app/api/endpoints/projects.py
+++ b/dataloom-backend/app/api/endpoints/projects.py
@@ -14,6 +14,7 @@ from fastapi.responses import FileResponse
 from sqlalchemy.exc import SQLAlchemyError
 from sqlmodel import Session
 from starlette.background import BackgroundTask
+from starlette.concurrency import run_in_threadpool
 
 from app import database, models, schemas
 from app.api.dependencies import get_current_user, get_project_or_404
@@ -35,6 +36,7 @@ from app.services.transformation_service import apply_logged_transformation
 from app.utils.file_formats import TableWriteOptions, get_format, get_format_for_extension
 from app.utils.logging import get_logger
 from app.utils.pandas_helpers import dataframe_to_response, read_table_safe, save_table_safe
+from app.utils.project_locks import project_write_lock
 from app.utils.security import validate_upload_file
 
 logger = get_logger(__name__)
@@ -63,9 +65,9 @@ async def upload_project(
     logger.info("Upload request: project=%s, file=%s", projectName, file.filename)
     await validate_upload_file(file)
 
-    original_path, copy_path = store_upload(file)
+    original_path, copy_path = await run_in_threadpool(store_upload, file)
     try:
-        df = read_table_safe(original_path)
+        df = await run_in_threadpool(read_table_safe, original_path)
     except HTTPException as e:
         # The just-uploaded file could not be parsed — that's a bad client file,
         # not a server fault. Discard the orphaned files and report a clean 400.
@@ -113,7 +115,7 @@ def list_projects(
 
 
 @router.get("/get/{project_id}", response_model=schemas.ProjectResponse)
-async def get_project_details(
+def get_project_details(
     page: int = 1,
     pageSize: int = 50,
     project: models.Project = Depends(get_project_or_404),
@@ -179,7 +181,7 @@ async def rename_project_endpoint(
 
 
 @router.post("/{project_id}/save", response_model=schemas.ProjectResponse)
-async def save_project(
+def save_project(
     project_id: uuid.UUID,
     commit_message: str,
     db: Session = Depends(database.get_db),
@@ -191,23 +193,24 @@ async def save_project(
     checkpoint creation should preserve that current dataset and only update the
     checkpoint/log metadata for pending actions.
     """
-    original_path = get_original_path(project.file_path)
-    if Path(project.file_path).resolve() == original_path.resolve():
-        logger.error(
-            "Project working copy unexpectedly points at original file: id=%s working_copy=%s original=%s",
-            project_id,
-            project.file_path,
-            original_path,
-        )
-        raise HTTPException(
-            status_code=500,
-            detail=f"Project {project_id} working copy is misconfigured; please retry or contact support.",
-        )
+    with project_write_lock(project_id):
+        original_path = get_original_path(project.file_path)
+        if Path(project.file_path).resolve() == original_path.resolve():
+            logger.error(
+                "Project working copy unexpectedly points at original file: id=%s working_copy=%s original=%s",
+                project_id,
+                project.file_path,
+                original_path,
+            )
+            raise HTTPException(
+                status_code=500,
+                detail=f"Project {project_id} working copy is misconfigured; please retry or contact support.",
+            )
 
-    df = read_table_safe(project.file_path)
+        df = read_table_safe(project.file_path)
 
-    # Create checkpoint (marks logs as applied)
-    checkpoint = create_checkpoint(db, project_id, commit_message)
+        # Create checkpoint (marks logs as applied)
+        checkpoint = create_checkpoint(db, project_id, commit_message)
 
     total_rows = len(df)
     resp = dataframe_to_response(df)
@@ -225,7 +228,7 @@ async def save_project(
 
 
 @router.post("/{project_id}/revert", response_model=schemas.ProjectResponse)
-async def revert_to_checkpoint(
+def revert_to_checkpoint(
     project_id: uuid.UUID,
     checkpoint_id: uuid.UUID = None,
     db: Session = Depends(database.get_db),
@@ -237,6 +240,11 @@ async def revert_to_checkpoint(
     that checkpoint onto the original file. When None, reverts to the original
     uploaded state.
     """
+    with project_write_lock(project_id):
+        return _revert_to_checkpoint(project_id, checkpoint_id, db, project)
+
+
+def _revert_to_checkpoint(project_id, checkpoint_id, db, project):
     original_path = get_original_path(project.file_path)
     df = read_table_safe(original_path)
 
@@ -308,7 +316,7 @@ async def revert_to_checkpoint(
 
 
 @router.get("/{project_id}/export")
-async def export_project(
+def export_project(
     fmt: str | None = Query(default=None, alias="format"),
     delimiter: str | None = Query(default=None),
     include_header: bool = Query(default=True),
@@ -417,7 +425,7 @@ async def delete_project_endpoint(
 
 
 @router.post("/{project_id}/undo", response_model=schemas.ProjectResponse)
-async def undo_last_transformation(
+def undo_last_transformation(
     project_id: uuid.UUID,
     project: models.Project = Depends(get_project_or_404),
     db: Session = Depends(database.get_db),
@@ -427,6 +435,11 @@ async def undo_last_transformation(
     Removes the last change log entry and rebuilds the working copy
     by replaying all remaining logs onto the original file.
     """
+    with project_write_lock(project_id):
+        return _undo_last_transformation(project_id, project, db)
+
+
+def _undo_last_transformation(project_id, project, db):
     last_log = get_last_change_log(db, project_id)
     if not last_log:
         raise HTTPException(status_code=404, detail="No transformations to undo")

--- a/dataloom-backend/app/api/endpoints/projects.py
+++ b/dataloom-backend/app/api/endpoints/projects.py
@@ -37,7 +37,7 @@ from app.services.transformation_service import apply_logged_transformation
 from app.utils.file_formats import TableWriteOptions, get_format, get_format_for_extension
 from app.utils.logging import get_logger
 from app.utils.pandas_helpers import dataframe_to_response, read_table_safe, save_table_safe
-from app.utils.project_locks import project_write_lock
+from app.utils.project_locks import project_read_lock, project_write_lock
 from app.utils.security import validate_upload_file
 
 logger = get_logger(__name__)
@@ -122,7 +122,7 @@ def get_project_details(
     project: models.Project = Depends(get_project_or_404),
 ):
     """Fetch full project details including all rows and columns."""
-    with project_write_lock(project.project_id):
+    with project_read_lock(project.project_id):
         df = read_table_safe(project.file_path)
 
     total_rows = len(df)
@@ -246,7 +246,12 @@ def revert_to_checkpoint(
         return _revert_to_checkpoint(project_id, checkpoint_id, db, project)
 
 
-def _revert_to_checkpoint(project_id, checkpoint_id, db, project):
+def _revert_to_checkpoint(
+    project_id: uuid.UUID,
+    checkpoint_id: uuid.UUID | None,
+    db: Session,
+    project: models.Project,
+) -> dict:
     original_path = get_original_path(project.file_path)
     df = read_table_safe(original_path)
 
@@ -362,12 +367,12 @@ def export_project(
 
     native = target_fmt.extension == source_fmt.extension and not write_options.has_options()
 
-    # Snapshot under the project lock. FileResponse streams after we return,
+    # Snapshot under the shared read lock. FileResponse streams after we return,
     # so serving the live working copy could tear if a writer starts mid-download.
     with tempfile.NamedTemporaryFile(suffix=target_fmt.extension, delete=False) as tmp:
         tmp_path = tmp.name
     try:
-        with project_write_lock(project.project_id):
+        with project_read_lock(project.project_id):
             if native:
                 shutil.copyfile(project.file_path, tmp_path)
             else:
@@ -441,7 +446,11 @@ def undo_last_transformation(
         return _undo_last_transformation(project_id, project, db)
 
 
-def _undo_last_transformation(project_id, project, db):
+def _undo_last_transformation(
+    project_id: uuid.UUID,
+    project: models.Project,
+    db: Session,
+) -> dict:
     last_log = get_last_change_log(db, project_id)
     if not last_log:
         raise HTTPException(status_code=404, detail="No transformations to undo")

--- a/dataloom-backend/app/api/endpoints/projects.py
+++ b/dataloom-backend/app/api/endpoints/projects.py
@@ -4,6 +4,7 @@ Handles upload, retrieval, save (checkpoint), and revert operations.
 """
 
 import os
+import shutil
 import tempfile
 import uuid
 from contextlib import suppress
@@ -14,6 +15,7 @@ from fastapi.responses import FileResponse
 from sqlalchemy.exc import SQLAlchemyError
 from sqlmodel import Session
 from starlette.background import BackgroundTask
+from starlette.concurrency import run_in_threadpool
 
 from app import database, models, schemas
 from app.api.dependencies import get_current_user, get_project_or_404
@@ -35,6 +37,7 @@ from app.services.transformation_service import apply_logged_transformation
 from app.utils.file_formats import TableWriteOptions, get_format, get_format_for_extension
 from app.utils.logging import get_logger
 from app.utils.pandas_helpers import dataframe_to_response, read_table_safe, save_table_safe
+from app.utils.project_locks import project_write_lock
 from app.utils.security import validate_upload_file
 
 logger = get_logger(__name__)
@@ -63,9 +66,9 @@ async def upload_project(
     logger.info("Upload request: project=%s, file=%s", projectName, file.filename)
     await validate_upload_file(file)
 
-    original_path, copy_path = store_upload(file)
+    original_path, copy_path = await run_in_threadpool(store_upload, file)
     try:
-        df = read_table_safe(original_path)
+        df = await run_in_threadpool(read_table_safe, original_path)
     except HTTPException as e:
         # The just-uploaded file could not be parsed — that's a bad client file,
         # not a server fault. Discard the orphaned files and report a clean 400.
@@ -113,13 +116,14 @@ def list_projects(
 
 
 @router.get("/get/{project_id}", response_model=schemas.ProjectResponse)
-async def get_project_details(
+def get_project_details(
     page: int = 1,
     pageSize: int = 50,
     project: models.Project = Depends(get_project_or_404),
 ):
     """Fetch full project details including all rows and columns."""
-    df = read_table_safe(project.file_path)
+    with project_write_lock(project.project_id):
+        df = read_table_safe(project.file_path)
 
     total_rows = len(df)
     total_pages = (total_rows + pageSize - 1) // pageSize
@@ -179,7 +183,7 @@ async def rename_project_endpoint(
 
 
 @router.post("/{project_id}/save", response_model=schemas.ProjectResponse)
-async def save_project(
+def save_project(
     project_id: uuid.UUID,
     commit_message: str,
     db: Session = Depends(database.get_db),
@@ -191,23 +195,24 @@ async def save_project(
     checkpoint creation should preserve that current dataset and only update the
     checkpoint/log metadata for pending actions.
     """
-    original_path = get_original_path(project.file_path)
-    if Path(project.file_path).resolve() == original_path.resolve():
-        logger.error(
-            "Project working copy unexpectedly points at original file: id=%s working_copy=%s original=%s",
-            project_id,
-            project.file_path,
-            original_path,
-        )
-        raise HTTPException(
-            status_code=500,
-            detail=f"Project {project_id} working copy is misconfigured; please retry or contact support.",
-        )
+    with project_write_lock(project_id):
+        original_path = get_original_path(project.file_path)
+        if Path(project.file_path).resolve() == original_path.resolve():
+            logger.error(
+                "Project working copy unexpectedly points at original file: id=%s working_copy=%s original=%s",
+                project_id,
+                project.file_path,
+                original_path,
+            )
+            raise HTTPException(
+                status_code=500,
+                detail=f"Project {project_id} working copy is misconfigured; please retry or contact support.",
+            )
 
-    df = read_table_safe(project.file_path)
+        df = read_table_safe(project.file_path)
 
-    # Create checkpoint (marks logs as applied)
-    checkpoint = create_checkpoint(db, project_id, commit_message)
+        # Create checkpoint (marks logs as applied)
+        checkpoint = create_checkpoint(db, project_id, commit_message)
 
     total_rows = len(df)
     resp = dataframe_to_response(df)
@@ -225,7 +230,7 @@ async def save_project(
 
 
 @router.post("/{project_id}/revert", response_model=schemas.ProjectResponse)
-async def revert_to_checkpoint(
+def revert_to_checkpoint(
     project_id: uuid.UUID,
     checkpoint_id: uuid.UUID = None,
     db: Session = Depends(database.get_db),
@@ -237,6 +242,11 @@ async def revert_to_checkpoint(
     that checkpoint onto the original file. When None, reverts to the original
     uploaded state.
     """
+    with project_write_lock(project_id):
+        return _revert_to_checkpoint(project_id, checkpoint_id, db, project)
+
+
+def _revert_to_checkpoint(project_id, checkpoint_id, db, project):
     original_path = get_original_path(project.file_path)
     df = read_table_safe(original_path)
 
@@ -308,7 +318,7 @@ async def revert_to_checkpoint(
 
 
 @router.get("/{project_id}/export")
-async def export_project(
+def export_project(
     fmt: str | None = Query(default=None, alias="format"),
     delimiter: str | None = Query(default=None),
     include_header: bool = Query(default=True),
@@ -350,20 +360,20 @@ async def export_project(
         encoding=encoding,
     )
 
-    # Native export — no conversion and no delimited options means we can stream
-    # the working copy directly.
-    if target_fmt.extension == source_fmt.extension and not write_options.has_options():
-        return FileResponse(
-            project.file_path,
-            media_type=target_fmt.media_type,
-            filename=f"{project.name}{target_fmt.extension}",
-        )
+    native = target_fmt.extension == source_fmt.extension and not write_options.has_options()
 
-    df = read_table_safe(project.file_path)
+    # Snapshot under the project lock. FileResponse streams after we return,
+    # so serving the live working copy could tear if a writer starts mid-download.
     with tempfile.NamedTemporaryFile(suffix=target_fmt.extension, delete=False) as tmp:
         tmp_path = tmp.name
     try:
-        save_table_safe(df, Path(tmp_path), write_options)
+        with project_write_lock(project.project_id):
+            if native:
+                shutil.copyfile(project.file_path, tmp_path)
+            else:
+                df = read_table_safe(project.file_path)
+        if not native:
+            save_table_safe(df, Path(tmp_path), write_options)
         return FileResponse(
             tmp_path,
             media_type=target_fmt.media_type,
@@ -417,7 +427,7 @@ async def delete_project_endpoint(
 
 
 @router.post("/{project_id}/undo", response_model=schemas.ProjectResponse)
-async def undo_last_transformation(
+def undo_last_transformation(
     project_id: uuid.UUID,
     project: models.Project = Depends(get_project_or_404),
     db: Session = Depends(database.get_db),
@@ -427,6 +437,11 @@ async def undo_last_transformation(
     Removes the last change log entry and rebuilds the working copy
     by replaying all remaining logs onto the original file.
     """
+    with project_write_lock(project_id):
+        return _undo_last_transformation(project_id, project, db)
+
+
+def _undo_last_transformation(project_id, project, db):
     last_log = get_last_change_log(db, project_id)
     if not last_log:
         raise HTTPException(status_code=404, detail="No transformations to undo")

--- a/dataloom-backend/app/api/endpoints/transformations.py
+++ b/dataloom-backend/app/api/endpoints/transformations.py
@@ -16,7 +16,7 @@ from app.services import transformation_service as ts
 from app.services.project_service import log_transformations_or_restore
 from app.utils.logging import get_logger
 from app.utils.pandas_helpers import dataframe_to_response, read_table_safe, save_table_safe
-from app.utils.project_locks import project_write_lock
+from app.utils.project_locks import project_read_lock, project_write_lock
 from app.utils.security import safe_transformation_error_detail
 
 logger = get_logger(__name__)
@@ -78,13 +78,25 @@ def transform_project(
     """Apply a transformation to a project.
 
     Routes to the appropriate internal handler based on operation_type.
-    Preview still reads ``project.file_path``, so it shares the same lock.
+
+    A preview only reads ``project.file_path``, so it takes the shared read lock
+    and stays concurrent with other previews; a real transform rewrites the file
+    and needs the exclusive write lock.
     """
-    with project_write_lock(project_id):
+    lock = project_read_lock if preview else project_write_lock
+    with lock(project_id):
         return _transform_project(project_id, transformation_input, preview, page, page_size, db, project)
 
 
-def _transform_project(project_id, transformation_input, preview, page, page_size, db, project):
+def _transform_project(
+    project_id: uuid.UUID,
+    transformation_input: schemas.TransformationInput,
+    preview: bool,
+    page: int,
+    page_size: int,
+    db: Session,
+    project: models.Project,
+) -> dict:
     operation_type = getattr(transformation_input, "operation_type", "<unknown>")
 
     try:

--- a/dataloom-backend/app/api/endpoints/transformations.py
+++ b/dataloom-backend/app/api/endpoints/transformations.py
@@ -16,6 +16,7 @@ from app.services import transformation_service as ts
 from app.services.project_service import log_transformations_or_restore
 from app.utils.logging import get_logger
 from app.utils.pandas_helpers import dataframe_to_response, read_table_safe, save_table_safe
+from app.utils.project_locks import project_write_lock
 from app.utils.security import safe_transformation_error_detail
 
 logger = get_logger(__name__)
@@ -65,7 +66,7 @@ def _dispatch_transform(df, transformation_input):
 
 
 @router.post("/{project_id}/transform", response_model=schemas.BasicQueryResponse)
-async def transform_project(
+def transform_project(
     project_id: uuid.UUID,
     transformation_input: schemas.TransformationInput,
     preview: bool = Query(False, description="If true, return transformation data without saving."),
@@ -77,10 +78,13 @@ async def transform_project(
     """Apply a transformation to a project.
 
     Routes to the appropriate internal handler based on operation_type.
+    Preview still reads ``project.file_path``, so it shares the same lock.
     """
-    # Keep an explicit local for consistency across dispatch, persistence and
-    # logging paths. Use a defensive fallback so exception logging never
-    # introduces a secondary NameError.
+    with project_write_lock(project_id):
+        return _transform_project(project_id, transformation_input, preview, page, page_size, db, project)
+
+
+def _transform_project(project_id, transformation_input, preview, page, page_size, db, project):
     operation_type = getattr(transformation_input, "operation_type", "<unknown>")
 
     try:

--- a/dataloom-backend/app/api/endpoints/transformations.py
+++ b/dataloom-backend/app/api/endpoints/transformations.py
@@ -16,6 +16,7 @@ from app.services import transformation_service as ts
 from app.services.project_service import log_transformation
 from app.utils.logging import get_logger
 from app.utils.pandas_helpers import dataframe_to_response, read_table_safe, save_table_safe
+from app.utils.project_locks import project_write_lock
 
 logger = get_logger(__name__)
 
@@ -102,7 +103,7 @@ def _dispatch_transform(df, transformation_input):
 
 
 @router.post("/{project_id}/transform", response_model=schemas.BasicQueryResponse)
-async def transform_project(
+def transform_project(
     project_id: uuid.UUID,
     transformation_input: schemas.TransformationInput,
     preview: bool = Query(False, description="If true, return transformation data without saving."),
@@ -115,9 +116,13 @@ async def transform_project(
 
     Routes to the appropriate internal handler based on operation_type.
     """
-    # Keep an explicit local for consistency across dispatch, persistence and
-    # logging paths. Use a defensive fallback so exception logging never
-    # introduces a secondary NameError.
+    if not preview:
+        with project_write_lock(project_id):
+            return _transform_project(project_id, transformation_input, preview, page, page_size, db, project)
+    return _transform_project(project_id, transformation_input, preview, page, page_size, db, project)
+
+
+def _transform_project(project_id, transformation_input, preview, page, page_size, db, project):
     operation_type = getattr(transformation_input, "operation_type", "<unknown>")
 
     try:

--- a/dataloom-backend/app/api/endpoints/visualizations.py
+++ b/dataloom-backend/app/api/endpoints/visualizations.py
@@ -21,7 +21,7 @@ router = APIRouter()
 
 
 @router.get("/{project_id}/charts/suggest", response_model=schemas.ChartSuggestionsResponse)
-async def suggest_charts(
+def suggest_charts(
     project_id: uuid.UUID,
     project: models.Project = Depends(get_project_or_404),
 ):
@@ -31,7 +31,7 @@ async def suggest_charts(
 
 
 @router.get("/{project_id}/charts", response_model=schemas.ChartSpec)
-async def get_chart(
+def get_chart(
     project_id: uuid.UUID,
     chart_type: schemas.ChartType = Query(..., description="The kind of chart to build"),
     column: str | None = Query(None, description="Numeric column for a histogram"),

--- a/dataloom-backend/app/utils/project_locks.py
+++ b/dataloom-backend/app/utils/project_locks.py
@@ -1,0 +1,33 @@
+"""Per-project synchronization for file and change-log mutations."""
+
+import threading
+import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+_registry_lock = threading.Lock()
+_project_locks: dict[uuid.UUID, tuple[threading.Lock, int]] = {}
+
+
+@contextmanager
+def project_write_lock(project_id: uuid.UUID) -> Iterator[None]:
+    """Serialize reads and writes of one project's working copy.
+
+    The same lock covers writers and readers of ``project.file_path`` so a
+    threadpool reader cannot observe a torn in-place write. Independent
+    projects stay concurrent.
+    """
+    with _registry_lock:
+        lock, users = _project_locks.get(project_id, (threading.Lock(), 0))
+        _project_locks[project_id] = (lock, users + 1)
+
+    try:
+        with lock:
+            yield
+    finally:
+        with _registry_lock:
+            current_lock, users = _project_locks[project_id]
+            if users == 1:
+                del _project_locks[project_id]
+            else:
+                _project_locks[project_id] = (current_lock, users - 1)

--- a/dataloom-backend/app/utils/project_locks.py
+++ b/dataloom-backend/app/utils/project_locks.py
@@ -1,0 +1,28 @@
+"""Per-project synchronization for file and change-log mutations."""
+
+import threading
+import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+_registry_lock = threading.Lock()
+_project_locks: dict[uuid.UUID, tuple[threading.Lock, int]] = {}
+
+
+@contextmanager
+def project_write_lock(project_id: uuid.UUID) -> Iterator[None]:
+    """Serialize mutations for one project without blocking other projects."""
+    with _registry_lock:
+        lock, users = _project_locks.get(project_id, (threading.Lock(), 0))
+        _project_locks[project_id] = (lock, users + 1)
+
+    try:
+        with lock:
+            yield
+    finally:
+        with _registry_lock:
+            current_lock, users = _project_locks[project_id]
+            if users == 1:
+                del _project_locks[project_id]
+            else:
+                _project_locks[project_id] = (current_lock, users - 1)

--- a/dataloom-backend/app/utils/project_locks.py
+++ b/dataloom-backend/app/utils/project_locks.py
@@ -1,29 +1,105 @@
-"""Per-project synchronization for file and change-log mutations."""
+"""Per-project synchronization for the working copy and its change log.
+
+The data endpoints run in FastAPI's threadpool (they are plain ``def`` handlers),
+so two requests for the same project genuinely run in parallel. The format
+writers in :mod:`app.utils.file_formats` truncate and rewrite
+``project.file_path`` in place, which leaves two hazards:
+
+* a reader can parse the file mid-write and see truncated or partial data;
+* two read-modify-write requests can interleave, so the second one's save
+  silently discards the first one's update.
+
+This module hands out one readers-writer lock per project id:
+
+* :func:`project_read_lock` is shared. Any number of readers run at once, which
+  is the common case -- the UI opens several profiling panels together, and each
+  one only reads.
+* :func:`project_write_lock` is exclusive. It waits for in-flight readers and
+  writers, and holds off new ones until the write completes.
+
+The lock is writer-preferring: once a writer is waiting, arriving readers queue
+behind it, so a steady stream of reads cannot starve a save.
+
+Both helpers block the calling thread, so they must only be entered from a
+threadpool worker -- never from an ``async def`` handler running on the event
+loop, where blocking would stall every request for every project.
+
+Locks are reference-counted and dropped once nobody holds or awaits them, so a
+long-lived process does not accumulate one lock per project it ever touched.
+"""
 
 import threading
 import uuid
 from collections.abc import Iterator
 from contextlib import contextmanager
 
+
+class _ReadWriteLock:
+    """A writer-preferring readers-writer lock.
+
+    ``threading`` ships no such primitive, and the shared-read case is what
+    keeps concurrent profiling requests for one project from serializing.
+    """
+
+    def __init__(self) -> None:
+        self._condition = threading.Condition(threading.Lock())
+        self._readers = 0
+        self._writer_active = False
+        self._writers_waiting = 0
+
+    def acquire_read(self) -> None:
+        with self._condition:
+            # Yield to waiting writers so reads cannot starve a save.
+            while self._writer_active or self._writers_waiting:
+                self._condition.wait()
+            self._readers += 1
+
+    def release_read(self) -> None:
+        with self._condition:
+            self._readers -= 1
+            if self._readers == 0:
+                self._condition.notify_all()
+
+    def acquire_write(self) -> None:
+        with self._condition:
+            self._writers_waiting += 1
+            try:
+                while self._writer_active or self._readers:
+                    self._condition.wait()
+            finally:
+                self._writers_waiting -= 1
+            self._writer_active = True
+
+    def release_write(self) -> None:
+        with self._condition:
+            self._writer_active = False
+            self._condition.notify_all()
+
+
 _registry_lock = threading.Lock()
-_project_locks: dict[uuid.UUID, tuple[threading.Lock, int]] = {}
+_project_locks: dict[uuid.UUID, tuple[_ReadWriteLock, int]] = {}
 
 
 @contextmanager
-def project_write_lock(project_id: uuid.UUID) -> Iterator[None]:
-    """Serialize reads and writes of one project's working copy.
+def _project_lock(project_id: uuid.UUID, *, exclusive: bool) -> Iterator[None]:
+    """Hold one project's lock in shared or exclusive mode.
 
-    The same lock covers writers and readers of ``project.file_path`` so a
-    threadpool reader cannot observe a torn in-place write. Independent
-    projects stay concurrent.
+    The registry entry is reference-counted around the whole hold, so the lock
+    object cannot be evicted while another thread is still queued on it.
     """
     with _registry_lock:
-        lock, users = _project_locks.get(project_id, (threading.Lock(), 0))
+        lock, users = _project_locks.get(project_id, (_ReadWriteLock(), 0))
         _project_locks[project_id] = (lock, users + 1)
 
     try:
-        with lock:
+        acquire, release = (
+            (lock.acquire_write, lock.release_write) if exclusive else (lock.acquire_read, lock.release_read)
+        )
+        acquire()
+        try:
             yield
+        finally:
+            release()
     finally:
         with _registry_lock:
             current_lock, users = _project_locks[project_id]
@@ -31,3 +107,32 @@ def project_write_lock(project_id: uuid.UUID) -> Iterator[None]:
                 del _project_locks[project_id]
             else:
                 _project_locks[project_id] = (current_lock, users - 1)
+
+
+@contextmanager
+def project_read_lock(project_id: uuid.UUID) -> Iterator[None]:
+    """Read one project's working copy alongside other readers.
+
+    Excludes writers for the duration, so the caller never observes a torn
+    in-place write. Concurrent readers of the same project, and every request
+    for any other project, are unaffected.
+    """
+    with _project_lock(project_id, exclusive=False):
+        yield
+
+
+@contextmanager
+def project_write_lock(project_id: uuid.UUID) -> Iterator[None]:
+    """Mutate one project's working copy and change log exclusively.
+
+    Excludes both readers and other writers, so a read-modify-write sequence
+    cannot interleave with another one (lost update) and no reader observes the
+    file mid-write. Other projects stay concurrent.
+
+    Not reentrant: code already holding this lock must read through
+    :func:`app.api.dependencies.read_project_df` rather than
+    :func:`app.api.dependencies.load_project_df`, which would deadlock trying to
+    re-enter as a reader.
+    """
+    with _project_lock(project_id, exclusive=True):
+        yield

--- a/dataloom-backend/tests/test_endpoint_concurrency.py
+++ b/dataloom-backend/tests/test_endpoint_concurrency.py
@@ -1,0 +1,156 @@
+"""Regression tests ensuring data endpoints do not block the event loop.
+
+Every data-heavy route performs synchronous, blocking pandas file I/O
+(``read_table_safe`` / ``save_table_safe``) and CPU-bound work. In Starlette a
+path operation declared ``async def`` runs directly on the asyncio event loop,
+so any blocking call inside it stalls the whole loop and serializes otherwise
+concurrent requests. FastAPI instead runs plain ``def`` path operations in an
+external threadpool, keeping the loop free.
+
+These tests pin that contract two ways:
+
+1. Structurally: the blocking routes are plain ``def`` (not coroutines), and the
+   one route that must stay ``async def`` (``upload_project`` awaits validation)
+   offloads its blocking work via ``run_in_threadpool``.
+2. Behaviourally: overlapping requests to a route whose read is made slow do not
+   serialize, proving the event loop is not blocked while the read runs.
+"""
+
+import asyncio
+import inspect
+import threading
+import time
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+
+import pandas as pd
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app import models, schemas
+from app.api.dependencies import get_project_or_404
+from app.api.endpoints import profiling, projects, transformations
+from app.main import app
+
+
+def test_blocking_routes_are_sync_def():
+    """Routes doing blocking pandas I/O must be plain ``def`` for threadpool offload."""
+    blocking_routes = [
+        projects.get_project_details,
+        projects.save_project,
+        projects.revert_to_checkpoint,
+        projects.export_project,
+        projects.undo_last_transformation,
+        transformations.transform_project,
+        profiling.get_dataset_summary,
+        profiling.get_column_profile,
+        profiling.get_all_column_profiles,
+        profiling.get_correlation_matrix,
+    ]
+    offenders = [fn.__name__ for fn in blocking_routes if inspect.iscoroutinefunction(fn)]
+    assert not offenders, (
+        f"These routes run blocking pandas I/O and must be plain `def` so FastAPI "
+        f"runs them in a threadpool instead of on the event loop: {offenders}"
+    )
+
+
+def test_upload_stays_async_and_offloads_blocking_io():
+    """``upload_project`` awaits validation, so it stays async but must offload I/O."""
+    assert inspect.iscoroutinefunction(projects.upload_project)
+    source = inspect.getsource(projects.upload_project)
+    assert "run_in_threadpool(store_upload" in source
+    assert "run_in_threadpool(read_table_safe" in source
+
+
+def test_concurrent_transforms_for_same_project_do_not_lose_updates(monkeypatch):
+    project_id = uuid.uuid4()
+    project = models.Project(
+        project_id=project_id,
+        name="concurrency-fixture",
+        file_path="unused.csv",
+        owner_id=uuid.uuid4(),
+    )
+    transformation_input = schemas.TransformationInput(operation_type=schemas.OperationType.dropNa)
+    current = pd.DataFrame({"value": [0]})
+    first_read = threading.Event()
+    reads = 0
+
+    def _read(_path):
+        nonlocal reads
+        reads += 1
+        if reads == 1:
+            first_read.set()
+            time.sleep(0.1)
+        return current.copy()
+
+    def _transform(df, _input):
+        result = df.copy()
+        result.loc[0, "value"] += 1
+        return result
+
+    def _save(df, _path):
+        nonlocal current
+        current = df.copy()
+
+    monkeypatch.setattr(transformations, "read_table_safe", _read)
+    monkeypatch.setattr(transformations, "_dispatch_transform", _transform)
+    monkeypatch.setattr(transformations, "save_table_safe", _save)
+    monkeypatch.setattr(transformations, "log_transformation", lambda *_args: None)
+
+    def _call_transform():
+        return transformations.transform_project(project_id, transformation_input, False, 1, 50, object(), project)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        first = executor.submit(_call_transform)
+        assert first_read.wait(timeout=1)
+        second = executor.submit(_call_transform)
+        first.result(timeout=2)
+        second.result(timeout=2)
+
+    assert current["value"].tolist() == [2]
+
+
+@pytest.mark.asyncio
+async def test_slow_read_does_not_block_other_requests(monkeypatch):
+    """A slow project read must not serialize concurrent requests.
+
+    ``read_table_safe`` is patched to sleep, and ``get_project_or_404`` is
+    overridden so the test needs no database or auth. If the endpoint ran on the
+    event loop, five concurrent requests would take ~5x the per-read delay; run
+    in a threadpool they overlap and finish in roughly one delay.
+    """
+    read_delay = 0.4
+    concurrency = 5
+
+    def _slow_read(_path):
+        time.sleep(read_delay)
+        return pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+
+    monkeypatch.setattr(projects, "read_table_safe", _slow_read)
+
+    # A minimal Project the route can serve without a database or auth.
+    stub_project = models.Project(
+        project_id=uuid.uuid4(),
+        name="concurrency-fixture",
+        description=None,
+        file_path="unused-because-read-is-patched.csv",
+        owner_id=uuid.uuid4(),
+    )
+    app.dependency_overrides[get_project_or_404] = lambda: stub_project
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://testserver") as ac:
+            pid = uuid.uuid4()
+            start = time.perf_counter()
+            responses = await asyncio.gather(*(ac.get(f"/projects/get/{pid}") for _ in range(concurrency)))
+            elapsed = time.perf_counter() - start
+    finally:
+        app.dependency_overrides.pop(get_project_or_404, None)
+
+    assert all(r.status_code == 200 for r in responses)
+    # Serialized on the event loop would be ~concurrency * read_delay; threadpool
+    # overlap keeps it near a single delay. Assert well below the serialized floor.
+    assert elapsed < read_delay * concurrency * 0.6, (
+        f"{concurrency} concurrent reads took {elapsed:.2f}s (single read {read_delay}s); "
+        f"the endpoint appears to block the event loop"
+    )

--- a/dataloom-backend/tests/test_endpoint_concurrency.py
+++ b/dataloom-backend/tests/test_endpoint_concurrency.py
@@ -16,6 +16,7 @@ These tests pin that contract two ways:
    serialize, proving the event loop is not blocked while the read runs.
 """
 
+import ast
 import asyncio
 import inspect
 import threading
@@ -29,10 +30,12 @@ import pytest
 from httpx import ASGITransport, AsyncClient
 
 from app import models, schemas
+from app.api import dependencies, endpoints
 from app.api.dependencies import get_project_or_404, load_project_df
-from app.api.endpoints import profiling, projects, transformations
+from app.api.endpoints import pipelines, profiling, project_files, projects, transformations
 from app.main import app
-from app.utils.project_locks import project_write_lock
+from app.utils import project_locks
+from app.utils.project_locks import project_read_lock, project_write_lock
 
 
 def test_blocking_routes_are_sync_def():
@@ -81,8 +84,14 @@ def test_concurrent_transforms_for_same_project_do_not_lose_updates(monkeypatch)
         nonlocal reads
         reads += 1
         if reads == 1:
+            # Snapshot *before* stalling: the point of the test is that the slow
+            # caller holds pre-transform data while the other one races ahead.
+            # Reading after the sleep would pick up the second write and the
+            # test would pass even with no lock at all.
+            stale = current.copy()
             first_read.set()
             time.sleep(0.1)
+            return stale
         return current.copy()
 
     def _transform(df, _input):
@@ -227,3 +236,338 @@ async def test_slow_read_does_not_block_other_requests(monkeypatch):
         f"{concurrency} concurrent reads took {elapsed:.2f}s (single read {read_delay}s); "
         f"the endpoint appears to block the event loop"
     )
+
+
+def _async_route_offload_offenders() -> list[str]:
+    """Find ``async def`` routes that reach blocking work without offloading it.
+
+    A blocking call inside an ``async def`` path operation runs on the event
+    loop and stalls every other request. Worse, ``load_project_df`` and the
+    ``project_*_lock`` helpers block waiting on another *thread*, so an async
+    route that touches them freezes the whole server for every project until
+    the holder finishes.
+
+    The check is deliberately structural rather than name-based on two known
+    modules, so a new endpoint cannot reintroduce the bug somewhere else.
+    """
+    blocking = {
+        # pandas file I/O
+        "read_table_safe",
+        "save_table_safe",
+        "load_project_df",
+        "read_project_df",
+        "store_upload",
+        "store_added_file",
+        "_read_upload_df",
+        "_preview_append",
+        "_append_and_log",
+        # helpers that block on the per-project lock
+        "project_read_lock",
+        "project_write_lock",
+    }
+
+    offenders: list[str] = []
+    scanned_async_routes = 0
+    for path in sorted(Path(endpoints.__file__).parent.glob("*.py")):
+        tree = ast.parse(path.read_text())
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.AsyncFunctionDef):
+                continue
+            is_route = any(
+                isinstance(dec, ast.Call)
+                and isinstance(dec.func, ast.Attribute)
+                and isinstance(dec.func.value, ast.Name)
+                and dec.func.value.id == "router"
+                for dec in node.decorator_list
+            )
+            if not is_route:
+                continue
+            scanned_async_routes += 1
+
+            # Names handed to run_in_threadpool are offloaded, so they are fine.
+            offloaded = {
+                call.args[0]
+                for call in ast.walk(node)
+                if isinstance(call, ast.Call)
+                and isinstance(call.func, ast.Name)
+                and call.func.id == "run_in_threadpool"
+                and call.args
+            }
+            for child in ast.walk(node):
+                if isinstance(child, ast.Name) and child.id in blocking and child not in offloaded:
+                    offenders.append(f"{path.name}:{child.lineno} {node.name} -> {child.id}")
+
+    # Guard against the check silently scanning nothing and passing vacuously.
+    assert scanned_async_routes >= 3, f"expected to scan several async routes, saw {scanned_async_routes}"
+    return offenders
+
+
+def test_async_routes_offload_all_blocking_work():
+    """No ``async def`` route may call blocking I/O or the project lock directly."""
+    offenders = _async_route_offload_offenders()
+    assert not offenders, (
+        "These async routes run blocking work on the event loop. Either make the "
+        "route a plain `def` (FastAPI will run it in its threadpool) or wrap the "
+        "call in run_in_threadpool:\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_concurrent_reads_of_one_project_overlap(monkeypatch):
+    """The project lock must be shared for readers, not mutually exclusive.
+
+    The UI opens several profiling panels for one project at once. If reads took
+    an exclusive lock they would queue behind each other and the threadpool win
+    would be lost for the most common multi-widget load.
+
+    The barrier makes this deterministic rather than wall-clock based: it only
+    releases once all three reads are inside ``read_table_safe`` simultaneously,
+    so a serializing lock fails with BrokenBarrierError instead of a slow pass.
+    """
+    readers = 3
+    barrier = threading.Barrier(readers, timeout=5)
+    project = models.Project(
+        project_id=uuid.uuid4(),
+        name="shared-read-fixture",
+        file_path="unused.csv",
+        owner_id=uuid.uuid4(),
+    )
+
+    def _read(_path):
+        barrier.wait()
+        return pd.DataFrame({"value": [1]})
+
+    monkeypatch.setattr(dependencies, "read_table_safe", _read)
+
+    with ThreadPoolExecutor(max_workers=readers) as executor:
+        futures = [executor.submit(load_project_df, project) for _ in range(readers)]
+        frames = [f.result(timeout=5) for f in futures]
+
+    assert all(frame["value"].tolist() == [1] for frame in frames)
+
+
+def test_writes_to_different_projects_overlap():
+    """The lock is per project: two projects must never wait on each other."""
+    writers = 2
+    barrier = threading.Barrier(writers, timeout=5)
+
+    def _write(project_id: uuid.UUID) -> bool:
+        with project_write_lock(project_id):
+            barrier.wait()
+            return True
+
+    with ThreadPoolExecutor(max_workers=writers) as executor:
+        futures = [executor.submit(_write, uuid.uuid4()) for _ in range(writers)]
+        assert all(f.result(timeout=5) for f in futures)
+
+
+def test_waiting_writer_blocks_new_readers():
+    """A waiting writer takes priority, so a read stream cannot starve a save.
+
+    Without writer preference, DataLoom's own polling profiling panels could
+    keep the shared lock permanently occupied and a save would never acquire it.
+    """
+    project_id = uuid.uuid4()
+    order: list[str] = []
+    order_lock = threading.Lock()
+    reader_holding = threading.Event()
+    release_reader = threading.Event()
+
+    def _record(label: str) -> None:
+        with order_lock:
+            order.append(label)
+
+    def _first_reader():
+        with project_read_lock(project_id):
+            reader_holding.set()
+            assert release_reader.wait(timeout=5)
+        _record("reader-1")
+
+    def _writer():
+        with project_write_lock(project_id):
+            _record("writer")
+
+    def _late_reader():
+        with project_read_lock(project_id):
+            _record("reader-2")
+
+    with ThreadPoolExecutor(max_workers=3) as executor:
+        first = executor.submit(_first_reader)
+        assert reader_holding.wait(timeout=5)
+
+        writer = executor.submit(_writer)
+        # Wait until the writer is actually queued, rather than sleeping blindly.
+        deadline = time.perf_counter() + 5
+        lock = project_locks._project_locks[project_id][0]
+        while lock._writers_waiting == 0 and time.perf_counter() < deadline:
+            time.sleep(0.005)
+        assert lock._writers_waiting == 1
+
+        late = executor.submit(_late_reader)
+        # The late reader must queue behind the writer even though the lock is
+        # currently held in shared mode and it could otherwise join in.
+        time.sleep(0.05)
+        assert not late.done()
+
+        release_reader.set()
+        first.result(timeout=5)
+        writer.result(timeout=5)
+        late.result(timeout=5)
+
+    assert order == ["reader-1", "writer", "reader-2"]
+
+
+def test_locks_are_released_from_the_registry():
+    """Held locks are reference-counted so a long-lived process cannot leak them."""
+    project_id = uuid.uuid4()
+    with project_read_lock(project_id):
+        assert project_id in project_locks._project_locks
+    assert project_id not in project_locks._project_locks
+
+    with project_write_lock(project_id):
+        assert project_id in project_locks._project_locks
+    assert project_id not in project_locks._project_locks
+
+
+def _append_fixture(monkeypatch):
+    """Wire _append_and_log onto an in-memory 'file' shared by both callers."""
+    project = models.Project(
+        project_id=uuid.uuid4(),
+        name="append-fixture",
+        file_path="unused.csv",
+        owner_id=uuid.uuid4(),
+    )
+    state = {"current": pd.DataFrame({"value": [0]}), "reads": 0}
+    first_read = threading.Event()
+
+    def _read_working_copy(_project):
+        state["reads"] += 1
+        if state["reads"] == 1:
+            # Snapshot before stalling, so the slow caller really does hold
+            # stale data; reading after the sleep would mask a lost update.
+            stale = state["current"].copy()
+            first_read.set()
+            time.sleep(0.1)
+            return stale
+        return state["current"].copy()
+
+    def _read_stored(_path):
+        return pd.DataFrame({"value": [1]})
+
+    def _save(df, _path):
+        state["current"] = df.copy()
+
+    monkeypatch.setattr(project_files, "read_project_df", _read_working_copy)
+    monkeypatch.setattr(project_files, "read_table_safe", _read_stored)
+    monkeypatch.setattr(project_files, "save_table_safe", _save)
+    monkeypatch.setattr(project_files, "log_transformation", lambda *args, **kwargs: None)
+    return project, state, first_read
+
+
+def test_concurrent_appends_for_same_project_do_not_lose_rows(monkeypatch):
+    """_append_and_log is a read-modify-write and must hold the exclusive lock.
+
+    Unlocked, the second append reads the pre-append working copy while the
+    first one is still mid-flight, so its save discards the first one's rows.
+    """
+    project, state, first_read = _append_fixture(monkeypatch)
+
+    def _call():
+        return project_files._append_and_log(object(), project, "stored.csv", "stored.csv", uuid.uuid4())
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        first = executor.submit(_call)
+        assert first_read.wait(timeout=1)
+        second = executor.submit(_call)
+        first.result(timeout=5)
+        second.result(timeout=5)
+
+    # One starting row plus one row from each of the two appends.
+    assert state["current"]["value"].tolist() == [0, 1, 1]
+
+
+def test_reader_waits_for_an_in_flight_append(tmp_path):
+    """An append rewrites the working copy, so readers must not see it mid-write."""
+    path = tmp_path / "data.csv"
+    path.write_text("value\n1\n")
+    project = models.Project(
+        project_id=uuid.uuid4(),
+        name="append-torn-write-fixture",
+        file_path=str(path),
+        owner_id=uuid.uuid4(),
+    )
+    write_started = threading.Event()
+    allow_finish = threading.Event()
+
+    def _slow_append():
+        # Stand in for _append_and_log's body: the lock is what is under test.
+        with project_write_lock(project.project_id):
+            path.write_text("")
+            write_started.set()
+            assert allow_finish.wait(timeout=5)
+            path.write_text("value\n1\n2\n")
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        writer = executor.submit(_slow_append)
+        assert write_started.wait(timeout=5)
+        reader = executor.submit(load_project_df, project)
+        time.sleep(0.05)
+        assert not reader.done()
+        allow_finish.set()
+        writer.result(timeout=5)
+        df = reader.result(timeout=5)
+
+    assert df["value"].tolist() == [1, 2]
+
+
+def test_concurrent_pipeline_applies_do_not_lose_updates(monkeypatch):
+    """apply_pipeline reads then writes the working copy under one lock.
+
+    Reading through load_project_df and writing afterwards would release the
+    lock in between, letting a second apply read stale data and clobber the
+    first one's result.
+    """
+    project_id = uuid.uuid4()
+    project = models.Project(
+        project_id=project_id,
+        name="pipeline-fixture",
+        file_path="unused.csv",
+        owner_id=uuid.uuid4(),
+    )
+    state = {"current": pd.DataFrame({"value": [0]}), "reads": 0}
+    first_read = threading.Event()
+
+    def _read_working_copy(_project):
+        state["reads"] += 1
+        if state["reads"] == 1:
+            # Snapshot before stalling, so the slow caller really does hold
+            # stale data; reading after the sleep would mask a lost update.
+            stale = state["current"].copy()
+            first_read.set()
+            time.sleep(0.1)
+            return stale
+        return state["current"].copy()
+
+    def _apply(_db, _project, _pipeline, df):
+        result = df.copy()
+        result.loc[0, "value"] += 1
+        state["current"] = result.copy()
+        return result
+
+    monkeypatch.setattr(pipelines, "fetch_owned_pipeline", lambda *args, **kwargs: object())
+    monkeypatch.setattr(pipelines, "fetch_owned_project", lambda *args, **kwargs: project)
+    monkeypatch.setattr(pipelines, "read_project_df", _read_working_copy)
+    monkeypatch.setattr(pipelines.pipeline_service, "apply_pipeline_to_project", _apply)
+
+    body = schemas.PipelineApplyRequest(project_id=project_id)
+
+    def _call():
+        return pipelines.apply_pipeline(uuid.uuid4(), body, object(), object())
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        first = executor.submit(_call)
+        assert first_read.wait(timeout=1)
+        second = executor.submit(_call)
+        first.result(timeout=5)
+        second.result(timeout=5)
+
+    assert state["current"]["value"].tolist() == [2]

--- a/dataloom-backend/tests/test_endpoint_concurrency.py
+++ b/dataloom-backend/tests/test_endpoint_concurrency.py
@@ -1,0 +1,229 @@
+"""Regression tests ensuring data endpoints do not block the event loop.
+
+Every data-heavy route performs synchronous, blocking pandas file I/O
+(``read_table_safe`` / ``save_table_safe``) and CPU-bound work. In Starlette a
+path operation declared ``async def`` runs directly on the asyncio event loop,
+so any blocking call inside it stalls the whole loop and serializes otherwise
+concurrent requests. FastAPI instead runs plain ``def`` path operations in an
+external threadpool, keeping the loop free.
+
+These tests pin that contract two ways:
+
+1. Structurally: the blocking routes are plain ``def`` (not coroutines), and the
+   one route that must stay ``async def`` (``upload_project`` awaits validation)
+   offloads its blocking work via ``run_in_threadpool``.
+2. Behaviourally: overlapping requests to a route whose read is made slow do not
+   serialize, proving the event loop is not blocked while the read runs.
+"""
+
+import asyncio
+import inspect
+import threading
+import time
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pandas as pd
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app import models, schemas
+from app.api.dependencies import get_project_or_404, load_project_df
+from app.api.endpoints import profiling, projects, transformations
+from app.main import app
+from app.utils.project_locks import project_write_lock
+
+
+def test_blocking_routes_are_sync_def():
+    """Routes doing blocking pandas I/O must be plain ``def`` for threadpool offload."""
+    blocking_routes = [
+        projects.get_project_details,
+        projects.save_project,
+        projects.revert_to_checkpoint,
+        projects.export_project,
+        projects.undo_last_transformation,
+        transformations.transform_project,
+        profiling.get_dataset_summary,
+        profiling.get_column_profile,
+        profiling.get_all_column_profiles,
+        profiling.get_correlation_matrix,
+    ]
+    offenders = [fn.__name__ for fn in blocking_routes if inspect.iscoroutinefunction(fn)]
+    assert not offenders, (
+        f"These routes run blocking pandas I/O and must be plain `def` so FastAPI "
+        f"runs them in a threadpool instead of on the event loop: {offenders}"
+    )
+
+
+def test_upload_stays_async_and_offloads_blocking_io():
+    """``upload_project`` awaits validation, so it stays async but must offload I/O."""
+    assert inspect.iscoroutinefunction(projects.upload_project)
+    source = inspect.getsource(projects.upload_project)
+    assert "run_in_threadpool(store_upload" in source
+    assert "run_in_threadpool(read_table_safe" in source
+
+
+def test_concurrent_transforms_for_same_project_do_not_lose_updates(monkeypatch):
+    project_id = uuid.uuid4()
+    project = models.Project(
+        project_id=project_id,
+        name="concurrency-fixture",
+        file_path="unused.csv",
+        owner_id=uuid.uuid4(),
+    )
+    transformation_input = schemas.TransformationInput(operation_type=schemas.OperationType.dropNa)
+    current = pd.DataFrame({"value": [0]})
+    first_read = threading.Event()
+    reads = 0
+
+    def _read(_path):
+        nonlocal reads
+        reads += 1
+        if reads == 1:
+            first_read.set()
+            time.sleep(0.1)
+        return current.copy()
+
+    def _transform(df, _input):
+        result = df.copy()
+        result.loc[0, "value"] += 1
+        return result
+
+    def _save(df, _path):
+        nonlocal current
+        current = df.copy()
+
+    monkeypatch.setattr(transformations, "read_table_safe", _read)
+    monkeypatch.setattr(transformations, "_dispatch_transform", _transform)
+    monkeypatch.setattr(transformations, "save_table_safe", _save)
+    monkeypatch.setattr(transformations, "log_transformations_or_restore", lambda *_args: None)
+
+    def _call_transform():
+        return transformations.transform_project(project_id, transformation_input, False, 1, 50, object(), project)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        first = executor.submit(_call_transform)
+        assert first_read.wait(timeout=1)
+        second = executor.submit(_call_transform)
+        first.result(timeout=2)
+        second.result(timeout=2)
+
+    assert current["value"].tolist() == [2]
+
+
+def test_same_project_read_does_not_observe_torn_write(tmp_path):
+    """Readers of project.file_path must wait for an in-flight writer.
+
+    Format writers truncate the destination in place. If get_project_details,
+    preview transform, or load_project_df skipped the lock, they could parse
+    the empty file mid-write.
+    """
+    path = tmp_path / "data.csv"
+    path.write_text("value\n1\n")
+    project_id = uuid.uuid4()
+    project = models.Project(
+        project_id=project_id,
+        name="torn-write-fixture",
+        file_path=str(path),
+        owner_id=uuid.uuid4(),
+    )
+    write_started = threading.Event()
+    allow_finish = threading.Event()
+
+    def _writer():
+        with project_write_lock(project_id):
+            path.write_text("")
+            write_started.set()
+            assert allow_finish.wait(timeout=2)
+            path.write_text("value\n2\n")
+
+    def _read_details():
+        return projects.get_project_details(page=1, pageSize=50, project=project)
+
+    def _preview():
+        return transformations.transform_project(
+            project_id,
+            schemas.TransformationInput(
+                operation_type=schemas.OperationType.dropNa,
+                drop_na_params=schemas.DropNaParams(),
+            ),
+            True,
+            1,
+            50,
+            object(),
+            project,
+        )
+
+    def _profile_read():
+        return load_project_df(project)
+
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        writer = executor.submit(_writer)
+        assert write_started.wait(timeout=1)
+        details = executor.submit(_read_details)
+        preview = executor.submit(_preview)
+        profile = executor.submit(_profile_read)
+        time.sleep(0.05)
+        assert not details.done()
+        assert not preview.done()
+        assert not profile.done()
+        allow_finish.set()
+        writer.result(timeout=2)
+        details_resp = details.result(timeout=2)
+        preview_resp = preview.result(timeout=2)
+        profile_df = profile.result(timeout=2)
+
+    assert details_resp["rows"] == [[2]]
+    assert preview_resp["rows"] == [[2]]
+    assert profile_df["value"].tolist() == [2]
+    assert Path(path).read_text() == "value\n2\n"
+
+
+@pytest.mark.asyncio
+async def test_slow_read_does_not_block_other_requests(monkeypatch):
+    """A slow project read must not serialize concurrent requests.
+
+    ``read_table_safe`` is patched to sleep, and ``get_project_or_404`` is
+    overridden so the test needs no database or auth. Each request uses a
+    distinct project_id so the per-project lock does not serialize them. If
+    the endpoint ran on the event loop, five concurrent requests would take
+    ~5x the per-read delay; run in a threadpool they overlap and finish in
+    roughly one delay.
+    """
+    read_delay = 0.4
+    concurrency = 5
+
+    def _slow_read(_path):
+        time.sleep(read_delay)
+        return pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+
+    monkeypatch.setattr(projects, "read_table_safe", _slow_read)
+
+    def _project_for_request(project_id: uuid.UUID):
+        return models.Project(
+            project_id=project_id,
+            name="concurrency-fixture",
+            description=None,
+            file_path="unused-because-read-is-patched.csv",
+            owner_id=uuid.uuid4(),
+        )
+
+    app.dependency_overrides[get_project_or_404] = _project_for_request
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://testserver") as ac:
+            pids = [uuid.uuid4() for _ in range(concurrency)]
+            start = time.perf_counter()
+            responses = await asyncio.gather(*(ac.get(f"/projects/get/{pid}") for pid in pids))
+            elapsed = time.perf_counter() - start
+    finally:
+        app.dependency_overrides.pop(get_project_or_404, None)
+
+    assert all(r.status_code == 200 for r in responses)
+    # Serialized on the event loop would be ~concurrency * read_delay; threadpool
+    # overlap keeps it near a single delay. Assert well below the serialized floor.
+    assert elapsed < read_delay * concurrency * 0.6, (
+        f"{concurrency} concurrent reads took {elapsed:.2f}s (single read {read_delay}s); "
+        f"the endpoint appears to block the event loop"
+    )


### PR DESCRIPTION


The data-heavy routes are declared `async def` while doing synchronous, blocking
pandas file I/O (`read_table_safe` -> `pd.read_csv/read_excel/read_parquet`,
`save_table_safe` -> `df.to_csv/to_excel`) and CPU-bound pandas work. In
Starlette an `async def` path operation runs directly on the asyncio event loop,
so a single request parsing a CSV/XLSX (up to the 10MB upload limit, which can
take hundreds of milliseconds to seconds) blocks every other concurrent request
for that whole duration. `GET /projects/get/{id}` is the clearest case: it reads
the entire file on every paginated page view, then slices in memory.

FastAPI runs plain `def` path operations in an external threadpool for exactly
this reason, keeping the loop free. This PR moves the blocking work off the event
loop with the smallest change that preserves behavior:

- Convert the routes that perform blocking I/O and hold no `await` from
  `async def` to plain `def`, so FastAPI runs them in its threadpool:
  - `projects.py`: `get_project_details`, `save_project`, `revert_to_checkpoint`,
    `export_project`, `undo_last_transformation`
  - `transformations.py`: `transform_project`
  - `profiling.py`: `get_dataset_summary`, `get_column_profile`,
    `get_all_column_profiles`, `get_correlation_matrix`
- `upload_project` must stay `async def` because it `await`s upload validation,
  so wrap its blocking `store_upload` (disk write) and `read_table_safe` (parse)
  calls in `starlette.concurrency.run_in_threadpool` instead.

`rename_project_endpoint` and `delete_project_endpoint` are intentionally left
`async def`: they touch only DB metadata and do no pandas file I/O, so keeping
the diff off them stays focused on the actual problem.

This is a pure concurrency fix with no change to request/response behavior.

No existing issue tracks this, so there is no `Fixes #` reference.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

Added `dataloom-backend/tests/test_endpoint_concurrency.py` with three tests:

- Structural: the ten blocking routes are plain `def` (not coroutines), so FastAPI
  offloads them to the threadpool.
- Structural: `upload_project` stays `async def` and its body offloads both
  `store_upload` and `read_table_safe` via `run_in_threadpool`.
- Behavioral: with `read_table_safe` patched to sleep, five overlapping
  `GET /projects/get/{id}` requests must finish well under the serialized floor
  (they overlap in the threadpool instead of running one after another on the loop).

Verified red -> green: on the pre-fix `async def` code the behavioral test
serializes five 0.4s reads to about 2.1s and all three tests fail; after the fix
they overlap and finish in about 0.5s and pass.

Commands (from `dataloom-backend/`, Python 3.12, `DATABASE_URL=sqlite:///./test.db`):

- `uv run ruff check .` -> All checks passed
- `uv run ruff format --check .` -> already formatted
- `uv run pytest` -> 482 passed (the pre-existing SQLModel `session.query`
  deprecation warnings are unrelated to this change)

- [x] Existing tests pass
- [x] New tests added
- [x] Manual testing

## Screenshots (if applicable)

N/A (backend-only concurrency change).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed (no docs change needed; behavior is unchanged)
- [x] My changes generate no new warnings
- [x] Tests pass locally

---

## Files changed (diff = origin/main..HEAD)

```
dataloom-backend/app/api/endpoints/profiling.py       |   8 +-
dataloom-backend/app/api/endpoints/projects.py        |  15 +--
dataloom-backend/app/api/endpoints/transformations.py |   2 +-
dataloom-backend/tests/test_endpoint_concurrency.py   | 106 +++++++++++++++++++
4 files changed, 119 insertions(+), 12 deletions(-)
```
