### PR TITLE
test: add unit test coverage for all transformation form components

### DIFF
--- a/dataloom-frontend/src/test/AdvQueryFilterForm.test.jsx
+++ b/dataloom-frontend/src/test/AdvQueryFilterForm.test.jsx
@@ -1,0 +1,189 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ADV_QUERY_FILTER } from "../constants/operationTypes";
+import AdvQueryFilterForm from "../Components/forms/AdvQueryFilterForm";
+import { transformProject } from "../api";
+import { useProjectContext } from "../context/ProjectContext";
+import usePreviewSave from "../hooks/usePreviewSave";
+
+vi.mock("../api", () => ({
+  transformProject: vi.fn(),
+}));
+
+vi.mock("../context/ProjectContext", () => ({
+  useProjectContext: vi.fn(),
+}));
+
+vi.mock("../hooks/usePreviewSave", () => ({
+  default: vi.fn(),
+}));
+
+const mockEnterPreviewMode = vi.fn();
+const mockCancelPreview = vi.fn();
+const mockHandleSave = vi.fn();
+
+const renderForm = ({ isPreviewMode = false, onClose = vi.fn(), saving = false } = {}) => {
+  useProjectContext.mockReturnValue({
+    isPreviewMode,
+    enterPreviewMode: mockEnterPreviewMode,
+    cancelPreview: mockCancelPreview,
+  });
+
+  usePreviewSave.mockReturnValue({
+    saving,
+    handleSave: mockHandleSave,
+  });
+
+  return {
+    onClose,
+    ...render(<AdvQueryFilterForm projectId="project-123" onClose={onClose} />),
+  };
+};
+
+describe("AdvQueryFilterForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    transformProject.mockResolvedValue({
+      columns: ["amount"],
+      rows: [["100"]],
+      dtypes: { amount: "integer" },
+    });
+  });
+
+  it("renders the query input and buttons", () => {
+    renderForm();
+
+    expect(screen.getByPlaceholderText("e.g., col1 > 10 and col2 < 5")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Submit" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+  });
+
+  it("requires a query to be entered", () => {
+    renderForm();
+
+    expect(screen.getByPlaceholderText("e.g., col1 > 10 and col2 < 5")).toBeRequired();
+  });
+
+  it("submits the query for preview", async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    await user.type(screen.getByPlaceholderText("e.g., col1 > 10 and col2 < 5"), "amount > 10");
+    await user.click(screen.getByRole("button", { name: "Submit" }));
+
+    await waitFor(() => {
+      expect(transformProject).toHaveBeenCalledWith(
+        "project-123",
+        {
+          operation_type: ADV_QUERY_FILTER,
+          adv_query: { query: "amount > 10" },
+        },
+        { preview: true },
+      );
+    });
+  });
+
+  it("enters preview mode using the transformation response", async () => {
+    const user = userEvent.setup();
+    const response = { columns: ["amount"], rows: [[100]], dtypes: { amount: "integer" } };
+    transformProject.mockResolvedValue(response);
+
+    renderForm();
+    await user.type(screen.getByPlaceholderText("e.g., col1 > 10 and col2 < 5"), "amount > 10");
+    await user.click(screen.getByRole("button", { name: "Submit" }));
+
+    await waitFor(() => {
+      expect(mockEnterPreviewMode).toHaveBeenCalledWith(
+        response.columns,
+        response.rows,
+        response.dtypes,
+        expect.objectContaining({ projectId: "project-123" }),
+      );
+    });
+  });
+
+  it("disables Submit while the request is pending", async () => {
+    const user = userEvent.setup();
+    let resolveTransform;
+    transformProject.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveTransform = resolve;
+        }),
+    );
+
+    renderForm();
+    await user.type(screen.getByPlaceholderText("e.g., col1 > 10 and col2 < 5"), "amount > 10");
+    await user.click(screen.getByRole("button", { name: "Submit" }));
+
+    expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
+
+    resolveTransform({ columns: [], rows: [], dtypes: {} });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Submit" })).not.toBeDisabled();
+    });
+  });
+
+  it("shows the backend error message when the query request fails", async () => {
+    const user = userEvent.setup();
+    transformProject.mockRejectedValue({
+      response: { data: { detail: "Invalid query syntax." } },
+    });
+
+    renderForm();
+    await user.type(screen.getByPlaceholderText("e.g., col1 > 10 and col2 < 5"), "amount >>");
+    await user.click(screen.getByRole("button", { name: "Submit" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Invalid query syntax.")).toBeInTheDocument();
+    });
+    expect(mockEnterPreviewMode).not.toHaveBeenCalled();
+  });
+
+  it("disables Submit and displays Save Changes in preview mode", () => {
+    renderForm({ isPreviewMode: true });
+
+    expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Save Changes" })).toBeInTheDocument();
+  });
+
+  it("calls the preview save handler when Save Changes is clicked", async () => {
+    const user = userEvent.setup();
+    renderForm({ isPreviewMode: true });
+
+    await user.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    expect(mockHandleSave).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows saving state while preview changes are being saved", () => {
+    renderForm({ isPreviewMode: true, saving: true });
+
+    expect(screen.getByRole("button", { name: "Saving..." })).toBeDisabled();
+  });
+
+  it("cancels preview mode when Cancel is clicked during preview", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    renderForm({ isPreviewMode: true, onClose });
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(mockCancelPreview).toHaveBeenCalledTimes(1);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("closes the form when Cancel is clicked outside preview mode", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    renderForm({ isPreviewMode: false, onClose });
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(mockCancelPreview).not.toHaveBeenCalled();
+  });
+});

--- a/dataloom-frontend/src/test/CastDataTypeForm.test.jsx
+++ b/dataloom-frontend/src/test/CastDataTypeForm.test.jsx
@@ -1,0 +1,338 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CAST_DATA_TYPE } from "../constants/operationTypes";
+import CastDataTypeForm from "../Components/forms/CastDataTypeForm";
+import { transformProject } from "../api";
+import { useToast } from "../context/ToastContext";
+import { useProjectContext } from "../context/ProjectContext";
+import usePreviewSave from "../hooks/usePreviewSave";
+
+vi.mock("../api", () => ({
+  transformProject: vi.fn(),
+}));
+
+vi.mock("../context/ToastContext", () => ({
+  useToast: vi.fn(),
+}));
+
+vi.mock("../context/ProjectContext", () => ({
+  useProjectContext: vi.fn(),
+}));
+
+vi.mock("../hooks/usePreviewSave", () => ({
+  default: vi.fn(),
+}));
+
+vi.mock("../Components/common/ColumnSelect", () => ({
+  default: ({ value, onChange, placeholder }) => (
+    <select aria-label="Column" value={value} onChange={(event) => onChange(event.target.value)}>
+      <option value="">{placeholder}</option>
+      <option value="amount">Amount</option>
+      <option value="created_at">Created At</option>
+    </select>
+  ),
+}));
+
+vi.mock("../Components/common/Select", () => ({
+  default: ({ value, onChange, options }) => (
+    <select
+      aria-label="Target Type"
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+    >
+      {options.map((option) => (
+        <option key={option.value} value={option.value}>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  ),
+}));
+
+const mockShowToast = vi.fn();
+const mockEnterPreviewMode = vi.fn();
+const mockCancelPreview = vi.fn();
+const mockHandleSave = vi.fn();
+
+const renderForm = ({ isPreviewMode = false, onClose = vi.fn(), saving = false } = {}) => {
+  useProjectContext.mockReturnValue({
+    isPreviewMode,
+    enterPreviewMode: mockEnterPreviewMode,
+    cancelPreview: mockCancelPreview,
+  });
+
+  usePreviewSave.mockReturnValue({
+    saving,
+    handleSave: mockHandleSave,
+  });
+
+  return {
+    onClose,
+    ...render(<CastDataTypeForm projectId="project-123" onClose={onClose} />),
+  };
+};
+
+describe("CastDataTypeForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    useToast.mockReturnValue({
+      showToast: mockShowToast,
+    });
+
+    transformProject.mockResolvedValue({
+      columns: ["amount", "created_at"],
+      rows: [
+        ["100", "2026-07-18"],
+        ["200", "2026-07-19"],
+      ],
+      dtypes: {
+        amount: "integer",
+        created_at: "datetime",
+      },
+    });
+  });
+
+  it("renders column and target type controls", () => {
+    renderForm();
+
+    expect(screen.getByLabelText("Column")).toBeInTheDocument();
+    expect(screen.getByLabelText("Target Type")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Apply" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+  });
+
+  it("uses string as the default target type", () => {
+    renderForm();
+
+    expect(screen.getByLabelText("Target Type")).toHaveValue("string");
+  });
+
+  it("shows validation error when no column is selected", async () => {
+    const user = userEvent.setup();
+
+    renderForm();
+
+    await user.click(screen.getByRole("button", { name: "Apply" }));
+
+    expect(screen.getByText("Please select a column.")).toBeInTheDocument();
+    expect(transformProject).not.toHaveBeenCalled();
+    expect(mockEnterPreviewMode).not.toHaveBeenCalled();
+  });
+
+  it("submits the selected column and target type for preview", async () => {
+    const user = userEvent.setup();
+
+    renderForm();
+
+    await user.selectOptions(screen.getByLabelText("Column"), "amount");
+    await user.selectOptions(screen.getByLabelText("Target Type"), "float");
+    await user.click(screen.getByRole("button", { name: "Apply" }));
+
+    await waitFor(() => {
+      expect(transformProject).toHaveBeenCalledWith(
+        "project-123",
+        {
+          operation_type: CAST_DATA_TYPE,
+          cast_data_type_params: {
+            column: "amount",
+            target_type: "float",
+          },
+        },
+        {
+          preview: true,
+        },
+      );
+    });
+  });
+
+  it("enters preview mode using the transformation response", async () => {
+    const user = userEvent.setup();
+
+    const response = {
+      columns: ["amount"],
+      rows: [[100], [200]],
+      dtypes: {
+        amount: "integer",
+      },
+    };
+
+    transformProject.mockResolvedValue(response);
+
+    renderForm();
+
+    await user.selectOptions(screen.getByLabelText("Column"), "amount");
+    await user.click(screen.getByRole("button", { name: "Apply" }));
+
+    await waitFor(() => {
+      expect(mockEnterPreviewMode).toHaveBeenCalledWith(
+        response.columns,
+        response.rows,
+        response.dtypes,
+        {
+          projectId: "project-123",
+          payload: {
+            operation_type: CAST_DATA_TYPE,
+            cast_data_type_params: {
+              column: "amount",
+              target_type: "string",
+            },
+          },
+        },
+      );
+    });
+  });
+
+  it("shows applying state while the preview request is pending", async () => {
+    const user = userEvent.setup();
+
+    let resolveTransform;
+    transformProject.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveTransform = resolve;
+        }),
+    );
+
+    renderForm();
+
+    await user.selectOptions(screen.getByLabelText("Column"), "amount");
+    await user.click(screen.getByRole("button", { name: "Apply" }));
+
+    expect(screen.getByRole("button", { name: "Applying..." })).toBeDisabled();
+
+    resolveTransform({
+      columns: ["amount"],
+      rows: [[100]],
+      dtypes: { amount: "integer" },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Apply" })).not.toBeDisabled();
+    });
+  });
+
+  it("shows the backend error message when preview fails", async () => {
+    const user = userEvent.setup();
+
+    transformProject.mockRejectedValue({
+      response: {
+        data: {
+          detail: "Unable to cast column to integer.",
+        },
+      },
+    });
+
+    renderForm();
+
+    await user.selectOptions(screen.getByLabelText("Column"), "amount");
+    await user.selectOptions(screen.getByLabelText("Target Type"), "integer");
+    await user.click(screen.getByRole("button", { name: "Apply" }));
+
+    await waitFor(() => {
+      expect(mockShowToast).toHaveBeenCalledWith("Unable to cast column to integer.", "error");
+    });
+
+    expect(mockEnterPreviewMode).not.toHaveBeenCalled();
+  });
+
+  it("shows a fallback message when preview fails without backend detail", async () => {
+    const user = userEvent.setup();
+
+    transformProject.mockRejectedValue(new Error("Network error"));
+
+    renderForm();
+
+    await user.selectOptions(screen.getByLabelText("Column"), "amount");
+    await user.click(screen.getByRole("button", { name: "Apply" }));
+
+    await waitFor(() => {
+      expect(mockShowToast).toHaveBeenCalledWith("Failed to cast data type.", "error");
+    });
+  });
+
+  it("disables Apply and displays Save Changes in preview mode", () => {
+    renderForm({ isPreviewMode: true });
+
+    expect(screen.getByRole("button", { name: "Apply" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Save Changes" })).toBeInTheDocument();
+  });
+
+  it("calls the preview save handler when Save Changes is clicked", async () => {
+    const user = userEvent.setup();
+
+    renderForm({ isPreviewMode: true });
+
+    await user.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    expect(mockHandleSave).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows saving state while preview changes are being saved", () => {
+    renderForm({
+      isPreviewMode: true,
+      saving: true,
+    });
+
+    expect(screen.getByRole("button", { name: "Saving..." })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Apply" })).toBeDisabled();
+  });
+
+  it("cancels preview mode when Cancel is clicked during preview", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+
+    renderForm({
+      isPreviewMode: true,
+      onClose,
+    });
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(mockCancelPreview).toHaveBeenCalledTimes(1);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("closes the form when Cancel is clicked outside preview mode", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+
+    renderForm({
+      isPreviewMode: false,
+      onClose,
+    });
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(mockCancelPreview).not.toHaveBeenCalled();
+  });
+
+  it("submits the form when Enter is pressed", async () => {
+    const user = userEvent.setup();
+
+    renderForm();
+
+    await user.selectOptions(screen.getByLabelText("Column"), "created_at");
+    await user.selectOptions(screen.getByLabelText("Target Type"), "datetime");
+
+    fireEvent.submit(screen.getByRole("button", { name: "Apply" }).closest("form"));
+
+    await waitFor(() => {
+      expect(transformProject).toHaveBeenCalledWith(
+        "project-123",
+        {
+          operation_type: CAST_DATA_TYPE,
+          cast_data_type_params: {
+            column: "created_at",
+            target_type: "datetime",
+          },
+        },
+        {
+          preview: true,
+        },
+      );
+    });
+  });
+});

--- a/dataloom-frontend/src/test/DropDuplicateForm.test.jsx
+++ b/dataloom-frontend/src/test/DropDuplicateForm.test.jsx
@@ -1,0 +1,218 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DROP_DUPLICATE } from "../constants/operationTypes";
+import DropDuplicateForm from "../Components/forms/DropDuplicateForm";
+import { transformProject } from "../api";
+import { useProjectContext } from "../context/ProjectContext";
+import usePreviewSave from "../hooks/usePreviewSave";
+
+vi.mock("../api", () => ({
+  transformProject: vi.fn(),
+}));
+
+vi.mock("../context/ProjectContext", () => ({
+  useProjectContext: vi.fn(),
+}));
+
+vi.mock("../hooks/usePreviewSave", () => ({
+  default: vi.fn(),
+}));
+
+vi.mock("../Components/common/ColumnMultiSelect", () => ({
+  default: ({ value, onChange, options }) => (
+    <select
+      multiple
+      aria-label="Columns"
+      value={value}
+      onChange={(event) =>
+        onChange(Array.from(event.target.selectedOptions).map((option) => option.value))
+      }
+    >
+      {(options || ["amount", "created_at"]).map((option) => (
+        <option key={option} value={option}>
+          {option}
+        </option>
+      ))}
+    </select>
+  ),
+}));
+
+vi.mock("../Components/common/Select", () => ({
+  default: ({ value, onChange, options }) => (
+    <select aria-label="Keep" value={value} onChange={(event) => onChange(event.target.value)}>
+      {options.map((option) => (
+        <option key={option.value} value={option.value}>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  ),
+}));
+
+const mockEnterPreviewMode = vi.fn();
+const mockCancelPreview = vi.fn();
+const mockHandleSave = vi.fn();
+
+const renderForm = ({ isPreviewMode = false, onClose = vi.fn(), saving = false } = {}) => {
+  useProjectContext.mockReturnValue({
+    isPreviewMode,
+    enterPreviewMode: mockEnterPreviewMode,
+    cancelPreview: mockCancelPreview,
+  });
+
+  usePreviewSave.mockReturnValue({
+    saving,
+    handleSave: mockHandleSave,
+  });
+
+  return {
+    onClose,
+    ...render(<DropDuplicateForm projectId="project-123" onClose={onClose} />),
+  };
+};
+
+describe("DropDuplicateForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    transformProject.mockResolvedValue({
+      columns: ["amount"],
+      rows: [["100"]],
+      dtypes: { amount: "integer" },
+    });
+  });
+
+  it("renders columns and keep controls with buttons", () => {
+    renderForm();
+
+    expect(screen.getByLabelText("Columns")).toBeInTheDocument();
+    expect(screen.getByLabelText("Keep")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Submit" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+  });
+
+  it("uses first as the default keep option", () => {
+    renderForm();
+
+    expect(screen.getByLabelText("Keep")).toHaveValue("first");
+  });
+
+  it("shows a validation error when no columns are selected", async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    await user.click(screen.getByRole("button", { name: "Submit" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Please select at least one column.")).toBeInTheDocument();
+    });
+    expect(transformProject).not.toHaveBeenCalled();
+  });
+
+  it("submits the selected columns joined and keep strategy", async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    await user.selectOptions(screen.getByLabelText("Columns"), ["amount", "created_at"]);
+    await user.selectOptions(screen.getByLabelText("Keep"), "last");
+    await user.click(screen.getByRole("button", { name: "Submit" }));
+
+    await waitFor(() => {
+      expect(transformProject).toHaveBeenCalledWith(
+        "project-123",
+        {
+          operation_type: DROP_DUPLICATE,
+          drop_duplicate: { columns: "amount,created_at", keep: "last" },
+        },
+        { preview: true },
+      );
+    });
+  });
+
+  it("enters preview mode using the transformation response", async () => {
+    const user = userEvent.setup();
+    const response = { columns: ["amount"], rows: [[100]], dtypes: { amount: "integer" } };
+    transformProject.mockResolvedValue(response);
+
+    renderForm();
+    await user.selectOptions(screen.getByLabelText("Columns"), ["amount"]);
+    await user.click(screen.getByRole("button", { name: "Submit" }));
+
+    await waitFor(() => {
+      expect(mockEnterPreviewMode).toHaveBeenCalledWith(
+        response.columns,
+        response.rows,
+        response.dtypes,
+        {
+          projectId: "project-123",
+          payload: {
+            operation_type: DROP_DUPLICATE,
+            drop_duplicate: { columns: "amount", keep: "first" },
+          },
+        },
+      );
+    });
+  });
+
+  it("shows the backend error message when the request fails", async () => {
+    const user = userEvent.setup();
+    transformProject.mockRejectedValue({
+      response: { data: { detail: "Unable to drop duplicates." } },
+    });
+
+    renderForm();
+    await user.selectOptions(screen.getByLabelText("Columns"), ["amount"]);
+    await user.click(screen.getByRole("button", { name: "Submit" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Unable to drop duplicates.")).toBeInTheDocument();
+    });
+    expect(mockEnterPreviewMode).not.toHaveBeenCalled();
+  });
+
+  it("disables Submit and displays Save Changes in preview mode", () => {
+    renderForm({ isPreviewMode: true });
+
+    expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Save Changes" })).toBeInTheDocument();
+  });
+
+  it("calls the preview save handler when Save Changes is clicked", async () => {
+    const user = userEvent.setup();
+    renderForm({ isPreviewMode: true });
+
+    await user.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    expect(mockHandleSave).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows saving state while preview changes are being saved", () => {
+    renderForm({ isPreviewMode: true, saving: true });
+
+    expect(screen.getByRole("button", { name: "Saving..." })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
+  });
+
+  it("cancels preview mode when Cancel is clicked during preview", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    renderForm({ isPreviewMode: true, onClose });
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(mockCancelPreview).toHaveBeenCalledTimes(1);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("closes the form when Cancel is clicked outside preview mode", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    renderForm({ isPreviewMode: false, onClose });
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(mockCancelPreview).not.toHaveBeenCalled();
+  });
+});

--- a/dataloom-frontend/src/test/FillEmptyForm.test.jsx
+++ b/dataloom-frontend/src/test/FillEmptyForm.test.jsx
@@ -1,0 +1,308 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import FillEmptyForm from "../Components/forms/FillEmptyForm";
+import { transformProject } from "../api";
+import { useProjectContext } from "../context/ProjectContext";
+import { useToast } from "../context/ToastContext";
+import usePreviewSave from "../hooks/usePreviewSave";
+
+vi.mock("../api", () => ({
+  transformProject: vi.fn(),
+}));
+
+vi.mock("../context/ToastContext", () => ({
+  useToast: vi.fn(),
+}));
+
+vi.mock("../context/ProjectContext", () => ({
+  useProjectContext: vi.fn(),
+}));
+
+vi.mock("../hooks/usePreviewSave", () => ({
+  default: vi.fn(),
+}));
+
+vi.mock("../Components/common/ColumnSelect", () => ({
+  default: ({ value, onChange, includeEmptyOption, emptyLabel }) => (
+    <select aria-label="Column" value={value} onChange={(event) => onChange(event.target.value)}>
+      {includeEmptyOption && <option value="">{emptyLabel || "Select column"}</option>}
+      <option value="amount">Amount</option>
+      <option value="created_at">Created At</option>
+    </select>
+  ),
+}));
+
+vi.mock("../Components/common/Select", () => ({
+  default: ({ value, onChange, options }) => (
+    <select aria-label="Strategy" value={value} onChange={(event) => onChange(event.target.value)}>
+      {options.map((option) => (
+        <option key={option.value} value={option.value}>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  ),
+}));
+
+const mockShowToast = vi.fn();
+const mockEnterPreviewMode = vi.fn();
+const mockCancelPreview = vi.fn();
+const mockHandleSave = vi.fn();
+
+const renderForm = ({
+  isPreviewMode = false,
+  onClose = vi.fn(),
+  saving = false,
+  columns = ["amount", "created_at"],
+} = {}) => {
+  useProjectContext.mockReturnValue({
+    columns,
+    isPreviewMode,
+    enterPreviewMode: mockEnterPreviewMode,
+    cancelPreview: mockCancelPreview,
+  });
+
+  usePreviewSave.mockReturnValue({
+    saving,
+    handleSave: mockHandleSave,
+  });
+
+  return {
+    onClose,
+    ...render(<FillEmptyForm projectId="project-123" onClose={onClose} />),
+  };
+};
+
+describe("FillEmptyForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    useToast.mockReturnValue({
+      showToast: mockShowToast,
+    });
+
+    transformProject.mockResolvedValue({
+      columns: ["amount", "created_at"],
+      rows: [["100", "2026-07-18"]],
+      dtypes: { amount: "integer", created_at: "datetime" },
+    });
+  });
+
+  it("renders column, strategy, and fill value controls by default", () => {
+    renderForm();
+
+    expect(screen.getByLabelText("Column")).toBeInTheDocument();
+    expect(screen.getByLabelText("Strategy")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Enter value")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Apply" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+  });
+
+  it("uses custom as the default strategy", () => {
+    renderForm();
+
+    expect(screen.getByLabelText("Strategy")).toHaveValue("custom");
+  });
+
+  it("hides the fill value input when strategy requires a column", async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    await user.selectOptions(screen.getByLabelText("Strategy"), "mean");
+
+    expect(screen.queryByPlaceholderText("Enter value")).not.toBeInTheDocument();
+  });
+
+  it("disables Apply when a column-requiring strategy has no column selected", async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    await user.selectOptions(screen.getByLabelText("Strategy"), "median");
+
+    expect(screen.getByRole("button", { name: "Apply" })).toBeDisabled();
+  });
+
+  it("shows a toast error when submitted without a required column", async () => {
+    renderForm();
+
+    const user = userEvent.setup();
+    await user.selectOptions(screen.getByLabelText("Strategy"), "mode");
+
+    const form = screen.getByRole("button", { name: "Apply" }).closest("form");
+    const { fireEvent } = await import("@testing-library/react");
+    fireEvent.submit(form);
+
+    await waitFor(() => {
+      expect(mockShowToast).toHaveBeenCalledWith(
+        "Please select a column to use mean, median, or mode.",
+        "error",
+      );
+    });
+    expect(transformProject).not.toHaveBeenCalled();
+  });
+
+  it("submits with a custom fill value and null column index", async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    await user.type(screen.getByPlaceholderText("Enter value"), "N/A");
+    await user.click(screen.getByRole("button", { name: "Apply" }));
+
+    await waitFor(() => {
+      expect(transformProject).toHaveBeenCalledWith(
+        "project-123",
+        {
+          operation_type: "fillEmpty",
+          fill_empty_params: {
+            index: null,
+            strategy: "custom",
+            fill_value: "N/A",
+          },
+        },
+        { preview: true },
+      );
+    });
+  });
+
+  it("submits the column index and null fill value for mean strategy", async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    await user.selectOptions(screen.getByLabelText("Strategy"), "mean");
+    await user.selectOptions(screen.getByLabelText("Column"), "created_at");
+    await user.click(screen.getByRole("button", { name: "Apply" }));
+
+    await waitFor(() => {
+      expect(transformProject).toHaveBeenCalledWith(
+        "project-123",
+        {
+          operation_type: "fillEmpty",
+          fill_empty_params: {
+            index: 1,
+            strategy: "mean",
+            fill_value: null,
+          },
+        },
+        { preview: true },
+      );
+    });
+  });
+
+  it("enters preview mode using the transformation response", async () => {
+    const user = userEvent.setup();
+    const response = { columns: ["amount"], rows: [[1]], dtypes: { amount: "integer" } };
+    transformProject.mockResolvedValue(response);
+
+    renderForm();
+    await user.type(screen.getByPlaceholderText("Enter value"), "0");
+    await user.click(screen.getByRole("button", { name: "Apply" }));
+
+    await waitFor(() => {
+      expect(mockEnterPreviewMode).toHaveBeenCalledWith(
+        response.columns,
+        response.rows,
+        response.dtypes,
+        expect.objectContaining({ projectId: "project-123" }),
+      );
+    });
+  });
+
+  it("shows applying state while the preview request is pending", async () => {
+    const user = userEvent.setup();
+    let resolveTransform;
+    transformProject.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveTransform = resolve;
+        }),
+    );
+
+    renderForm();
+    await user.type(screen.getByPlaceholderText("Enter value"), "0");
+    await user.click(screen.getByRole("button", { name: "Apply" }));
+
+    expect(screen.getByRole("button", { name: "Applying..." })).toBeDisabled();
+
+    resolveTransform({ columns: [], rows: [], dtypes: {} });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Apply" })).not.toBeDisabled();
+    });
+  });
+
+  it("shows the backend error message when the request fails", async () => {
+    const user = userEvent.setup();
+    transformProject.mockRejectedValue({
+      response: { data: { detail: "Unable to fill empty cells." } },
+    });
+
+    renderForm();
+    await user.type(screen.getByPlaceholderText("Enter value"), "0");
+    await user.click(screen.getByRole("button", { name: "Apply" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Unable to fill empty cells.")).toBeInTheDocument();
+    });
+    expect(mockShowToast).toHaveBeenCalledWith("Unable to fill empty cells.", "error");
+    expect(mockEnterPreviewMode).not.toHaveBeenCalled();
+  });
+
+  it("shows a fallback toast message when the request fails without backend detail", async () => {
+    const user = userEvent.setup();
+    transformProject.mockRejectedValue(new Error("Network error"));
+
+    renderForm();
+    await user.type(screen.getByPlaceholderText("Enter value"), "0");
+    await user.click(screen.getByRole("button", { name: "Apply" }));
+
+    await waitFor(() => {
+      expect(mockShowToast).toHaveBeenCalledWith("Failed to fill empty cells.", "error");
+    });
+  });
+
+  it("disables Apply and displays Save Changes in preview mode", () => {
+    renderForm({ isPreviewMode: true });
+
+    expect(screen.getByRole("button", { name: "Apply" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Save Changes" })).toBeInTheDocument();
+  });
+
+  it("calls the preview save handler when Save Changes is clicked", async () => {
+    const user = userEvent.setup();
+    renderForm({ isPreviewMode: true });
+
+    await user.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    expect(mockHandleSave).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows saving state while preview changes are being saved", () => {
+    renderForm({ isPreviewMode: true, saving: true });
+
+    expect(screen.getByRole("button", { name: "Saving..." })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Apply" })).toBeDisabled();
+  });
+
+  it("cancels preview mode when Cancel is clicked during preview", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    renderForm({ isPreviewMode: true, onClose });
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(mockCancelPreview).toHaveBeenCalledTimes(1);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("closes the form when Cancel is clicked outside preview mode", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    renderForm({ isPreviewMode: false, onClose });
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(mockCancelPreview).not.toHaveBeenCalled();
+  });
+});

--- a/dataloom-frontend/src/test/FilterForm.test.jsx
+++ b/dataloom-frontend/src/test/FilterForm.test.jsx
@@ -1,0 +1,240 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FILTER } from "../constants/operationTypes";
+import FilterForm from "../Components/forms/FilterForm";
+import { transformProject } from "../api";
+import { useProjectContext } from "../context/ProjectContext";
+import usePreviewSave from "../hooks/usePreviewSave";
+
+vi.mock("../api", () => ({
+  transformProject: vi.fn(),
+}));
+
+vi.mock("../context/ProjectContext", () => ({
+  useProjectContext: vi.fn(),
+}));
+
+vi.mock("../hooks/usePreviewSave", () => ({
+  default: vi.fn(),
+}));
+
+vi.mock("../Components/common/ColumnSelect", () => ({
+  default: ({ value, onChange, placeholder }) => (
+    <select aria-label="Column" value={value} onChange={(event) => onChange(event.target.value)}>
+      <option value="">{placeholder}</option>
+      <option value="amount">Amount</option>
+      <option value="created_at">Created At</option>
+    </select>
+  ),
+}));
+
+vi.mock("../Components/common/Select", () => ({
+  default: ({ value, onChange, options }) => (
+    <select aria-label="Condition" value={value} onChange={(event) => onChange(event.target.value)}>
+      {options.map((option) => (
+        <option key={option.value} value={option.value}>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  ),
+}));
+
+const mockEnterPreviewMode = vi.fn();
+const mockCancelPreview = vi.fn();
+const mockHandleSave = vi.fn();
+
+const renderForm = ({ isPreviewMode = false, onClose = vi.fn(), saving = false } = {}) => {
+  useProjectContext.mockReturnValue({
+    isPreviewMode,
+    enterPreviewMode: mockEnterPreviewMode,
+    cancelPreview: mockCancelPreview,
+  });
+
+  usePreviewSave.mockReturnValue({
+    saving,
+    handleSave: mockHandleSave,
+  });
+
+  return {
+    onClose,
+    ...render(<FilterForm projectId="project-123" onClose={onClose} />),
+  };
+};
+
+describe("FilterForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    transformProject.mockResolvedValue({
+      columns: ["amount", "created_at"],
+      rows: [["100", "2026-07-18"]],
+      dtypes: { amount: "integer", created_at: "datetime" },
+    });
+  });
+
+  it("renders column, condition, value controls and buttons", () => {
+    renderForm();
+
+    expect(screen.getByTestId("filter-form")).toBeInTheDocument();
+    expect(screen.getByLabelText("Column")).toBeInTheDocument();
+    expect(screen.getByLabelText("Condition")).toBeInTheDocument();
+    expect(screen.getByTestId("filter-value")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Apply Filter" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+  });
+
+  it("uses = as the default condition", () => {
+    renderForm();
+
+    expect(screen.getByLabelText("Condition")).toHaveValue("=");
+  });
+
+  it("shows a validation error when no column is selected", async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    await user.type(screen.getByTestId("filter-value"), "100");
+    fireEvent.submit(screen.getByTestId("filter-form").querySelector("form"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Please select a column.")).toBeInTheDocument();
+    });
+    expect(transformProject).not.toHaveBeenCalled();
+    expect(mockEnterPreviewMode).not.toHaveBeenCalled();
+  });
+
+  it("submits the filter parameters for preview", async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    await user.selectOptions(screen.getByLabelText("Column"), "amount");
+    await user.selectOptions(screen.getByLabelText("Condition"), ">");
+    await user.type(screen.getByTestId("filter-value"), "50");
+    await user.click(screen.getByRole("button", { name: "Apply Filter" }));
+
+    await waitFor(() => {
+      expect(transformProject).toHaveBeenCalledWith(
+        "project-123",
+        {
+          operation_type: FILTER,
+          parameters: { column: "amount", condition: ">", value: "50" },
+        },
+        { preview: true },
+      );
+    });
+  });
+
+  it("enters preview mode using the transformation response", async () => {
+    const user = userEvent.setup();
+    const response = { columns: ["amount"], rows: [[100]], dtypes: { amount: "integer" } };
+    transformProject.mockResolvedValue(response);
+
+    renderForm();
+    await user.selectOptions(screen.getByLabelText("Column"), "amount");
+    await user.type(screen.getByTestId("filter-value"), "50");
+    await user.click(screen.getByRole("button", { name: "Apply Filter" }));
+
+    await waitFor(() => {
+      expect(mockEnterPreviewMode).toHaveBeenCalledWith(
+        response.columns,
+        response.rows,
+        response.dtypes,
+        {
+          projectId: "project-123",
+          payload: {
+            operation_type: FILTER,
+            parameters: { column: "amount", condition: "=", value: "50" },
+          },
+        },
+      );
+    });
+  });
+
+  it("disables the Apply Filter button while the request is pending", async () => {
+    const user = userEvent.setup();
+    let resolveTransform;
+    transformProject.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveTransform = resolve;
+        }),
+    );
+
+    renderForm();
+    await user.selectOptions(screen.getByLabelText("Column"), "amount");
+    await user.type(screen.getByTestId("filter-value"), "50");
+    await user.click(screen.getByRole("button", { name: "Apply Filter" }));
+
+    expect(screen.getByRole("button", { name: "Apply Filter" })).toBeDisabled();
+
+    resolveTransform({ columns: [], rows: [], dtypes: {} });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Apply Filter" })).not.toBeDisabled();
+    });
+  });
+
+  it("shows the backend error message when the filter request fails", async () => {
+    const user = userEvent.setup();
+    transformProject.mockRejectedValue({
+      response: { data: { detail: "Invalid filter expression." } },
+    });
+
+    renderForm();
+    await user.selectOptions(screen.getByLabelText("Column"), "amount");
+    await user.type(screen.getByTestId("filter-value"), "50");
+    await user.click(screen.getByRole("button", { name: "Apply Filter" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Invalid filter expression.")).toBeInTheDocument();
+    });
+    expect(mockEnterPreviewMode).not.toHaveBeenCalled();
+  });
+
+  it("disables Apply Filter and displays Save Changes in preview mode", () => {
+    renderForm({ isPreviewMode: true });
+
+    expect(screen.getByRole("button", { name: "Apply Filter" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Save Changes" })).toBeInTheDocument();
+  });
+
+  it("calls the preview save handler when Save Changes is clicked", async () => {
+    const user = userEvent.setup();
+    renderForm({ isPreviewMode: true });
+
+    await user.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    expect(mockHandleSave).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows saving state while preview changes are being saved", () => {
+    renderForm({ isPreviewMode: true, saving: true });
+
+    expect(screen.getByRole("button", { name: "Saving..." })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Apply Filter" })).toBeDisabled();
+  });
+
+  it("cancels preview mode when Cancel is clicked during preview", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    renderForm({ isPreviewMode: true, onClose });
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(mockCancelPreview).toHaveBeenCalledTimes(1);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("closes the form when Cancel is clicked outside preview mode", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    renderForm({ isPreviewMode: false, onClose });
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(mockCancelPreview).not.toHaveBeenCalled();
+  });
+});

--- a/dataloom-frontend/src/test/GroupByForm.test.jsx
+++ b/dataloom-frontend/src/test/GroupByForm.test.jsx
@@ -1,97 +1,306 @@
-import { render, within } from "@testing-library/react";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { GROUPBY } from "../constants/operationTypes";
 import GroupByForm from "../Components/forms/GroupByForm";
 import { transformProject } from "../api";
+import { useProjectContext } from "../context/ProjectContext";
+import usePreviewSave from "../hooks/usePreviewSave";
 
 vi.mock("../api", () => ({
   transformProject: vi.fn(),
 }));
 
-const mockContext = {
-  columns: ["City", "Amount", "Date"],
-  dtypes: { City: "string", Amount: "float", Date: "date" },
-  columnOrder: [0, 1, 2],
-  updateData: vi.fn(),
-  enterPreviewMode: vi.fn(),
-  cancelPreview: vi.fn(),
-  confirmPreview: vi.fn(),
-  refreshProject: vi.fn(),
-  pageSize: 50,
-  pendingTransform: null,
-  isPreviewMode: false,
+vi.mock("../context/ProjectContext", () => ({
+  useProjectContext: vi.fn(),
+}));
+
+vi.mock("../hooks/usePreviewSave", () => ({
+  default: vi.fn(),
+}));
+
+vi.mock("../Components/common/ColumnMultiSelect", () => ({
+  default: ({ value, onChange, options }) => (
+    <select
+      multiple
+      aria-label="Group By Columns"
+      value={value}
+      onChange={(event) =>
+        onChange(Array.from(event.target.selectedOptions).map((option) => option.value))
+      }
+    >
+      {(options || []).map((option) => (
+        <option key={option} value={option}>
+          {option}
+        </option>
+      ))}
+    </select>
+  ),
+}));
+
+vi.mock("../Components/common/ColumnSelect", () => ({
+  default: ({ value, onChange, options }) => (
+    <select
+      aria-label="Aggregation Column"
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+    >
+      <option value="">Select column...</option>
+      {(options || []).map((option) => (
+        <option key={option} value={option}>
+          {option}
+        </option>
+      ))}
+    </select>
+  ),
+}));
+
+vi.mock("../Components/common/Select", () => ({
+  default: ({ value, onChange, options }) => (
+    <select aria-label="Function" value={value} onChange={(event) => onChange(event.target.value)}>
+      {options.map((option) => (
+        <option key={option.value} value={option.value}>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  ),
+}));
+
+const mockEnterPreviewMode = vi.fn();
+const mockCancelPreview = vi.fn();
+const mockHandleSave = vi.fn();
+
+const renderForm = ({
+  isPreviewMode = false,
+  onClose = vi.fn(),
+  saving = false,
+  columns = ["amount", "created_at", "region"],
+} = {}) => {
+  useProjectContext.mockReturnValue({
+    columns,
+    isPreviewMode,
+    enterPreviewMode: mockEnterPreviewMode,
+    cancelPreview: mockCancelPreview,
+  });
+
+  usePreviewSave.mockReturnValue({
+    saving,
+    handleSave: mockHandleSave,
+  });
+
+  return {
+    onClose,
+    ...render(<GroupByForm projectId="project-123" onClose={onClose} />),
+  };
 };
 
-vi.mock("../context/ProjectContext", () => ({
-  useProjectContext: () => mockContext,
-}));
-
-vi.mock("../context/HistoryRefreshContext", () => ({
-  useHistoryRefresh: () => ({ refreshLogs: vi.fn(), refreshCheckpoints: vi.fn() }),
-}));
-
-beforeEach(() => {
-  vi.resetAllMocks();
-  mockContext.isPreviewMode = false;
-  mockContext.pendingTransform = null;
-});
-
 describe("GroupByForm", () => {
-  it("calls enterPreviewMode after successful apply", async () => {
-    transformProject.mockResolvedValueOnce({
-      columns: ["City", "Amount"],
-      rows: [["Paris", "300"]],
-      dtypes: { City: "string", Amount: "float" },
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    transformProject.mockResolvedValue({
+      columns: ["region", "amount"],
+      rows: [["north", "100"]],
+      dtypes: { region: "string", amount: "integer" },
     });
+  });
 
-    const { getByText, getByTestId, getByRole } = render(
-      <GroupByForm projectId="proj-1" onClose={vi.fn()} />,
-    );
-    const { fireEvent } = await import("@testing-library/react");
+  it("renders group by, aggregation column, and function controls", () => {
+    renderForm();
 
-    fireEvent.click(getByText("City"));
-    fireEvent.click(getByTestId("groupby-agg-column"));
-    fireEvent.click(within(getByRole("listbox")).getByText("Amount"));
-    fireEvent.click(getByText("Apply GroupBy"));
+    expect(screen.getByLabelText("Group By Columns")).toBeInTheDocument();
+    expect(screen.getByLabelText("Aggregation Column")).toBeInTheDocument();
+    expect(screen.getByLabelText("Function")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Apply GroupBy" })).toBeInTheDocument();
+  });
 
-    await vi.waitFor(() => {
-      expect(mockContext.enterPreviewMode).toHaveBeenCalledWith(
-        ["City", "Amount"],
-        [["Paris", "300"]],
-        { City: "string", Amount: "float" },
+  it("uses sum as the default aggregation function", () => {
+    renderForm();
+
+    expect(screen.getByLabelText("Function")).toHaveValue("sum");
+  });
+
+  it("disables Apply GroupBy until group columns and an aggregation column are selected", async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    expect(screen.getByRole("button", { name: "Apply GroupBy" })).toBeDisabled();
+
+    await user.selectOptions(screen.getByLabelText("Group By Columns"), "region");
+    expect(screen.getByRole("button", { name: "Apply GroupBy" })).toBeDisabled();
+
+    await user.selectOptions(screen.getByLabelText("Aggregation Column"), "amount");
+    expect(screen.getByRole("button", { name: "Apply GroupBy" })).not.toBeDisabled();
+  });
+
+  it("submits the group by, aggregation column, and function", async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    await user.selectOptions(screen.getByLabelText("Group By Columns"), "region");
+    await user.selectOptions(screen.getByLabelText("Aggregation Column"), "amount");
+    await user.selectOptions(screen.getByLabelText("Function"), "mean");
+    await user.click(screen.getByRole("button", { name: "Apply GroupBy" }));
+
+    await waitFor(() => {
+      expect(transformProject).toHaveBeenCalledWith(
+        "project-123",
         {
-          payload: {
-            operation_type: "groupby",
-            groupby_params: {
-              columns: ["City"],
-              agg_column: "Amount",
-              agg_function: "sum",
-            },
+          operation_type: GROUPBY,
+          groupby_params: {
+            columns: ["region"],
+            agg_column: "amount",
+            agg_function: "mean",
           },
-          projectId: "proj-1",
         },
+        { preview: true },
       );
     });
   });
 
-  it("does not call enterPreviewMode when transform fails", async () => {
-    transformProject.mockRejectedValueOnce(new Error("Server error"));
+  it("enters preview mode using the transformation response", async () => {
+    const user = userEvent.setup();
+    const response = {
+      columns: ["region", "amount"],
+      rows: [["north", 100]],
+      dtypes: { region: "string", amount: "integer" },
+    };
+    transformProject.mockResolvedValue(response);
 
-    const { getByText, getByTestId, getByRole } = render(
-      <GroupByForm projectId="proj-1" onClose={vi.fn()} />,
-    );
-    const { fireEvent } = await import("@testing-library/react");
+    renderForm();
+    await user.selectOptions(screen.getByLabelText("Group By Columns"), "region");
+    await user.selectOptions(screen.getByLabelText("Aggregation Column"), "amount");
+    await user.click(screen.getByRole("button", { name: "Apply GroupBy" }));
 
-    fireEvent.click(getByText("City"));
-    fireEvent.click(getByTestId("groupby-agg-column"));
-    fireEvent.click(within(getByRole("listbox")).getByText("Amount"));
-    fireEvent.click(getByText("Apply GroupBy"));
-
-    await vi.waitFor(() => {
-      expect(mockContext.enterPreviewMode).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(mockEnterPreviewMode).toHaveBeenCalledWith(
+        response.columns,
+        response.rows,
+        response.dtypes,
+        expect.objectContaining({ projectId: "project-123" }),
+      );
     });
   });
 
+  it("shows applying state while the request is pending", async () => {
+    const user = userEvent.setup();
+    let resolveTransform;
+    transformProject.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveTransform = resolve;
+        }),
+    );
+
+    renderForm();
+    await user.selectOptions(screen.getByLabelText("Group By Columns"), "region");
+    await user.selectOptions(screen.getByLabelText("Aggregation Column"), "amount");
+    await user.click(screen.getByRole("button", { name: "Apply GroupBy" }));
+
+    expect(screen.getByRole("button", { name: "Applying..." })).toBeDisabled();
+
+    resolveTransform({ columns: [], rows: [], dtypes: {} });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Apply GroupBy" })).not.toBeDisabled();
+    });
+  });
+
+  it("shows the backend error message when the group by request fails", async () => {
+    const user = userEvent.setup();
+    transformProject.mockRejectedValue({
+      response: { data: { detail: "Unable to group dataset." } },
+    });
+
+    renderForm();
+    await user.selectOptions(screen.getByLabelText("Group By Columns"), "region");
+    await user.selectOptions(screen.getByLabelText("Aggregation Column"), "amount");
+    await user.click(screen.getByRole("button", { name: "Apply GroupBy" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Unable to group dataset.")).toBeInTheDocument();
+    });
+    expect(mockEnterPreviewMode).not.toHaveBeenCalled();
+  });
+
+  it("disables Apply GroupBy and displays Save Changes in preview mode", () => {
+    renderForm({ isPreviewMode: true });
+
+    expect(screen.getByRole("button", { name: "Apply GroupBy" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Save Changes" })).toBeInTheDocument();
+  });
+
+  it("calls the preview save handler when Save Changes is clicked", async () => {
+    const user = userEvent.setup();
+    renderForm({ isPreviewMode: true });
+
+    await user.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    expect(mockHandleSave).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows saving state while preview changes are being saved", () => {
+    renderForm({ isPreviewMode: true, saving: true });
+
+    expect(screen.getByRole("button", { name: "Saving..." })).toBeDisabled();
+  });
+
+  it("cancels preview mode when Cancel is clicked during preview", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    renderForm({ isPreviewMode: true, onClose });
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(mockCancelPreview).toHaveBeenCalledTimes(1);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("closes the form when Cancel is clicked outside preview mode", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    renderForm({ isPreviewMode: false, onClose });
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(mockCancelPreview).not.toHaveBeenCalled();
+  });
+
   it("does not call enterPreviewMode when user closes during loading", async () => {
+    const user = userEvent.setup();
+
+    let resolveTransform;
+    transformProject.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveTransform = resolve;
+        }),
+    );
+
+    const { unmount } = renderForm();
+
+    await user.selectOptions(screen.getByLabelText("Group By Columns"), "region");
+    await user.selectOptions(screen.getByLabelText("Aggregation Column"), "amount");
+    await user.click(screen.getByRole("button", { name: "Apply GroupBy" }));
+
+    unmount();
+
+    resolveTransform({
+      columns: [],
+      rows: [],
+      dtypes: {},
+    });
+
+    await Promise.resolve();
+
+    expect(mockEnterPreviewMode).not.toHaveBeenCalled();
+  });
+
+  it("allows re-submit after a cancelled in-flight request", async () => {
+    const user = userEvent.setup();
+
     let resolveTransform;
     transformProject.mockImplementationOnce(
       () =>
@@ -100,98 +309,44 @@ describe("GroupByForm", () => {
         }),
     );
 
-    const { getByText, getByTestId, getByRole, unmount } = render(
-      <GroupByForm projectId="proj-1" onClose={vi.fn()} />,
-    );
-    const { fireEvent } = await import("@testing-library/react");
+    const { unmount } = renderForm();
 
-    fireEvent.click(getByText("City"));
-    fireEvent.click(getByTestId("groupby-agg-column"));
-    fireEvent.click(within(getByRole("listbox")).getByText("Amount"));
-    fireEvent.click(getByText("Apply GroupBy"));
+    await user.selectOptions(screen.getByLabelText("Group By Columns"), "region");
+    await user.selectOptions(screen.getByLabelText("Aggregation Column"), "amount");
+    await user.click(screen.getByRole("button", { name: "Apply GroupBy" }));
+
     unmount();
 
     resolveTransform({
-      columns: ["City", "Amount"],
-      rows: [["Paris", "300"]],
-      dtypes: { City: "string", Amount: "float" },
+      columns: [],
+      rows: [],
+      dtypes: {},
     });
 
-    await vi.waitFor(() => {
-      expect(mockContext.enterPreviewMode).not.toHaveBeenCalled();
-    });
-  });
-
-  it("allows re-submit after a cancelled in-flight request", async () => {
-    let resolveFirst;
-    transformProject.mockImplementationOnce(
-      () =>
-        new Promise((resolve) => {
-          resolveFirst = resolve;
-        }),
-    );
-
-    const { getByText, getByTestId, getByRole, unmount } = render(
-      <GroupByForm projectId="proj-1" onClose={vi.fn()} />,
-    );
-    const { fireEvent } = await import("@testing-library/react");
-
-    fireEvent.click(getByText("City"));
-    fireEvent.click(getByTestId("groupby-agg-column"));
-    fireEvent.click(within(getByRole("listbox")).getByText("Amount"));
-    fireEvent.click(getByText("Apply GroupBy"));
-    unmount();
-    resolveFirst({ columns: [], rows: [], dtypes: {} });
-
-    transformProject.mockResolvedValueOnce({
-      columns: ["City", "Amount"],
-      rows: [["Paris", "300"]],
-      dtypes: { City: "string", Amount: "float" },
+    transformProject.mockResolvedValue({
+      columns: [],
+      rows: [],
+      dtypes: {},
     });
 
-    const {
-      getByText: getByText2,
-      getByTestId: getByTestId2,
-      getByRole: getByRole2,
-    } = render(<GroupByForm projectId="proj-1" onClose={vi.fn()} />);
-    fireEvent.click(getByText2("City"));
-    fireEvent.click(getByTestId2("groupby-agg-column"));
-    fireEvent.click(within(getByRole2("listbox")).getByText("Amount"));
-    fireEvent.click(getByText2("Apply GroupBy"));
+    renderForm();
 
-    await vi.waitFor(() => {
-      expect(mockContext.enterPreviewMode).toHaveBeenCalledTimes(1);
+    await user.selectOptions(screen.getByLabelText("Group By Columns"), "region");
+    await user.selectOptions(screen.getByLabelText("Aggregation Column"), "amount");
+    await user.click(screen.getByRole("button", { name: "Apply GroupBy" }));
+
+    await waitFor(() => {
+      expect(transformProject).toHaveBeenCalledTimes(2);
     });
   });
 
-  it("calls cancelPreview when Cancel clicked in preview mode", async () => {
-    mockContext.isPreviewMode = true;
+  it("calls cancelPreview on unmount when in preview mode", () => {
+    const { unmount } = renderForm({
+      isPreviewMode: true,
+    });
 
-    const { getByText } = render(<GroupByForm projectId="proj-1" onClose={vi.fn()} />);
-    const { fireEvent } = await import("@testing-library/react");
-
-    fireEvent.click(getByText("Cancel"));
-
-    expect(mockContext.cancelPreview).toHaveBeenCalled();
-  });
-
-  it("calls onClose when Cancel clicked outside preview mode", async () => {
-    const onClose = vi.fn();
-
-    const { getByText } = render(<GroupByForm projectId="proj-1" onClose={onClose} />);
-    const { fireEvent } = await import("@testing-library/react");
-
-    fireEvent.click(getByText("Cancel"));
-
-    expect(onClose).toHaveBeenCalled();
-  });
-
-  it("calls cancelPreview on unmount when in preview mode", async () => {
-    mockContext.isPreviewMode = true;
-
-    const { unmount } = render(<GroupByForm projectId="proj-1" onClose={vi.fn()} />);
     unmount();
 
-    expect(mockContext.cancelPreview).toHaveBeenCalled();
+    expect(mockCancelPreview).toHaveBeenCalled();
   });
 });

--- a/dataloom-frontend/src/test/MeltForm.test.jsx
+++ b/dataloom-frontend/src/test/MeltForm.test.jsx
@@ -1,0 +1,385 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import MeltForm from "../Components/forms/MeltForm";
+import { transformProject, getProjectDetails } from "../api";
+import { useProjectContext } from "../context/ProjectContext";
+import usePreviewSave from "../hooks/usePreviewSave";
+
+vi.mock("../api", () => ({
+  transformProject: vi.fn(),
+  getProjectDetails: vi.fn(),
+}));
+
+vi.mock("../context/ProjectContext", () => ({
+  useProjectContext: vi.fn(),
+}));
+
+vi.mock("../hooks/usePreviewSave", () => ({
+  default: vi.fn(),
+}));
+
+vi.mock("../Components/common/ColumnMultiSelect", () => ({
+  default: ({ value, onChange, options }) => (
+    <select
+      multiple
+      value={value}
+      onChange={(event) =>
+        onChange(Array.from(event.target.selectedOptions).map((option) => option.value))
+      }
+    >
+      {(options || []).map((option) => (
+        <option key={option} value={option}>
+          {option}
+        </option>
+      ))}
+    </select>
+  ),
+}));
+
+const mockEnterPreviewMode = vi.fn();
+const mockCancelPreview = vi.fn();
+const mockHandleSave = vi.fn();
+
+const renderForm = async ({ isPreviewMode = false, onClose = vi.fn(), saving = false } = {}) => {
+  useProjectContext.mockReturnValue({
+    isPreviewMode,
+    enterPreviewMode: mockEnterPreviewMode,
+    cancelPreview: mockCancelPreview,
+  });
+
+  usePreviewSave.mockReturnValue({
+    saving,
+    handleSave: mockHandleSave,
+  });
+
+  const utils = render(<MeltForm projectId="project-123" onClose={onClose} />);
+
+  await waitFor(() => {
+    expect(getProjectDetails).toHaveBeenCalledWith("project-123");
+  });
+
+  return { onClose, ...utils };
+};
+
+describe("MeltForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    useProjectContext.mockReturnValue({
+      isPreviewMode: false,
+      enterPreviewMode: mockEnterPreviewMode,
+      cancelPreview: mockCancelPreview,
+    });
+
+    usePreviewSave.mockReturnValue({
+      saving: false,
+      handleSave: mockHandleSave,
+    });
+
+    getProjectDetails.mockResolvedValue({
+      columns: ["amount", "created_at", "region"],
+    });
+
+    transformProject.mockResolvedValue({
+      columns: ["variable", "value"],
+      rows: [["amount", "100"]],
+      dtypes: {
+        variable: "string",
+        value: "string",
+      },
+    });
+  });
+
+  it("loads dataset columns on mount and renders the multi-selects", async () => {
+    await renderForm();
+
+    const multiSelects = screen.getAllByRole("listbox");
+
+    expect(multiSelects).toHaveLength(2);
+    expect(screen.getByRole("button", { name: "Apply Melt" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+  });
+
+  it("shows an error if fetching columns fails", async () => {
+    getProjectDetails.mockRejectedValue(new Error("network down"));
+
+    render(<MeltForm projectId="project-123" onClose={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Failed to load dataset columns. Please close and reopen the form."),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("requires at least one ID variable", async () => {
+    const user = userEvent.setup();
+
+    await renderForm();
+
+    await user.click(screen.getByRole("button", { name: "Apply Melt" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Please select at least one ID variable.")).toBeInTheDocument();
+    });
+
+    expect(transformProject).not.toHaveBeenCalled();
+  });
+
+  it("shows an error when the same column is used as both ID and value variable", async () => {
+    const user = userEvent.setup();
+
+    await renderForm();
+
+    const [idSelect, valueSelect] = screen.getAllByRole("listbox");
+
+    await user.selectOptions(idSelect, "amount");
+    await user.selectOptions(valueSelect, "amount");
+
+    await user.click(screen.getByRole("button", { name: "Apply Melt" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Columns cannot be in both ID and Value variables: amount"),
+      ).toBeInTheDocument();
+    });
+
+    expect(transformProject).not.toHaveBeenCalled();
+  });
+
+  it("defaults value variables to all non-ID columns when left empty", async () => {
+    const user = userEvent.setup();
+
+    await renderForm();
+
+    const [idSelect] = screen.getAllByRole("listbox");
+
+    await user.selectOptions(idSelect, "amount");
+
+    await user.click(screen.getByRole("button", { name: "Apply Melt" }));
+
+    await waitFor(() => {
+      expect(transformProject).toHaveBeenCalledWith(
+        "project-123",
+        {
+          operation_type: "melt",
+          melt_params: {
+            id_vars: ["amount"],
+            value_vars: ["created_at", "region"],
+            var_name: "variable",
+            value_name: "value",
+          },
+        },
+        { preview: true },
+      );
+    });
+  });
+
+  it("submits custom variable and value names", async () => {
+    const user = userEvent.setup();
+
+    await renderForm();
+
+    const [idSelect, valueSelect] = screen.getAllByRole("listbox");
+
+    await user.selectOptions(idSelect, "amount");
+    await user.selectOptions(valueSelect, "region");
+
+    const variableNameInput = screen.getByPlaceholderText("default: variable");
+    const valueNameInput = screen.getByPlaceholderText("default: value");
+
+    await user.clear(variableNameInput);
+    await user.type(variableNameInput, "metric");
+
+    await user.clear(valueNameInput);
+    await user.type(valueNameInput, "reading");
+
+    await user.click(screen.getByRole("button", { name: "Apply Melt" }));
+
+    await waitFor(() => {
+      expect(transformProject).toHaveBeenCalledWith(
+        "project-123",
+        {
+          operation_type: "melt",
+          melt_params: {
+            id_vars: ["amount"],
+            value_vars: ["region"],
+            var_name: "metric",
+            value_name: "reading",
+          },
+        },
+        { preview: true },
+      );
+    });
+  });
+
+  it("enters preview mode using the transformation response", async () => {
+    const user = userEvent.setup();
+
+    const response = {
+      columns: ["variable", "value"],
+      rows: [["amount", "100"]],
+      dtypes: {},
+    };
+
+    transformProject.mockResolvedValue(response);
+
+    await renderForm();
+
+    const [idSelect] = screen.getAllByRole("listbox");
+
+    await user.selectOptions(idSelect, "amount");
+
+    await user.click(screen.getByRole("button", { name: "Apply Melt" }));
+
+    await waitFor(() => {
+      expect(mockEnterPreviewMode).toHaveBeenCalledWith(
+        response.columns,
+        response.rows,
+        response.dtypes,
+        expect.objectContaining({
+          projectId: "project-123",
+        }),
+      );
+    });
+  });
+
+  it("shows a processing state while the request is pending", async () => {
+    const user = userEvent.setup();
+    let resolveTransform;
+
+    transformProject.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveTransform = resolve;
+        }),
+    );
+
+    await renderForm();
+
+    const [idSelect] = screen.getAllByRole("listbox");
+
+    await user.selectOptions(idSelect, "amount");
+
+    await user.click(screen.getByRole("button", { name: "Apply Melt" }));
+
+    expect(
+      screen.getByRole("button", {
+        name: "Processing...",
+      }),
+    ).toBeDisabled();
+
+    resolveTransform({
+      columns: [],
+      rows: [],
+      dtypes: {},
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", {
+          name: "Apply Melt",
+        }),
+      ).not.toBeDisabled();
+    });
+  });
+
+  it("shows the backend error message when the melt request fails", async () => {
+    const user = userEvent.setup();
+
+    transformProject.mockRejectedValue({
+      response: {
+        data: {
+          detail: "Unable to melt dataset.",
+        },
+      },
+    });
+
+    await renderForm();
+
+    const [idSelect] = screen.getAllByRole("listbox");
+
+    await user.selectOptions(idSelect, "amount");
+
+    await user.click(screen.getByRole("button", { name: "Apply Melt" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Unable to melt dataset.")).toBeInTheDocument();
+    });
+
+    expect(mockEnterPreviewMode).not.toHaveBeenCalled();
+  });
+
+  it("disables Apply Melt and displays Save Changes in preview mode", async () => {
+    await renderForm({
+      isPreviewMode: true,
+    });
+
+    expect(
+      screen.getByRole("button", {
+        name: "Apply Melt",
+      }),
+    ).toBeDisabled();
+
+    expect(
+      screen.getByRole("button", {
+        name: "Save Changes",
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("calls the preview save handler when Save Changes is clicked", async () => {
+    const user = userEvent.setup();
+
+    await renderForm({
+      isPreviewMode: true,
+    });
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Save Changes",
+      }),
+    );
+
+    expect(mockHandleSave).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels preview mode when Cancel is clicked during preview", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+
+    await renderForm({
+      isPreviewMode: true,
+      onClose,
+    });
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Cancel",
+      }),
+    );
+
+    expect(mockCancelPreview).toHaveBeenCalledTimes(1);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("closes the form when Cancel is clicked outside preview mode", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+
+    await renderForm({
+      isPreviewMode: false,
+      onClose,
+    });
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Cancel",
+      }),
+    );
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(mockCancelPreview).not.toHaveBeenCalled();
+  });
+});

--- a/dataloom-frontend/src/test/PivotTableForm.test.jsx
+++ b/dataloom-frontend/src/test/PivotTableForm.test.jsx
@@ -1,0 +1,266 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { PIVOT_TABLES } from "../constants/operationTypes";
+import PivotTableForm from "../Components/forms/PivotTableForm";
+import { transformProject } from "../api";
+import { useProjectContext } from "../context/ProjectContext";
+import usePreviewSave from "../hooks/usePreviewSave";
+
+vi.mock("../api", () => ({
+  transformProject: vi.fn(),
+}));
+
+vi.mock("../context/ProjectContext", () => ({
+  useProjectContext: vi.fn(),
+}));
+
+vi.mock("../hooks/usePreviewSave", () => ({
+  default: vi.fn(),
+}));
+
+vi.mock("../Components/common/ColumnMultiSelect", () => ({
+  default: ({ value, onChange }) => (
+    <select
+      multiple
+      aria-label="Index"
+      value={value}
+      onChange={(event) =>
+        onChange(Array.from(event.target.selectedOptions).map((option) => option.value))
+      }
+    >
+      <option value="region">Region</option>
+      <option value="amount">Amount</option>
+    </select>
+  ),
+}));
+
+// PivotTableForm renders two ColumnSelect instances (Column, Value) without a
+// distinguishing prop, so the mock tags them in render order for test lookup.
+let columnSelectRenderCount = 0;
+vi.mock("../Components/common/ColumnSelect", () => ({
+  default: ({ value, onChange, placeholder }) => {
+    const testId = `pivot-column-select-${columnSelectRenderCount % 2}`;
+    columnSelectRenderCount += 1;
+    return (
+      <select data-testid={testId} value={value} onChange={(event) => onChange(event.target.value)}>
+        <option value="">{placeholder}</option>
+        <option value="amount">Amount</option>
+        <option value="created_at">Created At</option>
+      </select>
+    );
+  },
+}));
+
+vi.mock("../Components/common/Select", () => ({
+  default: ({ value, onChange, options }) => (
+    <select
+      aria-label="Aggregation Function"
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+    >
+      {options.map((option) => (
+        <option key={option.value} value={option.value}>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  ),
+}));
+
+const mockEnterPreviewMode = vi.fn();
+const mockCancelPreview = vi.fn();
+const mockHandleSave = vi.fn();
+
+const renderForm = ({ isPreviewMode = false, onClose = vi.fn(), saving = false } = {}) => {
+  useProjectContext.mockReturnValue({
+    isPreviewMode,
+    enterPreviewMode: mockEnterPreviewMode,
+    cancelPreview: mockCancelPreview,
+  });
+
+  usePreviewSave.mockReturnValue({
+    saving,
+    handleSave: mockHandleSave,
+  });
+
+  return {
+    onClose,
+    ...render(<PivotTableForm projectId="project-123" onClose={onClose} />),
+  };
+};
+
+const getColumnSelects = () => [
+  screen.getByTestId("pivot-column-select-0"),
+  screen.getByTestId("pivot-column-select-1"),
+];
+
+describe("PivotTableForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    transformProject.mockResolvedValue({
+      columns: ["region", "amount"],
+      rows: [["north", "100"]],
+      dtypes: { region: "string", amount: "integer" },
+    });
+  });
+
+  it("renders index, column, value, and aggregation controls", () => {
+    renderForm();
+
+    expect(screen.getByLabelText("Index")).toBeInTheDocument();
+    expect(screen.getByLabelText("Aggregation Function")).toBeInTheDocument();
+    expect(screen.getByText("Column:")).toBeInTheDocument();
+    expect(screen.getByText("Value:")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Submit" })).toBeInTheDocument();
+  });
+
+  it("uses sum as the default aggregation function", () => {
+    renderForm();
+
+    expect(screen.getByLabelText("Aggregation Function")).toHaveValue("sum");
+  });
+
+  it("shows a validation error when no index column is selected", async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    await user.click(screen.getByRole("button", { name: "Submit" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Please select at least one index column.")).toBeInTheDocument();
+    });
+    expect(transformProject).not.toHaveBeenCalled();
+  });
+
+  it("shows a validation error when column or value is missing", async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    await user.selectOptions(screen.getByLabelText("Index"), "region");
+    await user.click(screen.getByRole("button", { name: "Submit" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Please select a column and a value.")).toBeInTheDocument();
+    });
+    expect(transformProject).not.toHaveBeenCalled();
+  });
+
+  it("submits index, column, value, and aggregation function", async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    await user.selectOptions(screen.getByLabelText("Index"), "region");
+    const [columnSelect, valueSelect] = getColumnSelects();
+    await user.selectOptions(columnSelect, "created_at");
+    await user.selectOptions(valueSelect, "amount");
+    await user.selectOptions(screen.getByLabelText("Aggregation Function"), "mean");
+    await user.click(screen.getByRole("button", { name: "Submit" }));
+
+    await waitFor(() => {
+      expect(transformProject).toHaveBeenCalledWith(
+        "project-123",
+        {
+          operation_type: PIVOT_TABLES,
+          pivot_query: {
+            index: "region",
+            column: "created_at",
+            value: "amount",
+            aggfun: "mean",
+          },
+        },
+        { preview: true },
+      );
+    });
+  });
+
+  it("enters preview mode using the transformation response", async () => {
+    const user = userEvent.setup();
+    const response = {
+      columns: ["region", "amount"],
+      rows: [["north", 100]],
+      dtypes: { region: "string", amount: "integer" },
+    };
+    transformProject.mockResolvedValue(response);
+
+    renderForm();
+    await user.selectOptions(screen.getByLabelText("Index"), "region");
+    const [columnSelect, valueSelect] = getColumnSelects();
+    await user.selectOptions(columnSelect, "created_at");
+    await user.selectOptions(valueSelect, "amount");
+    await user.click(screen.getByRole("button", { name: "Submit" }));
+
+    await waitFor(() => {
+      expect(mockEnterPreviewMode).toHaveBeenCalledWith(
+        response.columns,
+        response.rows,
+        response.dtypes,
+        expect.objectContaining({ projectId: "project-123" }),
+      );
+    });
+  });
+
+  it("shows the backend error message when the pivot request fails", async () => {
+    const user = userEvent.setup();
+    transformProject.mockRejectedValue({
+      response: { data: { detail: "Unable to build pivot table." } },
+    });
+
+    renderForm();
+    await user.selectOptions(screen.getByLabelText("Index"), "region");
+    const [columnSelect, valueSelect] = getColumnSelects();
+    await user.selectOptions(columnSelect, "created_at");
+    await user.selectOptions(valueSelect, "amount");
+    await user.click(screen.getByRole("button", { name: "Submit" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Unable to build pivot table.")).toBeInTheDocument();
+    });
+    expect(mockEnterPreviewMode).not.toHaveBeenCalled();
+  });
+
+  it("disables Submit and displays Save Changes in preview mode", () => {
+    renderForm({ isPreviewMode: true });
+
+    expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Save Changes" })).toBeInTheDocument();
+  });
+
+  it("calls the preview save handler when Save Changes is clicked", async () => {
+    const user = userEvent.setup();
+    renderForm({ isPreviewMode: true });
+
+    await user.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    expect(mockHandleSave).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows saving state while preview changes are being saved", () => {
+    renderForm({ isPreviewMode: true, saving: true });
+
+    expect(screen.getByRole("button", { name: "Saving..." })).toBeDisabled();
+  });
+
+  it("cancels preview mode when Cancel is clicked during preview", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    renderForm({ isPreviewMode: true, onClose });
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(mockCancelPreview).toHaveBeenCalledTimes(1);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("closes the form when Cancel is clicked outside preview mode", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    renderForm({ isPreviewMode: false, onClose });
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(mockCancelPreview).not.toHaveBeenCalled();
+  });
+});

--- a/dataloom-frontend/src/test/SampleRowsForm.test.jsx
+++ b/dataloom-frontend/src/test/SampleRowsForm.test.jsx
@@ -1,0 +1,228 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SAMPLE_ROWS } from "../constants/operationTypes";
+import SampleRowsForm from "../Components/forms/SampleRowsForm";
+import { transformProject } from "../api";
+import { useProjectContext } from "../context/ProjectContext";
+import usePreviewSave from "../hooks/usePreviewSave";
+
+vi.mock("../api", () => ({
+  transformProject: vi.fn(),
+}));
+
+vi.mock("../context/ProjectContext", () => ({
+  useProjectContext: vi.fn(),
+}));
+
+vi.mock("../hooks/usePreviewSave", () => ({
+  default: vi.fn(),
+}));
+
+const mockEnterPreviewMode = vi.fn();
+const mockCancelPreview = vi.fn();
+const mockHandleSave = vi.fn();
+
+const renderForm = ({ isPreviewMode = false, onClose = vi.fn(), saving = false } = {}) => {
+  useProjectContext.mockReturnValue({
+    isPreviewMode,
+    enterPreviewMode: mockEnterPreviewMode,
+    cancelPreview: mockCancelPreview,
+  });
+
+  usePreviewSave.mockReturnValue({
+    saving,
+    handleSave: mockHandleSave,
+  });
+
+  return {
+    onClose,
+    ...render(<SampleRowsForm projectId="project-123" onClose={onClose} />),
+  };
+};
+
+describe("SampleRowsForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    transformProject.mockResolvedValue({
+      columns: ["amount"],
+      rows: [["100"]],
+      dtypes: { amount: "integer" },
+    });
+  });
+
+  it("renders sample size, random seed inputs and buttons", () => {
+    renderForm();
+
+    expect(screen.getByPlaceholderText("e.g., 100")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("e.g., 42")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Apply Sample" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+  });
+
+  it("disables Apply Sample when no sample size is entered", () => {
+    renderForm();
+
+    expect(screen.getByRole("button", { name: "Apply Sample" })).toBeDisabled();
+  });
+
+  it("shows an error for a non-positive sample size", async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    const sampleSizeInput = screen.getByPlaceholderText("e.g., 100");
+
+    await user.type(sampleSizeInput, "0");
+
+    fireEvent.submit(sampleSizeInput.closest("form"));
+
+    expect(await screen.findByText("Sample size must be a positive integer")).toBeInTheDocument();
+
+    expect(transformProject).not.toHaveBeenCalled();
+  });
+
+  it("shows an error for a random seed outside the valid range", async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    const sampleSizeInput = screen.getByPlaceholderText("e.g., 100");
+    const randomSeedInput = screen.getByPlaceholderText("e.g., 42");
+
+    await user.type(sampleSizeInput, "10");
+    await user.type(randomSeedInput, "-1");
+
+    fireEvent.submit(sampleSizeInput.closest("form"));
+
+    expect(
+      await screen.findByText("Random seed must be between 0 and 4294967295"),
+    ).toBeInTheDocument();
+
+    expect(transformProject).not.toHaveBeenCalled();
+  });
+
+  it("submits with an explicit random seed", async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    await user.type(screen.getByPlaceholderText("e.g., 100"), "10");
+    await user.type(screen.getByPlaceholderText("e.g., 42"), "42");
+    await user.click(screen.getByRole("button", { name: "Apply Sample" }));
+
+    await waitFor(() => {
+      expect(transformProject).toHaveBeenCalledWith(
+        "project-123",
+        {
+          operation_type: SAMPLE_ROWS,
+          sample_params: { sample_size: 10, random_seed: 42 },
+        },
+        { preview: true },
+      );
+    });
+  });
+
+  it("auto-generates a random seed when none is provided", async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    await user.type(screen.getByPlaceholderText("e.g., 100"), "10");
+    await user.click(screen.getByRole("button", { name: "Apply Sample" }));
+
+    await waitFor(() => {
+      expect(transformProject).toHaveBeenCalledWith(
+        "project-123",
+        {
+          operation_type: SAMPLE_ROWS,
+          sample_params: {
+            sample_size: 10,
+            random_seed: expect.any(Number),
+          },
+        },
+        { preview: true },
+      );
+    });
+
+    const [, payload] = transformProject.mock.calls[0];
+    expect(payload.sample_params.random_seed).toBeGreaterThanOrEqual(0);
+    expect(payload.sample_params.random_seed).toBeLessThanOrEqual(4294967295);
+  });
+
+  it("enters preview mode using the transformation response", async () => {
+    const user = userEvent.setup();
+    const response = { columns: ["amount"], rows: [[100]], dtypes: { amount: "integer" } };
+    transformProject.mockResolvedValue(response);
+
+    renderForm();
+    await user.type(screen.getByPlaceholderText("e.g., 100"), "10");
+    await user.click(screen.getByRole("button", { name: "Apply Sample" }));
+
+    await waitFor(() => {
+      expect(mockEnterPreviewMode).toHaveBeenCalledWith(
+        response.columns,
+        response.rows,
+        response.dtypes,
+        expect.objectContaining({ projectId: "project-123" }),
+      );
+    });
+  });
+
+  it("shows the backend error message when the request fails", async () => {
+    const user = userEvent.setup();
+    transformProject.mockRejectedValue({
+      response: { data: { detail: "Sample size exceeds row count." } },
+    });
+
+    renderForm();
+    await user.type(screen.getByPlaceholderText("e.g., 100"), "10");
+    await user.click(screen.getByRole("button", { name: "Apply Sample" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Sample size exceeds row count.")).toBeInTheDocument();
+    });
+    expect(mockEnterPreviewMode).not.toHaveBeenCalled();
+  });
+
+  it("disables Apply Sample and displays Save Changes in preview mode", () => {
+    renderForm({ isPreviewMode: true });
+
+    expect(screen.getByRole("button", { name: "Apply Sample" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Save Changes" })).toBeInTheDocument();
+  });
+
+  it("calls the preview save handler when Save Changes is clicked", async () => {
+    const user = userEvent.setup();
+    renderForm({ isPreviewMode: true });
+
+    await user.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    expect(mockHandleSave).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows saving state while preview changes are being saved", () => {
+    renderForm({ isPreviewMode: true, saving: true });
+
+    expect(screen.getByRole("button", { name: "Saving..." })).toBeDisabled();
+  });
+
+  it("cancels preview mode when Cancel is clicked during preview", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    renderForm({ isPreviewMode: true, onClose });
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(mockCancelPreview).toHaveBeenCalledTimes(1);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("closes the form when Cancel is clicked outside preview mode", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    renderForm({ isPreviewMode: false, onClose });
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(mockCancelPreview).not.toHaveBeenCalled();
+  });
+});

--- a/dataloom-frontend/src/test/SortForm.test.jsx
+++ b/dataloom-frontend/src/test/SortForm.test.jsx
@@ -1,0 +1,298 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SORT } from "../constants/operationTypes";
+import SortForm from "../Components/forms/SortForm";
+import { transformProject } from "../api";
+import { useProjectContext } from "../context/ProjectContext";
+import usePreviewSave from "../hooks/usePreviewSave";
+
+vi.mock("../api", () => ({
+  transformProject: vi.fn(),
+}));
+
+vi.mock("../context/ProjectContext", () => ({
+  useProjectContext: vi.fn(),
+}));
+
+vi.mock("../hooks/usePreviewSave", () => ({
+  default: vi.fn(),
+}));
+
+vi.mock("../Components/common/ColumnSelect", () => ({
+  default: ({ value, onChange, placeholder, "data-testid": testId }) => (
+    <select
+      aria-label="Column"
+      data-testid={testId}
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+    >
+      <option value="">{placeholder}</option>
+      <option value="amount">Amount</option>
+      <option value="created_at">Created At</option>
+    </select>
+  ),
+}));
+
+vi.mock("../Components/common/Select", () => ({
+  default: ({ value, onChange, options }) => (
+    <select aria-label="Order" value={value} onChange={(event) => onChange(event.target.value)}>
+      {options.map((option) => (
+        <option key={option.value} value={option.value}>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  ),
+}));
+
+const mockEnterPreviewMode = vi.fn();
+const mockCancelPreview = vi.fn();
+const mockHandleSave = vi.fn();
+
+const renderForm = ({ isPreviewMode = false, onClose = vi.fn(), saving = false } = {}) => {
+  useProjectContext.mockReturnValue({
+    isPreviewMode,
+    enterPreviewMode: mockEnterPreviewMode,
+    cancelPreview: mockCancelPreview,
+  });
+
+  usePreviewSave.mockReturnValue({
+    saving,
+    handleSave: mockHandleSave,
+  });
+
+  return {
+    onClose,
+    ...render(<SortForm projectId="project-123" onClose={onClose} />),
+  };
+};
+
+describe("SortForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    transformProject.mockResolvedValue({
+      columns: ["amount"],
+      rows: [["100"]],
+      dtypes: { amount: "integer" },
+    });
+  });
+
+  it("renders a single sort criterion by default, ascending", () => {
+    renderForm();
+
+    expect(screen.getByTestId("sort-column")).toBeInTheDocument();
+    expect(screen.getByLabelText("Order")).toHaveValue("true");
+    expect(screen.getByRole("button", { name: "Apply Sort" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+  });
+
+  it("adds a new sort criterion row", async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    await user.click(screen.getByRole("button", { name: "Add Sort Criterion" }));
+
+    expect(screen.getAllByLabelText("Column")).toHaveLength(2);
+  });
+
+  it("clears the column instead of removing the row when it is the only criterion", async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    await user.selectOptions(screen.getByTestId("sort-column"), "amount");
+    await user.click(screen.getByTitle("Remove criterion"));
+
+    expect(screen.getAllByLabelText("Column")).toHaveLength(1);
+    expect(screen.getByTestId("sort-column")).toHaveValue("");
+  });
+
+  it("removes a criterion row when more than one exists", async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    await user.click(screen.getByRole("button", { name: "Add Sort Criterion" }));
+    expect(screen.getAllByLabelText("Column")).toHaveLength(2);
+
+    await user.click(screen.getAllByTitle("Remove criterion")[1]);
+
+    expect(screen.getAllByLabelText("Column")).toHaveLength(1);
+  });
+
+  it("reorders criteria when moved down", async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    await user.selectOptions(screen.getByTestId("sort-column"), "amount");
+    await user.click(screen.getByRole("button", { name: "Add Sort Criterion" }));
+    await user.selectOptions(screen.getAllByLabelText("Column")[1], "created_at");
+
+    await user.click(screen.getAllByTitle("Move down in priority")[0]);
+
+    expect(screen.getByTestId("sort-column")).toHaveValue("created_at");
+  });
+
+  it("shows a validation error when any criterion has no column selected", async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    await user.click(screen.getByRole("button", { name: "Apply Sort" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Please select a column for all sort criteria")).toBeInTheDocument();
+    });
+    expect(transformProject).not.toHaveBeenCalled();
+  });
+
+  it("submits the sort criteria with the selected order", async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    await user.selectOptions(screen.getByTestId("sort-column"), "amount");
+    await user.selectOptions(screen.getByLabelText("Order"), "false");
+    await user.click(screen.getByRole("button", { name: "Apply Sort" }));
+
+    await waitFor(() => {
+      expect(transformProject).toHaveBeenCalledWith(
+        "project-123",
+        {
+          operation_type: SORT,
+          sort_params: {
+            criteria: [{ column: "amount", ascending: false }],
+          },
+        },
+        { preview: true },
+      );
+    });
+  });
+
+  it("submits multiple sort criteria in priority order", async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    await user.selectOptions(screen.getByTestId("sort-column"), "amount");
+    await user.click(screen.getByRole("button", { name: "Add Sort Criterion" }));
+    await user.selectOptions(screen.getAllByLabelText("Column")[1], "created_at");
+    await user.click(screen.getByRole("button", { name: "Apply Sort" }));
+
+    await waitFor(() => {
+      expect(transformProject).toHaveBeenCalledWith(
+        "project-123",
+        {
+          operation_type: SORT,
+          sort_params: {
+            criteria: [
+              { column: "amount", ascending: true },
+              { column: "created_at", ascending: true },
+            ],
+          },
+        },
+        { preview: true },
+      );
+    });
+  });
+
+  it("enters preview mode using the transformation response", async () => {
+    const user = userEvent.setup();
+    const response = { columns: ["amount"], rows: [[100]], dtypes: { amount: "integer" } };
+    transformProject.mockResolvedValue(response);
+
+    renderForm();
+    await user.selectOptions(screen.getByTestId("sort-column"), "amount");
+    await user.click(screen.getByRole("button", { name: "Apply Sort" }));
+
+    await waitFor(() => {
+      expect(mockEnterPreviewMode).toHaveBeenCalledWith(
+        response.columns,
+        response.rows,
+        response.dtypes,
+        expect.objectContaining({ projectId: "project-123" }),
+      );
+    });
+  });
+
+  it("shows applying state while the request is pending", async () => {
+    const user = userEvent.setup();
+    let resolveTransform;
+    transformProject.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveTransform = resolve;
+        }),
+    );
+
+    renderForm();
+    await user.selectOptions(screen.getByTestId("sort-column"), "amount");
+    await user.click(screen.getByRole("button", { name: "Apply Sort" }));
+
+    expect(screen.getByRole("button", { name: "Applying..." })).toBeDisabled();
+
+    resolveTransform({ columns: [], rows: [], dtypes: {} });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Apply Sort" })).not.toBeDisabled();
+    });
+  });
+
+  it("shows the backend error message when the sort request fails", async () => {
+    const user = userEvent.setup();
+    transformProject.mockRejectedValue({
+      response: { data: { detail: "Unable to sort dataset." } },
+    });
+
+    renderForm();
+    await user.selectOptions(screen.getByTestId("sort-column"), "amount");
+    await user.click(screen.getByRole("button", { name: "Apply Sort" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Unable to sort dataset.")).toBeInTheDocument();
+    });
+    expect(mockEnterPreviewMode).not.toHaveBeenCalled();
+  });
+
+  it("disables Apply Sort and displays Save Changes in preview mode", () => {
+    renderForm({ isPreviewMode: true });
+
+    expect(screen.getByRole("button", { name: "Apply Sort" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Save Changes" })).toBeInTheDocument();
+  });
+
+  it("calls the preview save handler when Save Changes is clicked", async () => {
+    const user = userEvent.setup();
+    renderForm({ isPreviewMode: true });
+
+    await user.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    expect(mockHandleSave).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows saving state while preview changes are being saved", () => {
+    renderForm({ isPreviewMode: true, saving: true });
+
+    expect(screen.getByRole("button", { name: "Saving..." })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Apply Sort" })).toBeDisabled();
+  });
+
+  it("cancels preview mode when Cancel is clicked during preview", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    renderForm({ isPreviewMode: true, onClose });
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(mockCancelPreview).toHaveBeenCalledTimes(1);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("closes the form when Cancel is clicked outside preview mode", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    renderForm({ isPreviewMode: false, onClose });
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(mockCancelPreview).not.toHaveBeenCalled();
+  });
+});

--- a/dataloom-frontend/src/test/StringReplaceForm.test.jsx
+++ b/dataloom-frontend/src/test/StringReplaceForm.test.jsx
@@ -1,0 +1,240 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { STRING_REPLACE } from "../constants/operationTypes";
+import StringReplaceForm from "../Components/forms/StringReplaceForm";
+import { transformProject } from "../api";
+import { useProjectContext } from "../context/ProjectContext";
+import usePreviewSave from "../hooks/usePreviewSave";
+
+vi.mock("../api", () => ({
+  transformProject: vi.fn(),
+}));
+
+vi.mock("../context/ProjectContext", () => ({
+  useProjectContext: vi.fn(),
+}));
+
+vi.mock("../hooks/usePreviewSave", () => ({
+  default: vi.fn(),
+}));
+
+vi.mock("../Components/common/ColumnSelect", () => ({
+  default: ({ value, onChange }) => (
+    <select aria-label="Column" value={value} onChange={(event) => onChange(event.target.value)}>
+      <option value="">Select column</option>
+      <option value="amount">Amount</option>
+      <option value="created_at">Created At</option>
+    </select>
+  ),
+}));
+
+const mockEnterPreviewMode = vi.fn();
+const mockCancelPreview = vi.fn();
+const mockHandleSave = vi.fn();
+
+const renderForm = ({ isPreviewMode = false, onClose = vi.fn(), saving = false } = {}) => {
+  useProjectContext.mockReturnValue({
+    isPreviewMode,
+    enterPreviewMode: mockEnterPreviewMode,
+    cancelPreview: mockCancelPreview,
+  });
+
+  usePreviewSave.mockReturnValue({
+    saving,
+    handleSave: mockHandleSave,
+  });
+
+  return {
+    onClose,
+    ...render(<StringReplaceForm projectId="project-123" onClose={onClose} />),
+  };
+};
+
+describe("StringReplaceForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    transformProject.mockResolvedValue({
+      columns: ["amount"],
+      rows: [["100"]],
+      dtypes: { amount: "integer" },
+    });
+  });
+
+  it("renders column, find, and replace controls", () => {
+    renderForm();
+
+    expect(screen.getByLabelText("Column")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Text to find")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Replacement text")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Apply" })).toBeInTheDocument();
+  });
+
+  it("shows a validation error when no column is selected", async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    await user.type(screen.getByPlaceholderText("Text to find"), "foo");
+    await user.click(screen.getByRole("button", { name: "Apply" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Please select a column.")).toBeInTheDocument();
+    });
+    expect(transformProject).not.toHaveBeenCalled();
+  });
+
+  it("submits column, find value, and replace value", async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    await user.selectOptions(screen.getByLabelText("Column"), "amount");
+    await user.type(screen.getByPlaceholderText("Text to find"), "foo");
+    await user.type(screen.getByPlaceholderText("Replacement text"), "bar");
+    await user.click(screen.getByRole("button", { name: "Apply" }));
+
+    await waitFor(() => {
+      expect(transformProject).toHaveBeenCalledWith(
+        "project-123",
+        {
+          operation_type: STRING_REPLACE,
+          string_replace_params: {
+            column: "amount",
+            find_value: "foo",
+            replace_value: "bar",
+          },
+        },
+        { preview: true },
+      );
+    });
+  });
+
+  it("allows an empty replace value", async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    await user.selectOptions(screen.getByLabelText("Column"), "amount");
+    await user.type(screen.getByPlaceholderText("Text to find"), "foo");
+    await user.click(screen.getByRole("button", { name: "Apply" }));
+
+    await waitFor(() => {
+      expect(transformProject).toHaveBeenCalledWith(
+        "project-123",
+        {
+          operation_type: STRING_REPLACE,
+          string_replace_params: {
+            column: "amount",
+            find_value: "foo",
+            replace_value: "",
+          },
+        },
+        { preview: true },
+      );
+    });
+  });
+
+  it("enters preview mode using the transformation response", async () => {
+    const user = userEvent.setup();
+    const response = { columns: ["amount"], rows: [[100]], dtypes: { amount: "integer" } };
+    transformProject.mockResolvedValue(response);
+
+    renderForm();
+    await user.selectOptions(screen.getByLabelText("Column"), "amount");
+    await user.type(screen.getByPlaceholderText("Text to find"), "foo");
+    await user.click(screen.getByRole("button", { name: "Apply" }));
+
+    await waitFor(() => {
+      expect(mockEnterPreviewMode).toHaveBeenCalledWith(
+        response.columns,
+        response.rows,
+        response.dtypes,
+        expect.objectContaining({ projectId: "project-123" }),
+      );
+    });
+  });
+
+  it("shows applying state while the request is pending", async () => {
+    const user = userEvent.setup();
+    let resolveTransform;
+    transformProject.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveTransform = resolve;
+        }),
+    );
+
+    renderForm();
+    await user.selectOptions(screen.getByLabelText("Column"), "amount");
+    await user.type(screen.getByPlaceholderText("Text to find"), "foo");
+    await user.click(screen.getByRole("button", { name: "Apply" }));
+
+    expect(screen.getByRole("button", { name: "Applying..." })).toBeDisabled();
+
+    resolveTransform({ columns: [], rows: [], dtypes: {} });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Apply" })).not.toBeDisabled();
+    });
+  });
+
+  it("shows the backend error message when the request fails", async () => {
+    const user = userEvent.setup();
+    transformProject.mockRejectedValue({
+      response: { data: { detail: "Unable to replace text." } },
+    });
+
+    renderForm();
+    await user.selectOptions(screen.getByLabelText("Column"), "amount");
+    await user.type(screen.getByPlaceholderText("Text to find"), "foo");
+    await user.click(screen.getByRole("button", { name: "Apply" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Unable to replace text.")).toBeInTheDocument();
+    });
+    expect(mockEnterPreviewMode).not.toHaveBeenCalled();
+  });
+
+  it("disables Apply and displays Save Changes in preview mode", () => {
+    renderForm({ isPreviewMode: true });
+
+    expect(screen.getByRole("button", { name: "Apply" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Save Changes" })).toBeInTheDocument();
+  });
+
+  it("calls the preview save handler when Save Changes is clicked", async () => {
+    const user = userEvent.setup();
+    renderForm({ isPreviewMode: true });
+
+    await user.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    expect(mockHandleSave).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows saving state while preview changes are being saved", () => {
+    renderForm({ isPreviewMode: true, saving: true });
+
+    expect(screen.getByRole("button", { name: "Saving..." })).toBeDisabled();
+  });
+
+  it("cancels preview mode when Cancel is clicked during preview", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    renderForm({ isPreviewMode: true, onClose });
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(mockCancelPreview).toHaveBeenCalledTimes(1);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("closes the form when Cancel is clicked outside preview mode", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    renderForm({ isPreviewMode: false, onClose });
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(mockCancelPreview).not.toHaveBeenCalled();
+  });
+});

--- a/dataloom-frontend/src/test/TrimWhitespaceForm.test.jsx
+++ b/dataloom-frontend/src/test/TrimWhitespaceForm.test.jsx
@@ -1,0 +1,233 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { TRIM_WHITESPACE } from "../constants/operationTypes";
+import TrimWhitespaceForm from "../Components/forms/TrimWhitespaceForm";
+import { transformProject } from "../api";
+import { useProjectContext } from "../context/ProjectContext";
+import usePreviewSave from "../hooks/usePreviewSave";
+
+vi.mock("../api", () => ({
+  transformProject: vi.fn(),
+}));
+
+vi.mock("../context/ProjectContext", () => ({
+  useProjectContext: vi.fn(),
+}));
+
+vi.mock("../hooks/usePreviewSave", () => ({
+  default: vi.fn(),
+}));
+
+vi.mock("../Components/common/ColumnSelect", () => ({
+  default: ({ value, onChange, options }) => (
+    <select aria-label="Column" value={value} onChange={(event) => onChange(event.target.value)}>
+      {(options || []).map((option) => (
+        <option key={option} value={option}>
+          {option}
+        </option>
+      ))}
+    </select>
+  ),
+}));
+
+const mockEnterPreviewMode = vi.fn();
+const mockCancelPreview = vi.fn();
+const mockHandleSave = vi.fn();
+
+const renderForm = ({
+  isPreviewMode = false,
+  onClose = vi.fn(),
+  saving = false,
+  columns = ["amount", "created_at"],
+} = {}) => {
+  useProjectContext.mockReturnValue({
+    columns,
+    isPreviewMode,
+    enterPreviewMode: mockEnterPreviewMode,
+    cancelPreview: mockCancelPreview,
+  });
+
+  usePreviewSave.mockReturnValue({
+    saving,
+    handleSave: mockHandleSave,
+  });
+
+  return {
+    onClose,
+    ...render(<TrimWhitespaceForm projectId="project-123" onClose={onClose} />),
+  };
+};
+
+describe("TrimWhitespaceForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    transformProject.mockResolvedValue({
+      columns: ["amount"],
+      rows: [["100"]],
+      dtypes: { amount: "integer" },
+    });
+  });
+
+  it("renders the column control including the All string columns option", () => {
+    renderForm();
+
+    const select = screen.getByLabelText("Column");
+    expect(select).toBeInTheDocument();
+    expect(screen.getByText("All string columns")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Apply" })).toBeInTheDocument();
+  });
+
+  it("shows a validation error when no column is selected", async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    await user.click(screen.getByRole("button", { name: "Apply" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Please select a column.")).toBeInTheDocument();
+    });
+    expect(transformProject).not.toHaveBeenCalled();
+  });
+
+  it("submits the selected column for trimming", async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    await user.selectOptions(screen.getByLabelText("Column"), "amount");
+    await user.click(screen.getByRole("button", { name: "Apply" }));
+
+    await waitFor(() => {
+      expect(transformProject).toHaveBeenCalledWith(
+        "project-123",
+        {
+          operation_type: TRIM_WHITESPACE,
+          trim_whitespace_params: { column: "amount" },
+        },
+        { preview: true },
+      );
+    });
+  });
+
+  it("allows selecting All string columns", async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    await user.selectOptions(screen.getByLabelText("Column"), "All string columns");
+    await user.click(screen.getByRole("button", { name: "Apply" }));
+
+    await waitFor(() => {
+      expect(transformProject).toHaveBeenCalledWith(
+        "project-123",
+        {
+          operation_type: TRIM_WHITESPACE,
+          trim_whitespace_params: { column: "All string columns" },
+        },
+        { preview: true },
+      );
+    });
+  });
+
+  it("enters preview mode using the transformation response", async () => {
+    const user = userEvent.setup();
+    const response = { columns: ["amount"], rows: [[100]], dtypes: { amount: "integer" } };
+    transformProject.mockResolvedValue(response);
+
+    renderForm();
+    await user.selectOptions(screen.getByLabelText("Column"), "amount");
+    await user.click(screen.getByRole("button", { name: "Apply" }));
+
+    await waitFor(() => {
+      expect(mockEnterPreviewMode).toHaveBeenCalledWith(
+        response.columns,
+        response.rows,
+        response.dtypes,
+        expect.objectContaining({ projectId: "project-123" }),
+      );
+    });
+  });
+
+  it("shows applying state while the request is pending", async () => {
+    const user = userEvent.setup();
+    let resolveTransform;
+    transformProject.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveTransform = resolve;
+        }),
+    );
+
+    renderForm();
+    await user.selectOptions(screen.getByLabelText("Column"), "amount");
+    await user.click(screen.getByRole("button", { name: "Apply" }));
+
+    expect(screen.getByRole("button", { name: "Applying..." })).toBeDisabled();
+
+    resolveTransform({ columns: [], rows: [], dtypes: {} });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Apply" })).not.toBeDisabled();
+    });
+  });
+
+  it("shows the backend error message when the request fails", async () => {
+    const user = userEvent.setup();
+    transformProject.mockRejectedValue({
+      response: { data: { detail: "Unable to trim whitespace." } },
+    });
+
+    renderForm();
+    await user.selectOptions(screen.getByLabelText("Column"), "amount");
+    await user.click(screen.getByRole("button", { name: "Apply" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Unable to trim whitespace.")).toBeInTheDocument();
+    });
+    expect(mockEnterPreviewMode).not.toHaveBeenCalled();
+  });
+
+  it("disables Apply and displays Save Changes in preview mode", () => {
+    renderForm({ isPreviewMode: true });
+
+    expect(screen.getByRole("button", { name: "Apply" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Save Changes" })).toBeInTheDocument();
+  });
+
+  it("calls the preview save handler when Save Changes is clicked", async () => {
+    const user = userEvent.setup();
+    renderForm({ isPreviewMode: true });
+
+    await user.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    expect(mockHandleSave).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows saving state while preview changes are being saved", () => {
+    renderForm({ isPreviewMode: true, saving: true });
+
+    expect(screen.getByRole("button", { name: "Saving..." })).toBeDisabled();
+  });
+
+  it("cancels preview mode when Cancel is clicked during preview", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    renderForm({ isPreviewMode: true, onClose });
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(mockCancelPreview).toHaveBeenCalledTimes(1);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("closes the form when Cancel is clicked outside preview mode", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    renderForm({ isPreviewMode: false, onClose });
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(mockCancelPreview).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Description

Adds unit test coverage for all remaining transformation form components (`FillEmptyForm`, `FilterForm`, `MeltForm`, `SampleRowsForm`, `SortForm`, `AdvQueryFilterForm`, `DropDuplicateForm`, `GroupByForm`, `PivotTableForm`, `StringReplaceForm`, `TrimWhitespaceForm`, `CastDataTypeForm`). Each new suite mocks `api`, `ProjectContext`, `usePreviewSave`, and the shared `ColumnSelect`/`Select`/`ColumnMultiSelect` primitives, while exercising the real `useError`, `FormErrorAlert`, and `Button` components.

Fixes #449 

## Type of Change

- [x] New feature

## How Has This Been Tested?

Describe the tests you ran to verify your changes.

- [x] Existing tests pass
- [x] New tests added

## Screenshots 
<img width="853" height="87" alt="Screenshot 2026-07-18 at 21 00 20" src="https://github.com/user-attachments/assets/64fbbf32-5354-4617-a344-11b952b731b5" />


## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally