### PR TITLE
fix: run lint on pull_request and comment via workflow_run

### DIFF
--- a/.github/workflows/lint-comment.yml
+++ b/.github/workflows/lint-comment.yml
@@ -1,0 +1,159 @@
+name: Lint Comment
+
+# Privileged half of the lint pipeline. It is triggered by the completion of
+# Lint (lint.yml) and never checks out or executes pull request code — it only
+# reads the data-only report.json artifact that run produced.
+
+on:
+  workflow_run:
+    workflows: [Lint]
+    types: [completed]
+
+concurrency:
+  group: lint-comment-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  actions: read
+  pull-requests: write
+
+jobs:
+  comment:
+    name: PR Comment
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download report
+        id: download
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: pr-lint-report
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Post or delete combined comment
+        if: steps.download.outcome == 'success'
+        uses: actions/github-script@v7
+        env:
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        with:
+          script: |
+            const fs = require('fs');
+            const report = JSON.parse(fs.readFileSync('report.json', 'utf8'));
+
+            // report.json comes from a run that executed fork code, so treat
+            // every field as untrusted input.
+            const prNumber = parseInt(report.pr, 10);
+            if (!Number.isInteger(prNumber) || prNumber <= 0) {
+              core.setFailed('Report contains no usable PR number.');
+              return;
+            }
+
+            // Confirm the reported PR really is the one that triggered the run,
+            // so a forged report cannot make the bot comment on someone else's PR.
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner, repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+            if (pr.head.sha !== process.env.HEAD_SHA) {
+              core.setFailed(`PR #${prNumber} head ${pr.head.sha} does not match run head ${process.env.HEAD_SHA}.`);
+              return;
+            }
+
+            const marker = '<!-- ci-bot -->';
+            const oldMarkers = ['<!-- lint-frontend-bot -->', '<!-- lint-backend-bot -->', '<!-- rebase-bot -->'];
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner, repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+
+            // Clean up old individual comments from previous workflow versions
+            for (const old of oldMarkers) {
+              const c = comments.find(c => c.body.includes(old));
+              if (c) {
+                await github.rest.issues.deleteComment({
+                  owner: context.repo.owner, repo: context.repo.repo,
+                  comment_id: c.id,
+                });
+              }
+            }
+
+            // Build combined comment sections
+            const sections = [];
+
+            const eslintFailed = report.eslint === 'failure';
+            const prettierFailed = report.prettier === 'failure';
+            const typecheckFailed = report.typecheck === 'failure';
+            if (eslintFailed || prettierFailed || typecheckFailed) {
+              let s = '### Frontend\n\n';
+              if (eslintFailed) s += '- **ESLint:** Run `npx eslint --fix . --ext js,jsx,ts,tsx` in `dataloom-frontend/`\n';
+              if (prettierFailed) s += '- **Prettier:** Run `npx prettier --write "src/**/*.{js,jsx,ts,tsx,css,md}"` in `dataloom-frontend/`\n';
+              if (typecheckFailed) s += '- **TypeScript:** Run `npx tsc --noEmit` in `dataloom-frontend/` and fix the reported errors\n';
+              sections.push(s);
+            }
+
+            const ruffLintFailed = report.ruff_lint === 'failure';
+            const ruffFormatFailed = report.ruff_format === 'failure';
+            if (ruffLintFailed || ruffFormatFailed) {
+              let s = '### Backend\n\n';
+              if (ruffLintFailed) s += '- **Ruff lint:** Run `uv run ruff check --fix .` in `dataloom-backend/`\n';
+              if (ruffFormatFailed) s += '- **Ruff format:** Run `uv run ruff format .` in `dataloom-backend/`\n';
+              sections.push(s);
+            }
+
+            const behind = parseInt(report.behind_count || '0', 10) || 0;
+            // Commit subjects are author-controlled: strip fence characters and
+            // cap the volume before embedding them in the comment.
+            const mergeCommits = (report.merge_commits || '')
+              .trim()
+              .replace(/`/g, "'")
+              .split('\n')
+              .slice(0, 20)
+              .join('\n');
+            if (behind > 0 || mergeCommits) {
+              let s = '### Rebase\n\n';
+              if (behind > 0) s += `Your branch is **${behind} commit(s) behind \`main\`**. Please rebase.\n\n`;
+              if (mergeCommits) s += '**Merge commits detected** — please use rebase instead of merge:\n\n```\n' + mergeCommits + '\n```\n\n';
+              sections.push(s);
+            }
+
+            const prCommits = parseInt(report.pr_commits || '1', 10) || 1;
+            if (prCommits > 1) {
+              sections.push(`### Squash\n\nYour PR has **${prCommits} commits**. Please squash into a single commit.\n`);
+            }
+
+            const existing = comments.find(c => c.body.includes(marker));
+
+            if (sections.length === 0) {
+              if (existing) {
+                await github.rest.issues.deleteComment({
+                  owner: context.repo.owner, repo: context.repo.repo,
+                  comment_id: existing.id,
+                });
+              }
+              return;
+            }
+
+            let body = marker + '\n## PR Review\n\n';
+            body += sections.join('\n');
+
+            if (behind > 0 || mergeCommits || prCommits > 1) {
+              body += '\n### How to fix\n```bash\ngit fetch origin\ngit rebase -i origin/main   # mark all but first commit as "squash"\ngit push --force-with-lease\n```\n';
+            }
+
+            body += '\n---\n*This comment updates automatically on each push.*\n';
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                comment_id: existing.id, body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: prNumber, body,
+              });
+            }

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,7 @@
 name: Lint
 
 on:
-  pull_request_target:
+  pull_request:
     branches: [main]
   push:
     branches: [main]
@@ -9,15 +9,18 @@ on:
 concurrency:
   group: >-
     ci-${{
-      github.event_name == 'pull_request_target'
+      github.event_name == 'pull_request'
         && format('pr-{0}', github.event.pull_request.number)
         || github.ref
     }}
   cancel-in-progress: true
 
+# Fork code is checked out and executed here (npm ci lifecycle scripts, the
+# eslint config, uv build backends), so this workflow runs on `pull_request`
+# with a read-only token and no secrets. Commenting needs write access and
+# therefore lives in lint-comment.yml, which never checks out PR code.
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   frontend-lint:
@@ -32,9 +35,6 @@ jobs:
         working-directory: dataloom-frontend
     steps:
       - uses: actions/checkout@v4
-        with:
-          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ github.event.pull_request.head.sha || '' }}
       - uses: actions/setup-node@v4
         with:
           node-version: 24
@@ -72,9 +72,6 @@ jobs:
         working-directory: dataloom-backend
     steps:
       - uses: actions/checkout@v4
-        with:
-          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ github.event.pull_request.head.sha || '' }}
       - uses: astral-sh/setup-uv@v4
       - uses: actions/setup-python@v5
         with:
@@ -97,7 +94,7 @@ jobs:
 
   rebase-check:
     name: Rebase Check
-    if: github.event_name == 'pull_request_target'
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     outputs:
       behind_count: ${{ steps.rebase.outputs.behind_count }}
@@ -123,15 +120,18 @@ jobs:
           echo "EOF" >> "$GITHUB_OUTPUT"
           echo "behind_count=$BEHIND_COUNT" >> "$GITHUB_OUTPUT"
 
-  pr-comment:
-    name: PR Comment
+  report:
+    name: Report
     needs: [frontend-lint, backend-lint, rebase-check]
-    if: always() && github.event_name == 'pull_request_target'
+    if: always() && github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - name: Post or delete combined comment
-        uses: actions/github-script@v7
+      # Results are handed to lint-comment.yml as a data-only artifact. That
+      # workflow holds the write permission this one deliberately lacks.
+      - name: Write report
         env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_COMMITS: ${{ github.event.pull_request.commits }}
           ESLINT: ${{ needs.frontend-lint.outputs.eslint }}
           PRETTIER: ${{ needs.frontend-lint.outputs.prettier }}
           TYPECHECK: ${{ needs.frontend-lint.outputs.typecheck }}
@@ -139,95 +139,31 @@ jobs:
           RUFF_FORMAT: ${{ needs.backend-lint.outputs.ruff-format }}
           BEHIND_COUNT: ${{ needs.rebase-check.outputs.behind_count }}
           MERGE_COMMITS: ${{ needs.rebase-check.outputs.merge_commits }}
-          PR_COMMITS: ${{ github.event.pull_request.commits }}
+        run: |
+          jq -n \
+            --arg pr "$PR_NUMBER" \
+            --arg pr_commits "$PR_COMMITS" \
+            --arg eslint "$ESLINT" \
+            --arg prettier "$PRETTIER" \
+            --arg typecheck "$TYPECHECK" \
+            --arg ruff_lint "$RUFF_LINT" \
+            --arg ruff_format "$RUFF_FORMAT" \
+            --arg behind_count "$BEHIND_COUNT" \
+            --arg merge_commits "$MERGE_COMMITS" \
+            '{
+              pr: $pr,
+              pr_commits: $pr_commits,
+              eslint: $eslint,
+              prettier: $prettier,
+              typecheck: $typecheck,
+              ruff_lint: $ruff_lint,
+              ruff_format: $ruff_format,
+              behind_count: $behind_count,
+              merge_commits: $merge_commits
+            }' > report.json
+
+      - uses: actions/upload-artifact@v4
         with:
-          script: |
-            const marker = '<!-- ci-bot -->';
-            const oldMarkers = ['<!-- lint-frontend-bot -->', '<!-- lint-backend-bot -->', '<!-- rebase-bot -->'];
-            const prNumber = context.payload.pull_request.number;
-
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner, repo: context.repo.repo,
-              issue_number: prNumber,
-            });
-
-            // Clean up old individual comments from previous workflow version
-            for (const old of oldMarkers) {
-              const c = comments.find(c => c.body.includes(old));
-              if (c) {
-                await github.rest.issues.deleteComment({
-                  owner: context.repo.owner, repo: context.repo.repo,
-                  comment_id: c.id,
-                });
-              }
-            }
-
-            // Build combined comment sections
-            const sections = [];
-
-            const eslintFailed = process.env.ESLINT === 'failure';
-            const prettierFailed = process.env.PRETTIER === 'failure';
-            const typecheckFailed = process.env.TYPECHECK === 'failure';
-            if (eslintFailed || prettierFailed || typecheckFailed) {
-              let s = '### Frontend\n\n';
-              if (eslintFailed) s += '- **ESLint:** Run `npx eslint --fix . --ext js,jsx,ts,tsx` in `dataloom-frontend/`\n';
-              if (prettierFailed) s += '- **Prettier:** Run `npx prettier --write "src/**/*.{js,jsx,ts,tsx,css,md}"` in `dataloom-frontend/`\n';
-              if (typecheckFailed) s += '- **TypeScript:** Run `npx tsc --noEmit` in `dataloom-frontend/` and fix the reported errors\n';
-              sections.push(s);
-            }
-
-            const ruffLintFailed = process.env.RUFF_LINT === 'failure';
-            const ruffFormatFailed = process.env.RUFF_FORMAT === 'failure';
-            if (ruffLintFailed || ruffFormatFailed) {
-              let s = '### Backend\n\n';
-              if (ruffLintFailed) s += '- **Ruff lint:** Run `uv run ruff check --fix .` in `dataloom-backend/`\n';
-              if (ruffFormatFailed) s += '- **Ruff format:** Run `uv run ruff format .` in `dataloom-backend/`\n';
-              sections.push(s);
-            }
-
-            const behind = parseInt(process.env.BEHIND_COUNT || '0');
-            const mergeCommits = (process.env.MERGE_COMMITS || '').trim();
-            if (behind > 0 || mergeCommits) {
-              let s = '### Rebase\n\n';
-              if (behind > 0) s += `Your branch is **${behind} commit(s) behind \`main\`**. Please rebase.\n\n`;
-              if (mergeCommits) s += '**Merge commits detected** — please use rebase instead of merge:\n\n```\n' + mergeCommits + '\n```\n\n';
-              sections.push(s);
-            }
-
-            const prCommits = parseInt(process.env.PR_COMMITS || '1');
-            if (prCommits > 1) {
-              sections.push(`### Squash\n\nYour PR has **${prCommits} commits**. Please squash into a single commit.\n`);
-            }
-
-            const existing = comments.find(c => c.body.includes(marker));
-
-            if (sections.length === 0) {
-              if (existing) {
-                await github.rest.issues.deleteComment({
-                  owner: context.repo.owner, repo: context.repo.repo,
-                  comment_id: existing.id,
-                });
-              }
-              return;
-            }
-
-            let body = marker + '\n## PR Review\n\n';
-            body += sections.join('\n');
-
-            if (behind > 0 || mergeCommits || prCommits > 1) {
-              body += '\n### How to fix\n```bash\ngit fetch origin\ngit rebase -i origin/main   # mark all but first commit as "squash"\ngit push --force-with-lease\n```\n';
-            }
-
-            body += '\n---\n*This comment updates automatically on each push.*\n';
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner, repo: context.repo.repo,
-                comment_id: existing.id, body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner, repo: context.repo.repo,
-                issue_number: prNumber, body,
-              });
-            }
+          name: pr-lint-report
+          path: report.json
+          retention-days: 1


### PR DESCRIPTION
## Summary

`actions/checkout@v4` now refuses fork checkouts under `pull_request_target`, which blocks the `Lint / Frontend Lint` and `Lint / Backend Lint` required checks on **every fork PR**.

My first attempt at this fix set `allow-unsafe-pr-checkout: true`. That was the wrong call and I've replaced it — details below.

## Why overriding the guard was unsafe

The lint jobs don't only run read-only tools. They execute PR-authored code:

- `npm ci` runs `postinstall` / `prepare` lifecycle scripts from the PR's `package.json` and lockfile
- `npx eslint` loads `eslint.config.js` **from the PR** — contributor-authored JS executed in-process
- `uv sync --frozen` can invoke build backends declared in the PR's `pyproject.toml`

Under `pull_request_target` that code ran with `permissions: pull-requests: write` and default-branch cache scope. That is exactly the "pwn request" pattern the checkout guard exists to prevent, so the guard was right and my override would have re-opened the hole.

## The change

Split the pipeline along the trust boundary instead:

- **`lint.yml`** → `pull_request` trigger, `permissions: contents: read`. Fork code still runs, but with a read-only token and no secrets — the same model `ci.yml` and `e2e.yml` already use in this repo. Results are published as a data-only `report.json` artifact.
- **`lint-comment.yml`** (new) → `workflow_run` trigger. Holds the `pull-requests: write` that `lint.yml` gave up, and never checks out PR code. The comment logic is a faithful port: same `<!-- ci-bot -->` marker, same legacy-marker cleanup, same update-in-place and delete-when-clean behaviour.

Two hardenings beyond a straight port, since the artifact originates from a run that executed fork code:

- verifies the reported PR head SHA matches the triggering run's head SHA, so a forged `report.json` cannot make the bot comment on an unrelated PR
- strips backticks and caps the merge-commit list at 20 lines before embedding author-controlled commit subjects in the comment

Workflow name and both job names are unchanged.

## Verification

The new `pull_request` lint ran green on this PR — which is itself a fork PR, so it exercises the exact path that was broken:

- Frontend Lint ✅ · Backend Lint ✅ · Rebase Check ✅ · Report ✅
- https://github.com/c2siorg/dataloom/actions/runs/29833169069

To be upfront about coverage: **`lint-comment.yml` has not executed and cannot until it is on `main`**, because `workflow_run` always loads its workflow file from the default branch. I've tested its logic locally (clean/failure/rebase/squash paths, comment update vs. duplicate, forged-PR-number rejection, markdown-fence sanitisation), but it is unproven in live CI until merge.

## What this needs from a maintainer

1. **This PR requires an admin merge.** The `Lint / ... (pull_request_target)` checks here are produced by the current `main` workflow — the one this PR removes — so they cannot pass on this PR by construction.
2. **Branch protection needs updating at merge time.** Once this lands, `pull_request_target` lint checks will never be produced again. If they remain in the required-contexts list, every future PR will block permanently. The replacements are the `pull_request`-triggered `Frontend Lint` / `Backend Lint`.

Happy to adjust the approach if you'd prefer a different split.

Closes #454
