### PR TITLE
feat: add paginated preview support for transformations

### DIFF
--- a/dataloom-backend/app/api/endpoints/transformations.py
+++ b/dataloom-backend/app/api/endpoints/transformations.py
@@ -3,6 +3,7 @@
 All transformations are handled through a single unified /transform endpoint.
 """
 
+import math
 import re
 import uuid
 
@@ -105,6 +106,8 @@ async def transform_project(
     project_id: uuid.UUID,
     transformation_input: schemas.TransformationInput,
     preview: bool = Query(False, description="If true, return transformation data without saving."),
+    page: int = Query(1, ge=1, description="Preview page number."),
+    page_size: int = Query(50, ge=1, le=100, description="Rows per preview page."),
     db: Session = Depends(database.get_db),
     project: models.Project = Depends(get_project_or_404),
 ):
@@ -145,11 +148,32 @@ async def transform_project(
                     )
                 raise
 
-        resp = dataframe_to_response(result_df)
+        response_df = result_df
+        pagination = {}
+
+        if preview:
+            total_rows = len(result_df)
+            total_pages = max(1, math.ceil(total_rows / page_size))
+            effective_page = min(page, total_pages)
+
+            start = (effective_page - 1) * page_size
+            end = start + page_size
+            response_df = result_df.iloc[start:end]
+
+            pagination = {
+                "total_rows": total_rows,
+                "total_pages": total_pages,
+                "page": effective_page,
+                "page_size": page_size,
+            }
+
+        resp = dataframe_to_response(response_df)
+
         return {
             "project_id": project_id,
             "operation_type": operation_type,
             **resp,
+            **pagination,
         }
     except HTTPException as e:
         safe_detail = _safe_http_exception_detail(e)

--- a/dataloom-backend/app/schemas.py
+++ b/dataloom-backend/app/schemas.py
@@ -343,7 +343,11 @@ class BasicQueryResponse(BaseModel):
     row_count: int
     columns: list[str]
     rows: list[list]
-    dtypes: dict[str, str] = {}
+    dtypes: dict[str, str] = Field(default_factory=dict)
+    total_rows: int | None = None
+    total_pages: int | None = None
+    page: int | None = None
+    page_size: int | None = None
 
 
 class ProjectResponse(BaseModel):

--- a/dataloom-frontend/src/Components/Table.tsx
+++ b/dataloom-frontend/src/Components/Table.tsx
@@ -65,12 +65,28 @@ interface ProjectContextValue {
   totalPages: number;
   page: number;
   pageSize: number;
+  isPreviewMode: boolean;
+  pendingTransform: {
+    projectId: string;
+    payload: Record<string, unknown>;
+  } | null;
   setPaginationData: (info: {
     page?: number;
     page_size?: number;
     total_rows?: number;
     total_pages?: number;
   }) => void;
+  updatePreviewPage: (
+    columns: string[],
+    rows: Cell[][],
+    dtypes: Record<string, string> | undefined,
+    paginationInfo: {
+      total_rows?: number;
+      total_pages?: number;
+      page?: number;
+      page_size?: number;
+    },
+  ) => void;
   refreshProject: (id: string, page: number, pageSize: number) => void;
 }
 
@@ -115,7 +131,10 @@ const Table = ({ projectId, showColumnProfiles = false }: TableProps) => {
     totalPages,
     page,
     pageSize,
+    isPreviewMode,
+    pendingTransform,
     setPaginationData,
+    updatePreviewPage,
     refreshProject,
   } = useProjectContext() as unknown as ProjectContextValue;
   const { refreshLogs } = useHistoryRefresh();
@@ -366,6 +385,8 @@ const Table = ({ projectId, showColumnProfiles = false }: TableProps) => {
   };
 
   const handleCellClick = (rowIndex: number, cellIndex: number, cellValue: Cell) => {
+    if (isPreviewMode) return;
+
     if (cellIndex !== 0) {
       setEditingCell({ rowIndex, cellIndex });
       // Coerce null/undefined (missing cells now serialize to null) to "" so the
@@ -374,12 +395,54 @@ const Table = ({ projectId, showColumnProfiles = false }: TableProps) => {
     }
   };
 
-  const handlePageChange = (newPage: number) => {
+  const fetchPreviewPage = async (targetPage: number, targetPageSize: number) => {
+    if (!pendingTransform) return;
+
+    try {
+      const response = (await transformProject(
+        pendingTransform.projectId,
+        pendingTransform.payload,
+        {
+          preview: true,
+          page: targetPage,
+          pageSize: targetPageSize,
+        },
+      )) as unknown as TransformResponse & {
+        total_rows: number;
+        total_pages: number;
+        page: number;
+        page_size: number;
+      };
+
+      updatePreviewPage(response.columns, normalizeRows(response.rows), response.dtypes, {
+        total_rows: response.total_rows,
+        total_pages: response.total_pages,
+        page: response.page,
+        page_size: response.page_size,
+      });
+    } catch {
+      setToast({
+        message: "Failed to load preview page. Please try again.",
+        type: "error",
+      });
+    }
+  };
+
+  const handlePageChange = async (newPage: number) => {
+    if (isPreviewMode) {
+      await fetchPreviewPage(newPage, pageSize);
+      return;
+    }
+
     setPaginationData({ page: newPage });
     refreshProject(projectId, newPage, pageSize);
   };
+  const handlePageSizeChange = async (newSize: number) => {
+    if (isPreviewMode) {
+      await fetchPreviewPage(1, newSize);
+      return;
+    }
 
-  const handlePageSizeChange = (newSize: number) => {
     setPaginationData({ page: 1, page_size: newSize });
     refreshProject(projectId, 1, newSize);
   };
@@ -428,7 +491,11 @@ const Table = ({ projectId, showColumnProfiles = false }: TableProps) => {
                       className={`h-6 px-0.5 py-0 border-r border-app-border text-left text-xs font-medium text-muted-foreground uppercase tracking-wider ${
                         isDropTarget ? "ring-2 ring-blue-400" : ""
                       } ${isSerialNumber ? "w-16 sticky left-0 z-10 bg-surface" : "bg-surface"}`}
-                      onContextMenu={(e) => open(e, { type: "column", columnIndex })}
+                      onContextMenu={(e) => {
+                        if (!isPreviewMode) {
+                          open(e, { type: "column", columnIndex });
+                        }
+                      }}
                     >
                       <button
                         type="button"
@@ -512,7 +579,11 @@ const Table = ({ projectId, showColumnProfiles = false }: TableProps) => {
                           ? "w-16 sticky left-0 z-10 bg-surface text-center font-medium text-muted-foreground"
                           : "text-foreground"
                       }`}
-                      onContextMenu={(e) => open(e, { type: "row", rowIndex })}
+                      onContextMenu={(e) => {
+                        if (!isPreviewMode) {
+                          open(e, { type: "row", rowIndex });
+                        }
+                      }}
                     >
                       {editingCell &&
                       editingCell.rowIndex === rowIndex &&

--- a/dataloom-frontend/src/Components/Table.tsx
+++ b/dataloom-frontend/src/Components/Table.tsx
@@ -1,6 +1,14 @@
 import ContextMenu from "./ContextMenu";
 import { useContextMenu } from "../hooks/useContextMenu";
-import { useState, useEffect, useMemo, useRef, type ReactNode, type KeyboardEvent } from "react";
+import {
+  useState,
+  useEffect,
+  useMemo,
+  useRef,
+  type ReactNode,
+  type KeyboardEvent,
+  useCallback,
+} from "react";
 import { ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight } from "lucide-react";
 import { transformProject } from "../api";
 import { useProjectContext } from "../context/ProjectContext";
@@ -149,6 +157,9 @@ const Table = ({ projectId, showColumnProfiles = false }: TableProps) => {
 
   const [draggedColIndex, setDraggedColIndex] = useState<number | null>(null);
   const [hoveredTargetIndex, setHoveredTargetIndex] = useState<number | null>(null);
+
+  const [previewLoading, setPreviewLoading] = useState(false);
+  const previewRequestIdRef = useRef(0);
 
   // Per-column profiles for the "Columns" toggle. dataVersion is the change
   // signal (bumped on any content edit), so cached profiles refresh after a
@@ -395,41 +406,65 @@ const Table = ({ projectId, showColumnProfiles = false }: TableProps) => {
     }
   };
 
-  const fetchPreviewPage = async (targetPage: number, targetPageSize: number) => {
-    if (!pendingTransform) return;
+  const fetchPreviewPage = useCallback(
+    async (targetPage: number, targetPageSize: number) => {
+      if (!pendingTransform) return;
 
-    try {
-      const response = (await transformProject(
-        pendingTransform.projectId,
-        pendingTransform.payload,
-        {
-          preview: true,
-          page: targetPage,
-          pageSize: targetPageSize,
-        },
-      )) as unknown as TransformResponse & {
-        total_rows: number;
-        total_pages: number;
-        page: number;
-        page_size: number;
-      };
+      const requestId = ++previewRequestIdRef.current;
 
-      updatePreviewPage(response.columns, normalizeRows(response.rows), response.dtypes, {
-        total_rows: response.total_rows,
-        total_pages: response.total_pages,
-        page: response.page,
-        page_size: response.page_size,
-      });
-    } catch {
-      setToast({
-        message: "Failed to load preview page. Please try again.",
-        type: "error",
-      });
-    }
-  };
+      setPreviewLoading(true);
+
+      try {
+        const response = (await transformProject(
+          pendingTransform.projectId,
+          pendingTransform.payload,
+          {
+            preview: true,
+            page: targetPage,
+            pageSize: targetPageSize,
+          },
+        )) as unknown as TransformResponse & {
+          total_rows: number;
+          total_pages: number;
+          page: number;
+          page_size: number;
+        };
+
+        // Ignore stale responses from older requests.
+        if (requestId !== previewRequestIdRef.current) {
+          return;
+        }
+
+        updatePreviewPage(response.columns, normalizeRows(response.rows), response.dtypes, {
+          total_rows: response.total_rows,
+          total_pages: response.total_pages,
+          page: response.page,
+          page_size: response.page_size,
+        });
+      } catch {
+        // Ignore errors from stale requests.
+        if (requestId !== previewRequestIdRef.current) {
+          return;
+        }
+
+        setToast({
+          message: "Failed to load preview page. Please try again.",
+          type: "error",
+        });
+      } finally {
+        // Only the latest request controls the loading state.
+        if (requestId === previewRequestIdRef.current) {
+          setPreviewLoading(false);
+        }
+      }
+    },
+    [pendingTransform, updatePreviewPage],
+  );
 
   const handlePageChange = async (newPage: number) => {
     if (isPreviewMode) {
+      if (previewLoading) return;
+
       await fetchPreviewPage(newPage, pageSize);
       return;
     }
@@ -437,8 +472,11 @@ const Table = ({ projectId, showColumnProfiles = false }: TableProps) => {
     setPaginationData({ page: newPage });
     refreshProject(projectId, newPage, pageSize);
   };
+
   const handlePageSizeChange = async (newSize: number) => {
     if (isPreviewMode) {
+      if (previewLoading) return;
+
       await fetchPreviewPage(1, newSize);
       return;
     }
@@ -625,6 +663,7 @@ const Table = ({ projectId, showColumnProfiles = false }: TableProps) => {
           pageSize={pageSize}
           onPageChange={handlePageChange}
           onPageSizeChange={handlePageSizeChange}
+          isLoading={isPreviewMode && previewLoading}
         />
       </div>
 
@@ -693,6 +732,7 @@ interface TablePaginationProps {
   pageSize: number;
   onPageChange: (page: number) => void;
   onPageSizeChange: (size: number) => void;
+  isLoading?: boolean;
 }
 
 export function TablePagination({
@@ -702,6 +742,7 @@ export function TablePagination({
   pageSize,
   onPageChange,
   onPageSizeChange,
+  isLoading = false,
 }: TablePaginationProps) {
   const [pageSizeOpen, setPageSizeOpen] = useState(false);
   const [pageInput, setPageInput] = useState(String(page));
@@ -716,19 +757,34 @@ export function TablePagination({
   }
 
   const handleFirst = () => {
-    if (page !== 1) onPageChange(1);
+    if (page !== 1) {
+      onPageChange(1);
+    }
   };
+
   const handlePrevious = () => {
-    if (page > 1) onPageChange(page - 1);
+    if (page > 1) {
+      onPageChange(page - 1);
+    }
   };
+
   const handleNext = () => {
-    if (page < totalPages) onPageChange(page + 1);
+    if (page < totalPages) {
+      onPageChange(page + 1);
+    }
   };
+
   const handleLast = () => {
-    if (page !== totalPages) onPageChange(totalPages);
+    if (page !== totalPages) {
+      onPageChange(totalPages);
+    }
   };
 
   const commitPageInput = () => {
+    if (isLoading) {
+      return;
+    }
+
     const input = pageInputRef.current;
     if (input && !input.reportValidity()) {
       showToast("Invalid page number", "error");
@@ -762,6 +818,7 @@ export function TablePagination({
           <div className="relative inline-block">
             <button
               onClick={() => setPageSizeOpen(!pageSizeOpen)}
+              disabled={isLoading}
               className="min-w-8.5 rounded border border-app-border px-2 py-0.5 text-center focus:outline-none focus:ring-1 focus:ring-blue-500"
             >
               {pageSize}
@@ -772,10 +829,16 @@ export function TablePagination({
                   <div
                     key={size}
                     onClick={() => {
+                      if (isLoading) return;
+
                       onPageSizeChange(size);
                       setPageSizeOpen(false);
                     }}
-                    className="cursor-pointer rounded px-3 py-1 hover:bg-surface-hover hover:text-blue-700"
+                    className={`rounded px-3 py-1 ${
+                      isLoading
+                        ? "cursor-not-allowed opacity-40"
+                        : "cursor-pointer hover:bg-surface-hover hover:text-blue-700"
+                    }`}
                   >
                     {size}
                   </div>
@@ -790,7 +853,7 @@ export function TablePagination({
       <div className="flex flex-wrap items-center justify-end gap-1.5">
         <button
           onClick={handleFirst}
-          disabled={page === 1}
+          disabled={page === 1 || isLoading}
           className="rounded border border-app-border p-1 transition-colors hover:bg-surface-hover focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-40"
           aria-label="First page"
         >
@@ -798,7 +861,7 @@ export function TablePagination({
         </button>
         <button
           onClick={handlePrevious}
-          disabled={page === 1}
+          disabled={page === 1 || isLoading}
           className="rounded border border-app-border p-1 transition-colors hover:bg-surface-hover focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-40"
           aria-label="Previous page"
         >
@@ -815,11 +878,12 @@ export function TablePagination({
             max={totalPages}
             step={1}
             value={pageInput}
+            disabled={isLoading}
             onChange={(e) => setPageInput(e.target.value)}
             onKeyDown={handlePageInputKeyDown}
             onBlur={commitPageInput}
             title={`Enter a page between 1 and ${totalPages}`}
-            className="h-6 w-11 rounded border border-app-border px-1 text-center text-foreground focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+            className="h-6 w-11 rounded border border-app-border px-1 text-center text-foreground focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-40 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
             aria-label="Current page"
           />
           <span className="text-muted-foreground">of {totalPages}</span>
@@ -827,7 +891,7 @@ export function TablePagination({
 
         <button
           onClick={handleNext}
-          disabled={page === totalPages}
+          disabled={page === totalPages || isLoading}
           className="rounded border border-app-border p-1 transition-colors hover:bg-surface-hover focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-40"
           aria-label="Next page"
         >
@@ -835,7 +899,7 @@ export function TablePagination({
         </button>
         <button
           onClick={handleLast}
-          disabled={page === totalPages}
+          disabled={page === totalPages || isLoading}
           className="rounded border border-app-border p-1 transition-colors hover:bg-surface-hover focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-40"
           aria-label="Last page"
         >

--- a/dataloom-frontend/src/Components/forms/AdvQueryFilterForm.tsx
+++ b/dataloom-frontend/src/Components/forms/AdvQueryFilterForm.tsx
@@ -11,7 +11,7 @@ const AdvQueryFilterForm = ({ projectId, onClose }: { projectId: string; onClose
   const [query, setQuery] = useState("");
   const [loading, setLoading] = useState(false);
   const { error, clearError, handleError } = useError();
-  const { isPreviewMode, enterPreviewMode, cancelPreview } = useProjectContext();
+  const { pageSize, isPreviewMode, enterPreviewMode, cancelPreview } = useProjectContext();
   const { saving, handleSave } = usePreviewSave({
     clearError,
     handleError,
@@ -27,8 +27,23 @@ const AdvQueryFilterForm = ({ projectId, onClose }: { projectId: string; onClose
         operation_type: ADV_QUERY_FILTER,
         adv_query: { query },
       };
-      const response = await transformProject(projectId, payload, { preview: true });
-      enterPreviewMode(response.columns, response.rows, response.dtypes, { projectId, payload });
+      const response = await transformProject(projectId, payload, {
+        preview: true,
+        page: 1,
+        pageSize,
+      });
+      enterPreviewMode(
+        response.columns,
+        response.rows,
+        response.dtypes,
+        { projectId, payload },
+        {
+          total_rows: response.total_rows,
+          total_pages: response.total_pages,
+          page: response.page,
+          page_size: response.page_size,
+        },
+      );
     } catch (err) {
       console.error("Error applying query:", (err as Error).message);
       handleError(err);

--- a/dataloom-frontend/src/Components/forms/CastDataTypeForm.tsx
+++ b/dataloom-frontend/src/Components/forms/CastDataTypeForm.tsx
@@ -24,7 +24,7 @@ const CastDataTypeForm = ({ projectId, onClose }: { projectId: string; onClose: 
   const [column, setColumn] = useState("");
   const [targetType, setTargetType] = useState("string");
   const { error, setError, clearError, handleError } = useError();
-  const { isPreviewMode, enterPreviewMode, cancelPreview } = useProjectContext();
+  const { pageSize, isPreviewMode, enterPreviewMode, cancelPreview } = useProjectContext();
   const [loading, setLoading] = useState(false);
   const { saving, handleSave } = usePreviewSave({
     clearError,
@@ -52,12 +52,22 @@ const CastDataTypeForm = ({ projectId, onClose }: { projectId: string; onClose: 
       };
       const response = await transformProject(projectId, payload, {
         preview: true,
+        page: 1,
+        pageSize,
       });
 
-      enterPreviewMode(response.columns, response.rows, response.dtypes, {
-        projectId,
-        payload,
-      });
+      enterPreviewMode(
+        response.columns,
+        response.rows,
+        response.dtypes,
+        { projectId, payload },
+        {
+          total_rows: response.total_rows,
+          total_pages: response.total_pages,
+          page: response.page,
+          page_size: response.page_size,
+        },
+      );
     } catch (err) {
       console.error("Error casting data type:", err);
       showToast(

--- a/dataloom-frontend/src/Components/forms/DropDuplicateForm.tsx
+++ b/dataloom-frontend/src/Components/forms/DropDuplicateForm.tsx
@@ -18,7 +18,7 @@ const DropDuplicateForm = ({ projectId, onClose }: { projectId: string; onClose:
   const [columns, setColumns] = useState<string[]>([]);
   const [keep, setKeep] = useState("first");
   const { error, setError, clearError, handleError } = useError();
-  const { isPreviewMode, enterPreviewMode, cancelPreview } = useProjectContext();
+  const { pageSize, isPreviewMode, enterPreviewMode, cancelPreview } = useProjectContext();
   const { saving, handleSave } = usePreviewSave({
     clearError,
     handleError,
@@ -34,7 +34,7 @@ const DropDuplicateForm = ({ projectId, onClose }: { projectId: string; onClose:
       return;
     }
 
-    const transformationInput = {
+    const payload = {
       operation_type: DROP_DUPLICATE,
       drop_duplicate: {
         columns: columns.join(","),
@@ -43,11 +43,24 @@ const DropDuplicateForm = ({ projectId, onClose }: { projectId: string; onClose:
     };
 
     try {
-      const response = await transformProject(projectId, transformationInput, { preview: true });
-      enterPreviewMode(response.columns, response.rows, response.dtypes, {
-        projectId,
-        payload: transformationInput,
+      const response = await transformProject(projectId, payload, {
+        preview: true,
+        page: 1,
+        pageSize,
       });
+
+      enterPreviewMode(
+        response.columns,
+        response.rows,
+        response.dtypes,
+        { projectId, payload },
+        {
+          total_rows: response.total_rows,
+          total_pages: response.total_pages,
+          page: response.page,
+          page_size: response.page_size,
+        },
+      );
     } catch (err) {
       console.error("Error transforming project:", err);
       handleError(err);

--- a/dataloom-frontend/src/Components/forms/FillEmptyForm.tsx
+++ b/dataloom-frontend/src/Components/forms/FillEmptyForm.tsx
@@ -19,7 +19,7 @@ const STRATEGIES = [
 ];
 
 const FillEmptyForm = ({ projectId, onClose }: { projectId: string; onClose: () => void }) => {
-  const { columns, isPreviewMode, enterPreviewMode, cancelPreview } = useProjectContext();
+  const { columns, pageSize, isPreviewMode, enterPreviewMode, cancelPreview } = useProjectContext();
   const { showToast } = useToast();
   const { error, clearError, handleError } = useError();
   const [loading, setLoading] = useState(false);
@@ -53,8 +53,23 @@ const FillEmptyForm = ({ projectId, onClose }: { projectId: string; onClose: () 
           fill_value: strategy === "custom" ? fillValue : null,
         },
       };
-      const response = await transformProject(projectId, payload, { preview: true });
-      enterPreviewMode(response.columns, response.rows, response.dtypes, { projectId, payload });
+      const response = await transformProject(projectId, payload, {
+        preview: true,
+        page: 1,
+        pageSize,
+      });
+      enterPreviewMode(
+        response.columns,
+        response.rows,
+        response.dtypes,
+        { projectId, payload },
+        {
+          total_rows: response.total_rows,
+          total_pages: response.total_pages,
+          page: response.page,
+          page_size: response.page_size,
+        },
+      );
     } catch (err) {
       handleError(err);
       showToast(

--- a/dataloom-frontend/src/Components/forms/FilterForm.tsx
+++ b/dataloom-frontend/src/Components/forms/FilterForm.tsx
@@ -27,7 +27,7 @@ const FilterForm = ({ projectId, onClose }: { projectId: string; onClose: () => 
   });
   const [loading, setLoading] = useState(false);
   const { error, setError, clearError, handleError } = useError();
-  const { isPreviewMode, enterPreviewMode, cancelPreview } = useProjectContext();
+  const { pageSize, isPreviewMode, enterPreviewMode, cancelPreview } = useProjectContext();
   const { saving, handleSave } = usePreviewSave({
     clearError,
     handleError,
@@ -58,11 +58,21 @@ const FilterForm = ({ projectId, onClose }: { projectId: string; onClose: () => 
       };
       const response = await transformProject(projectId, payload, {
         preview: true,
+        page: 1,
+        pageSize,
       });
-      enterPreviewMode(response.columns, response.rows, response.dtypes, {
-        projectId,
-        payload,
-      });
+      enterPreviewMode(
+        response.columns,
+        response.rows,
+        response.dtypes,
+        { projectId, payload },
+        {
+          total_rows: response.total_rows,
+          total_pages: response.total_pages,
+          page: response.page,
+          page_size: response.page_size,
+        },
+      );
     } catch (err) {
       const e = err as { response?: { data?: unknown }; message?: string };
       console.error("Error applying filter:", e.response?.data || e.message);

--- a/dataloom-frontend/src/Components/forms/GroupByForm.tsx
+++ b/dataloom-frontend/src/Components/forms/GroupByForm.tsx
@@ -14,6 +14,7 @@ import { AGG_FUNCTIONS } from "../../constants/aggregations";
 const GroupByForm = ({ projectId, onClose }: { projectId: string; onClose: () => void }) => {
   const {
     columns: availableColumns,
+    pageSize,
     isPreviewMode,
     enterPreviewMode,
     cancelPreview,
@@ -55,9 +56,24 @@ const GroupByForm = ({ projectId, onClose }: { projectId: string; onClose: () =>
           agg_function: aggFunction,
         },
       };
-      const response = await transformProject(projectId, payload, { preview: true });
+      const response = await transformProject(projectId, payload, {
+        preview: true,
+        page: 1,
+        pageSize,
+      });
       if (cancelledRef.current) return;
-      enterPreviewMode(response.columns, response.rows, response.dtypes, { projectId, payload });
+      enterPreviewMode(
+        response.columns,
+        response.rows,
+        response.dtypes,
+        { projectId, payload },
+        {
+          total_rows: response.total_rows,
+          total_pages: response.total_pages,
+          page: response.page,
+          page_size: response.page_size,
+        },
+      );
     } catch (err) {
       handleError(err);
     } finally {

--- a/dataloom-frontend/src/Components/forms/MeltForm.tsx
+++ b/dataloom-frontend/src/Components/forms/MeltForm.tsx
@@ -13,7 +13,7 @@ const MeltForm = ({ projectId, onClose }: { projectId: string; onClose: () => vo
   const [valueName, setValueName] = useState("value");
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
-  const { isPreviewMode, enterPreviewMode, cancelPreview } = useProjectContext();
+  const { pageSize, isPreviewMode, enterPreviewMode, cancelPreview } = useProjectContext();
   const { saving, handleSave } = usePreviewSave({
     clearError: () => setError(null),
     handleError: (err: { response?: { data?: { detail?: string } }; message?: string }) =>
@@ -77,8 +77,23 @@ const MeltForm = ({ projectId, onClose }: { projectId: string; onClose: () => vo
           value_name: finalValueName,
         },
       };
-      const response = await transformProject(projectId, payload, { preview: true });
-      enterPreviewMode(response.columns, response.rows, response.dtypes, { projectId, payload });
+      const response = await transformProject(projectId, payload, {
+        preview: true,
+        page: 1,
+        pageSize,
+      });
+      enterPreviewMode(
+        response.columns,
+        response.rows,
+        response.dtypes,
+        { projectId, payload },
+        {
+          total_rows: response.total_rows,
+          total_pages: response.total_pages,
+          page: response.page,
+          page_size: response.page_size,
+        },
+      );
     } catch (err) {
       const e = err as { response?: { data?: { detail?: string } }; message?: string };
       setError(e.response?.data?.detail || e.message || null);

--- a/dataloom-frontend/src/Components/forms/PivotTableForm.tsx
+++ b/dataloom-frontend/src/Components/forms/PivotTableForm.tsx
@@ -18,7 +18,7 @@ const PivotTableForm = ({ projectId, onClose }: { projectId: string; onClose: ()
   const [aggfun, setAggfun] = useState("sum");
   const [loading, setLoading] = useState(false);
   const { error, setError, clearError, handleError } = useError();
-  const { isPreviewMode, enterPreviewMode, cancelPreview } = useProjectContext();
+  const { pageSize, isPreviewMode, enterPreviewMode, cancelPreview } = useProjectContext();
   const { saving, handleSave } = usePreviewSave({ clearError, handleError, onClose });
 
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
@@ -41,8 +41,23 @@ const PivotTableForm = ({ projectId, onClose }: { projectId: string; onClose: ()
         operation_type: PIVOT_TABLES,
         pivot_query: { index: index.join(","), column, value, aggfun },
       };
-      const response = await transformProject(projectId, payload, { preview: true });
-      enterPreviewMode(response.columns, response.rows, response.dtypes, { projectId, payload });
+      const response = await transformProject(projectId, payload, {
+        preview: true,
+        page: 1,
+        pageSize,
+      });
+      enterPreviewMode(
+        response.columns,
+        response.rows,
+        response.dtypes,
+        { projectId, payload },
+        {
+          total_rows: response.total_rows,
+          total_pages: response.total_pages,
+          page: response.page,
+          page_size: response.page_size,
+        },
+      );
     } catch (err) {
       console.error("Error applying pivot table:", (err as Error).message);
       handleError(err);

--- a/dataloom-frontend/src/Components/forms/SampleRowsForm.tsx
+++ b/dataloom-frontend/src/Components/forms/SampleRowsForm.tsx
@@ -8,7 +8,7 @@ import { useProjectContext } from "../../context/ProjectContext";
 import Button from "../common/Button";
 
 const SampleRowsForm = ({ projectId, onClose }: { projectId: string; onClose: () => void }) => {
-  const { isPreviewMode, enterPreviewMode, cancelPreview } = useProjectContext();
+  const { pageSize, isPreviewMode, enterPreviewMode, cancelPreview } = useProjectContext();
   const [sampleSize, setSampleSize] = useState("");
   const [randomSeed, setRandomSeed] = useState("");
   const [loading, setLoading] = useState(false);
@@ -54,8 +54,23 @@ const SampleRowsForm = ({ projectId, onClose }: { projectId: string; onClose: ()
         operation_type: SAMPLE_ROWS,
         sample_params: params,
       };
-      const response = await transformProject(projectId, payload, { preview: true });
-      enterPreviewMode(response.columns, response.rows, response.dtypes, { projectId, payload });
+      const response = await transformProject(projectId, payload, {
+        preview: true,
+        page: 1,
+        pageSize,
+      });
+      enterPreviewMode(
+        response.columns,
+        response.rows,
+        response.dtypes,
+        { projectId, payload },
+        {
+          total_rows: response.total_rows,
+          total_pages: response.total_pages,
+          page: response.page,
+          page_size: response.page_size,
+        },
+      );
     } catch (err) {
       handleError(err);
     } finally {

--- a/dataloom-frontend/src/Components/forms/SortForm.tsx
+++ b/dataloom-frontend/src/Components/forms/SortForm.tsx
@@ -25,7 +25,7 @@ interface SortCriterion {
  * Allows users to add, remove, and reorder multiple sort criteria.
  */
 const SortForm = ({ projectId, onClose }: { projectId: string; onClose: () => void }) => {
-  const { isPreviewMode, enterPreviewMode, cancelPreview } = useProjectContext();
+  const { pageSize, isPreviewMode, enterPreviewMode, cancelPreview } = useProjectContext();
   const [criteria, setCriteria] = useState<SortCriterion[]>([
     { id: 1, column: "", ascending: true },
   ]);
@@ -110,8 +110,23 @@ const SortForm = ({ projectId, onClose }: { projectId: string; onClose: () => vo
           criteria: criteriaList,
         },
       };
-      const response = await transformProject(projectId, payload, { preview: true });
-      enterPreviewMode(response.columns, response.rows, response.dtypes, { projectId, payload });
+      const response = await transformProject(projectId, payload, {
+        preview: true,
+        page: 1,
+        pageSize,
+      });
+      enterPreviewMode(
+        response.columns,
+        response.rows,
+        response.dtypes,
+        { projectId, payload },
+        {
+          total_rows: response.total_rows,
+          total_pages: response.total_pages,
+          page: response.page,
+          page_size: response.page_size,
+        },
+      );
     } catch (err) {
       handleError(err);
     } finally {

--- a/dataloom-frontend/src/Components/forms/StringReplaceForm.tsx
+++ b/dataloom-frontend/src/Components/forms/StringReplaceForm.tsx
@@ -9,7 +9,7 @@ import ColumnSelect from "../common/ColumnSelect";
 import Button from "../common/Button";
 
 const StringReplaceForm = ({ projectId, onClose }: { projectId: string; onClose: () => void }) => {
-  const { isPreviewMode, enterPreviewMode, cancelPreview } = useProjectContext();
+  const { pageSize, isPreviewMode, enterPreviewMode, cancelPreview } = useProjectContext();
 
   const [column, setColumn] = useState("");
   const [findValue, setFindValue] = useState("");
@@ -38,8 +38,23 @@ const StringReplaceForm = ({ projectId, onClose }: { projectId: string; onClose:
           replace_value: replaceValue,
         },
       };
-      const response = await transformProject(projectId, payload, { preview: true });
-      enterPreviewMode(response.columns, response.rows, response.dtypes, { projectId, payload });
+      const response = await transformProject(projectId, payload, {
+        preview: true,
+        page: 1,
+        pageSize,
+      });
+      enterPreviewMode(
+        response.columns,
+        response.rows,
+        response.dtypes,
+        { projectId, payload },
+        {
+          total_rows: response.total_rows,
+          total_pages: response.total_pages,
+          page: response.page,
+          page_size: response.page_size,
+        },
+      );
     } catch (error) {
       handleError(error);
     } finally {

--- a/dataloom-frontend/src/Components/forms/TrimWhitespaceForm.tsx
+++ b/dataloom-frontend/src/Components/forms/TrimWhitespaceForm.tsx
@@ -8,7 +8,7 @@ import FormErrorAlert from "../common/FormErrorAlert";
 import ColumnSelect from "../common/ColumnSelect";
 import Button from "../common/Button";
 const TrimWhitespaceForm = ({ projectId, onClose }: { projectId: string; onClose: () => void }) => {
-  const { columns, isPreviewMode, enterPreviewMode, cancelPreview } = useProjectContext();
+  const { columns, pageSize, isPreviewMode, enterPreviewMode, cancelPreview } = useProjectContext();
 
   const [column, setColumn] = useState("");
   const [loading, setLoading] = useState(false);
@@ -34,8 +34,23 @@ const TrimWhitespaceForm = ({ projectId, onClose }: { projectId: string; onClose
           column,
         },
       };
-      const response = await transformProject(projectId, payload, { preview: true });
-      enterPreviewMode(response.columns, response.rows, response.dtypes, { projectId, payload });
+      const response = await transformProject(projectId, payload, {
+        preview: true,
+        page: 1,
+        pageSize,
+      });
+      enterPreviewMode(
+        response.columns,
+        response.rows,
+        response.dtypes,
+        { projectId, payload },
+        {
+          total_rows: response.total_rows,
+          total_pages: response.total_pages,
+          page: response.page,
+          page_size: response.page_size,
+        },
+      );
     } catch (error) {
       handleError(error);
     } finally {

--- a/dataloom-frontend/src/api/transforms.js
+++ b/dataloom-frontend/src/api/transforms.js
@@ -6,28 +6,42 @@ import client from "./client";
 
 /**
  * @typedef {Object} TransformResult
- * @property {string[]} columns - Column names after the transformation.
- * @property {Array<Array<*>>} rows - Row data after the transformation.
- * @property {Object.<string, string>} dtypes - Column name to pandas dtype mapping.
+ * @property {string} project_id
+ * @property {string} operation_type
+ * @property {number} row_count
+ * @property {string[]} columns
+ * @property {any[][]} rows
+ * @property {Object.<string, string>} dtypes
+ * @property {number} [page]
+ * @property {number} [page_size]
+ * @property {number} [total_rows]
+ * @property {number} [total_pages]
  */
-
 /**
  * Apply a transformation (filter, sort, add/delete row/column, pivot, etc).
  * @param {string} projectId - The project ID.
  * @param {Object} transformationInput - The transformation parameters including operation_type.
  * @param {Object} options - Request options.
  * @param {boolean} options.preview - If true, return transformed data without persisting.
+ * @param {number} [options.page] - Preview page number.
+ * @param {number} [options.pageSize] - Number of preview rows per page.
  * @returns {Promise<TransformResult>} Transformation result with updated rows and columns.
  */
 export const transformProject = async (
   projectId,
   transformationInput,
-  { preview = false } = {},
+  { preview = false, page, pageSize } = {},
 ) => {
-  const params = preview ? { preview: true } : {};
+  const params = {
+    ...(preview ? { preview: true } : {}),
+    ...(preview && page !== undefined ? { page } : {}),
+    ...(preview && pageSize !== undefined ? { page_size: pageSize } : {}),
+  };
+
   const response = await client.post(`/projects/${projectId}/transform`, transformationInput, {
     params,
   });
+
   return response.data;
 };
 

--- a/dataloom-frontend/src/context/ProjectContext.jsx
+++ b/dataloom-frontend/src/context/ProjectContext.jsx
@@ -5,7 +5,7 @@ const ProjectContext = createContext(null);
 
 /**
  * Hook to access project state and actions.
- * @returns {{ projectId: string, columns: string[], rows: Array[], dtypes: Object.<string, string>, columnOrder: number[], setColumnOrder: Function, deleteProjectOrder: Function, loading: boolean, error: string|null, dataVersion: number, projectName: string, totalRows: number, totalPages: number, page: number, pageSize: number, refreshProject: Function, updateData: Function, setProjectInfo: Function, setPaginationData: Function, updatePageSizePreference: Function, isPreviewMode: boolean, previewSnapshot: Object|null, pendingTransform: Object|null, setIsPreviewMode: Function, setPreviewSnapshot: Function, setPendingTransform: Function, enterPreviewMode: Function, cancelPreview: Function, confirmPreview: Function }}
+ * @returns {{ projectId: string, columns: string[], rows: Array[], dtypes: Object.<string, string>, columnOrder: number[], setColumnOrder: Function, deleteProjectOrder: Function, loading: boolean, error: string|null, dataVersion: number, projectName: string, totalRows: number, totalPages: number, page: number, pageSize: number, refreshProject: Function, updateData: Function, setProjectInfo: Function, setPaginationData: Function, updatePageSizePreference: Function, isPreviewMode: boolean, previewSnapshot: Object|null, pendingTransform: Object|null, setIsPreviewMode: Function, setPreviewSnapshot: Function, setPendingTransform: Function, enterPreviewMode: Function, updatePreviewPage: Function, cancelPreview: Function, confirmPreview: Function }}
  */
 // eslint-disable-next-line react-refresh/only-export-components
 export function useProjectContext() {
@@ -170,7 +170,7 @@ export function ProjectProvider({ children }) {
   }, []);
 
   const enterPreviewMode = useCallback(
-    (previewColumns, previewRows, previewDtypes, transformInfo = null) => {
+    (previewColumns, previewRows, previewDtypes, transformInfo = null, paginationInfo = {}) => {
       // Save the current table state into the snapshot (only on first entry;
       // a second Apply click while already in preview mode refreshes the
       // preview data but keeps the original snapshot intact).
@@ -182,26 +182,43 @@ export function ProjectProvider({ children }) {
           totalRows,
           totalPages,
           page,
+          pageSize,
         });
       }
 
-      // Update the table to show the preview data
+      // Update the table to show the preview data.
       setColumns(previewColumns);
       setRows(previewRows);
       if (previewDtypes) setDtypes(previewDtypes);
       setPendingTransform(transformInfo);
 
-      // Update pagination counters to reflect the preview result so the
-      // pagination UI doesn't misleadingly show the original row/page count.
-      const previewRowCount = previewRows.length;
-      setTotalRows(previewRowCount);
-      setTotalPages(1);
-      setPage(1);
+      // Use pagination metadata returned for the transformed preview.
+      setTotalRows(paginationInfo.total_rows ?? previewRows.length);
+      setTotalPages(paginationInfo.total_pages ?? 1);
+      setPage(paginationInfo.page ?? 1);
+      setPageSize(paginationInfo.page_size ?? pageSize);
 
-      // Activate preview mode
+      // Activate preview mode.
       setIsPreviewMode(true);
     },
-    [columns, rows, dtypes, totalRows, totalPages, page, previewSnapshot],
+    [columns, rows, dtypes, totalRows, totalPages, page, pageSize, previewSnapshot],
+  );
+
+  const updatePreviewPage = useCallback(
+    (previewColumns, previewRows, previewDtypes, paginationInfo = {}) => {
+      setColumns(previewColumns);
+      setRows(previewRows);
+
+      if (previewDtypes) {
+        setDtypes(previewDtypes);
+      }
+
+      setTotalRows(paginationInfo.total_rows ?? previewRows.length);
+      setTotalPages(paginationInfo.total_pages ?? 1);
+      setPage(paginationInfo.page ?? 1);
+      setPageSize(paginationInfo.page_size ?? pageSize);
+    },
+    [pageSize],
   );
 
   const cancelPreview = useCallback(() => {
@@ -214,6 +231,7 @@ export function ProjectProvider({ children }) {
     setTotalRows(previewSnapshot.totalRows);
     setTotalPages(previewSnapshot.totalPages);
     setPage(previewSnapshot.page);
+    setPageSize(previewSnapshot.pageSize);
 
     // Clear the snapshot and exit preview mode
     setPreviewSnapshot(null);
@@ -283,6 +301,7 @@ export function ProjectProvider({ children }) {
         setPreviewSnapshot,
         setPendingTransform,
         enterPreviewMode,
+        updatePreviewPage,
         cancelPreview,
         confirmPreview,
         setColumnOrder,

--- a/dataloom-frontend/src/test/AdvQueryFilterForm.test.jsx
+++ b/dataloom-frontend/src/test/AdvQueryFilterForm.test.jsx
@@ -23,9 +23,15 @@ const mockEnterPreviewMode = vi.fn();
 const mockCancelPreview = vi.fn();
 const mockHandleSave = vi.fn();
 
-const renderForm = ({ isPreviewMode = false, onClose = vi.fn(), saving = false } = {}) => {
+const renderForm = ({
+  isPreviewMode = false,
+  onClose = vi.fn(),
+  saving = false,
+  pageSize = 50,
+} = {}) => {
   useProjectContext.mockReturnValue({
     isPreviewMode,
+    pageSize,
     enterPreviewMode: mockEnterPreviewMode,
     cancelPreview: mockCancelPreview,
   });
@@ -49,6 +55,10 @@ describe("AdvQueryFilterForm", () => {
       columns: ["amount"],
       rows: [["100"]],
       dtypes: { amount: "integer" },
+      total_rows: 1,
+      total_pages: 1,
+      page: 1,
+      page_size: 50,
     });
   });
 
@@ -66,7 +76,7 @@ describe("AdvQueryFilterForm", () => {
     expect(screen.getByPlaceholderText("e.g., col1 > 10 and col2 < 5")).toBeRequired();
   });
 
-  it("submits the query for preview", async () => {
+  it("submits the query for preview with pagination parameters", async () => {
     const user = userEvent.setup();
     renderForm();
 
@@ -80,17 +90,31 @@ describe("AdvQueryFilterForm", () => {
           operation_type: ADV_QUERY_FILTER,
           adv_query: { query: "amount > 10" },
         },
-        { preview: true },
+        {
+          preview: true,
+          page: 1,
+          pageSize: 50,
+        },
       );
     });
   });
 
-  it("enters preview mode using the transformation response", async () => {
+  it("enters preview mode using the transformation response and pagination metadata", async () => {
     const user = userEvent.setup();
-    const response = { columns: ["amount"], rows: [[100]], dtypes: { amount: "integer" } };
+    const response = {
+      columns: ["amount"],
+      rows: [[100]],
+      dtypes: { amount: "integer" },
+      total_rows: 1,
+      total_pages: 1,
+      page: 1,
+      page_size: 50,
+    };
+
     transformProject.mockResolvedValue(response);
 
     renderForm();
+
     await user.type(screen.getByPlaceholderText("e.g., col1 > 10 and col2 < 5"), "amount > 10");
     await user.click(screen.getByRole("button", { name: "Submit" }));
 
@@ -99,7 +123,38 @@ describe("AdvQueryFilterForm", () => {
         response.columns,
         response.rows,
         response.dtypes,
-        expect.objectContaining({ projectId: "project-123" }),
+        expect.objectContaining({
+          projectId: "project-123",
+        }),
+        {
+          total_rows: response.total_rows,
+          total_pages: response.total_pages,
+          page: response.page,
+          page_size: response.page_size,
+        },
+      );
+    });
+  });
+
+  it("uses the current page size when requesting the preview", async () => {
+    const user = userEvent.setup();
+    renderForm({ pageSize: 10 });
+
+    await user.type(screen.getByPlaceholderText("e.g., col1 > 10 and col2 < 5"), "amount > 10");
+    await user.click(screen.getByRole("button", { name: "Submit" }));
+
+    await waitFor(() => {
+      expect(transformProject).toHaveBeenCalledWith(
+        "project-123",
+        {
+          operation_type: ADV_QUERY_FILTER,
+          adv_query: { query: "amount > 10" },
+        },
+        {
+          preview: true,
+          page: 1,
+          pageSize: 10,
+        },
       );
     });
   });
@@ -107,6 +162,7 @@ describe("AdvQueryFilterForm", () => {
   it("disables Submit while the request is pending", async () => {
     const user = userEvent.setup();
     let resolveTransform;
+
     transformProject.mockImplementation(
       () =>
         new Promise((resolve) => {
@@ -115,12 +171,21 @@ describe("AdvQueryFilterForm", () => {
     );
 
     renderForm();
+
     await user.type(screen.getByPlaceholderText("e.g., col1 > 10 and col2 < 5"), "amount > 10");
     await user.click(screen.getByRole("button", { name: "Submit" }));
 
     expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
 
-    resolveTransform({ columns: [], rows: [], dtypes: {} });
+    resolveTransform({
+      columns: [],
+      rows: [],
+      dtypes: {},
+      total_rows: 0,
+      total_pages: 1,
+      page: 1,
+      page_size: 50,
+    });
 
     await waitFor(() => {
       expect(screen.getByRole("button", { name: "Submit" })).not.toBeDisabled();
@@ -129,17 +194,24 @@ describe("AdvQueryFilterForm", () => {
 
   it("shows the backend error message when the query request fails", async () => {
     const user = userEvent.setup();
+
     transformProject.mockRejectedValue({
-      response: { data: { detail: "Invalid query syntax." } },
+      response: {
+        data: {
+          detail: "Invalid query syntax.",
+        },
+      },
     });
 
     renderForm();
+
     await user.type(screen.getByPlaceholderText("e.g., col1 > 10 and col2 < 5"), "amount >>");
     await user.click(screen.getByRole("button", { name: "Submit" }));
 
     await waitFor(() => {
       expect(screen.getByText("Invalid query syntax.")).toBeInTheDocument();
     });
+
     expect(mockEnterPreviewMode).not.toHaveBeenCalled();
   });
 
@@ -152,6 +224,7 @@ describe("AdvQueryFilterForm", () => {
 
   it("calls the preview save handler when Save Changes is clicked", async () => {
     const user = userEvent.setup();
+
     renderForm({ isPreviewMode: true });
 
     await user.click(screen.getByRole("button", { name: "Save Changes" }));
@@ -160,7 +233,10 @@ describe("AdvQueryFilterForm", () => {
   });
 
   it("shows saving state while preview changes are being saved", () => {
-    renderForm({ isPreviewMode: true, saving: true });
+    renderForm({
+      isPreviewMode: true,
+      saving: true,
+    });
 
     expect(screen.getByRole("button", { name: "Saving..." })).toBeDisabled();
   });
@@ -168,7 +244,11 @@ describe("AdvQueryFilterForm", () => {
   it("cancels preview mode when Cancel is clicked during preview", async () => {
     const user = userEvent.setup();
     const onClose = vi.fn();
-    renderForm({ isPreviewMode: true, onClose });
+
+    renderForm({
+      isPreviewMode: true,
+      onClose,
+    });
 
     await user.click(screen.getByRole("button", { name: "Cancel" }));
 
@@ -179,7 +259,11 @@ describe("AdvQueryFilterForm", () => {
   it("closes the form when Cancel is clicked outside preview mode", async () => {
     const user = userEvent.setup();
     const onClose = vi.fn();
-    renderForm({ isPreviewMode: false, onClose });
+
+    renderForm({
+      isPreviewMode: false,
+      onClose,
+    });
 
     await user.click(screen.getByRole("button", { name: "Cancel" }));
 

--- a/dataloom-frontend/src/test/CastDataTypeForm.test.jsx
+++ b/dataloom-frontend/src/test/CastDataTypeForm.test.jsx
@@ -60,6 +60,7 @@ const renderForm = ({ isPreviewMode = false, onClose = vi.fn(), saving = false }
     isPreviewMode,
     enterPreviewMode: mockEnterPreviewMode,
     cancelPreview: mockCancelPreview,
+    pageSize: 50,
   });
 
   usePreviewSave.mockReturnValue({
@@ -91,6 +92,10 @@ describe("CastDataTypeForm", () => {
         amount: "integer",
         created_at: "datetime",
       },
+      total_rows: 2,
+      total_pages: 1,
+      page: 1,
+      page_size: 50,
     });
   });
 
@@ -127,7 +132,9 @@ describe("CastDataTypeForm", () => {
     renderForm();
 
     await user.selectOptions(screen.getByLabelText("Column"), "amount");
+
     await user.selectOptions(screen.getByLabelText("Target Type"), "float");
+
     await user.click(screen.getByRole("button", { name: "Apply" }));
 
     await waitFor(() => {
@@ -142,12 +149,14 @@ describe("CastDataTypeForm", () => {
         },
         {
           preview: true,
+          page: 1,
+          pageSize: 50,
         },
       );
     });
   });
 
-  it("enters preview mode using the transformation response", async () => {
+  it("enters preview mode using the transformation response and pagination metadata", async () => {
     const user = userEvent.setup();
 
     const response = {
@@ -156,6 +165,10 @@ describe("CastDataTypeForm", () => {
       dtypes: {
         amount: "integer",
       },
+      total_rows: 2,
+      total_pages: 1,
+      page: 1,
+      page_size: 50,
     };
 
     transformProject.mockResolvedValue(response);
@@ -163,6 +176,7 @@ describe("CastDataTypeForm", () => {
     renderForm();
 
     await user.selectOptions(screen.getByLabelText("Column"), "amount");
+
     await user.click(screen.getByRole("button", { name: "Apply" }));
 
     await waitFor(() => {
@@ -180,6 +194,12 @@ describe("CastDataTypeForm", () => {
             },
           },
         },
+        {
+          total_rows: response.total_rows,
+          total_pages: response.total_pages,
+          page: response.page,
+          page_size: response.page_size,
+        },
       );
     });
   });
@@ -188,6 +208,7 @@ describe("CastDataTypeForm", () => {
     const user = userEvent.setup();
 
     let resolveTransform;
+
     transformProject.mockImplementation(
       () =>
         new Promise((resolve) => {
@@ -198,6 +219,7 @@ describe("CastDataTypeForm", () => {
     renderForm();
 
     await user.selectOptions(screen.getByLabelText("Column"), "amount");
+
     await user.click(screen.getByRole("button", { name: "Apply" }));
 
     expect(screen.getByRole("button", { name: "Applying..." })).toBeDisabled();
@@ -206,6 +228,10 @@ describe("CastDataTypeForm", () => {
       columns: ["amount"],
       rows: [[100]],
       dtypes: { amount: "integer" },
+      total_rows: 1,
+      total_pages: 1,
+      page: 1,
+      page_size: 50,
     });
 
     await waitFor(() => {
@@ -227,7 +253,9 @@ describe("CastDataTypeForm", () => {
     renderForm();
 
     await user.selectOptions(screen.getByLabelText("Column"), "amount");
+
     await user.selectOptions(screen.getByLabelText("Target Type"), "integer");
+
     await user.click(screen.getByRole("button", { name: "Apply" }));
 
     await waitFor(() => {
@@ -245,24 +273,32 @@ describe("CastDataTypeForm", () => {
     renderForm();
 
     await user.selectOptions(screen.getByLabelText("Column"), "amount");
+
     await user.click(screen.getByRole("button", { name: "Apply" }));
 
     await waitFor(() => {
       expect(mockShowToast).toHaveBeenCalledWith("Failed to cast data type.", "error");
     });
+
+    expect(mockEnterPreviewMode).not.toHaveBeenCalled();
   });
 
   it("disables Apply and displays Save Changes in preview mode", () => {
-    renderForm({ isPreviewMode: true });
+    renderForm({
+      isPreviewMode: true,
+    });
 
     expect(screen.getByRole("button", { name: "Apply" })).toBeDisabled();
+
     expect(screen.getByRole("button", { name: "Save Changes" })).toBeInTheDocument();
   });
 
   it("calls the preview save handler when Save Changes is clicked", async () => {
     const user = userEvent.setup();
 
-    renderForm({ isPreviewMode: true });
+    renderForm({
+      isPreviewMode: true,
+    });
 
     await user.click(screen.getByRole("button", { name: "Save Changes" }));
 
@@ -276,6 +312,7 @@ describe("CastDataTypeForm", () => {
     });
 
     expect(screen.getByRole("button", { name: "Saving..." })).toBeDisabled();
+
     expect(screen.getByRole("button", { name: "Apply" })).toBeDisabled();
   });
 
@@ -315,6 +352,7 @@ describe("CastDataTypeForm", () => {
     renderForm();
 
     await user.selectOptions(screen.getByLabelText("Column"), "created_at");
+
     await user.selectOptions(screen.getByLabelText("Target Type"), "datetime");
 
     fireEvent.submit(screen.getByRole("button", { name: "Apply" }).closest("form"));
@@ -331,6 +369,8 @@ describe("CastDataTypeForm", () => {
         },
         {
           preview: true,
+          page: 1,
+          pageSize: 50,
         },
       );
     });

--- a/dataloom-frontend/src/test/DropDuplicateForm.test.jsx
+++ b/dataloom-frontend/src/test/DropDuplicateForm.test.jsx
@@ -57,6 +57,7 @@ const mockHandleSave = vi.fn();
 const renderForm = ({ isPreviewMode = false, onClose = vi.fn(), saving = false } = {}) => {
   useProjectContext.mockReturnValue({
     isPreviewMode,
+    pageSize: 50,
     enterPreviewMode: mockEnterPreviewMode,
     cancelPreview: mockCancelPreview,
   });
@@ -80,6 +81,10 @@ describe("DropDuplicateForm", () => {
       columns: ["amount"],
       rows: [["100"]],
       dtypes: { amount: "integer" },
+      total_rows: 1,
+      total_pages: 1,
+      page: 1,
+      page_size: 50,
     });
   });
 
@@ -107,6 +112,7 @@ describe("DropDuplicateForm", () => {
     await waitFor(() => {
       expect(screen.getByText("Please select at least one column.")).toBeInTheDocument();
     });
+
     expect(transformProject).not.toHaveBeenCalled();
   });
 
@@ -123,19 +129,37 @@ describe("DropDuplicateForm", () => {
         "project-123",
         {
           operation_type: DROP_DUPLICATE,
-          drop_duplicate: { columns: "amount,created_at", keep: "last" },
+          drop_duplicate: {
+            columns: "amount,created_at",
+            keep: "last",
+          },
         },
-        { preview: true },
+        {
+          preview: true,
+          page: 1,
+          pageSize: 50,
+        },
       );
     });
   });
 
-  it("enters preview mode using the transformation response", async () => {
+  it("enters preview mode using the transformation response and pagination metadata", async () => {
     const user = userEvent.setup();
-    const response = { columns: ["amount"], rows: [[100]], dtypes: { amount: "integer" } };
+
+    const response = {
+      columns: ["amount"],
+      rows: [[100]],
+      dtypes: { amount: "integer" },
+      total_rows: 38,
+      total_pages: 4,
+      page: 2,
+      page_size: 10,
+    };
+
     transformProject.mockResolvedValue(response);
 
     renderForm();
+
     await user.selectOptions(screen.getByLabelText("Columns"), ["amount"]);
     await user.click(screen.getByRole("button", { name: "Submit" }));
 
@@ -148,8 +172,17 @@ describe("DropDuplicateForm", () => {
           projectId: "project-123",
           payload: {
             operation_type: DROP_DUPLICATE,
-            drop_duplicate: { columns: "amount", keep: "first" },
+            drop_duplicate: {
+              columns: "amount",
+              keep: "first",
+            },
           },
+        },
+        {
+          total_rows: response.total_rows,
+          total_pages: response.total_pages,
+          page: response.page,
+          page_size: response.page_size,
         },
       );
     });
@@ -157,17 +190,24 @@ describe("DropDuplicateForm", () => {
 
   it("shows the backend error message when the request fails", async () => {
     const user = userEvent.setup();
+
     transformProject.mockRejectedValue({
-      response: { data: { detail: "Unable to drop duplicates." } },
+      response: {
+        data: {
+          detail: "Unable to drop duplicates.",
+        },
+      },
     });
 
     renderForm();
+
     await user.selectOptions(screen.getByLabelText("Columns"), ["amount"]);
     await user.click(screen.getByRole("button", { name: "Submit" }));
 
     await waitFor(() => {
       expect(screen.getByText("Unable to drop duplicates.")).toBeInTheDocument();
     });
+
     expect(mockEnterPreviewMode).not.toHaveBeenCalled();
   });
 
@@ -180,6 +220,7 @@ describe("DropDuplicateForm", () => {
 
   it("calls the preview save handler when Save Changes is clicked", async () => {
     const user = userEvent.setup();
+
     renderForm({ isPreviewMode: true });
 
     await user.click(screen.getByRole("button", { name: "Save Changes" }));
@@ -188,7 +229,10 @@ describe("DropDuplicateForm", () => {
   });
 
   it("shows saving state while preview changes are being saved", () => {
-    renderForm({ isPreviewMode: true, saving: true });
+    renderForm({
+      isPreviewMode: true,
+      saving: true,
+    });
 
     expect(screen.getByRole("button", { name: "Saving..." })).toBeDisabled();
     expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
@@ -197,7 +241,11 @@ describe("DropDuplicateForm", () => {
   it("cancels preview mode when Cancel is clicked during preview", async () => {
     const user = userEvent.setup();
     const onClose = vi.fn();
-    renderForm({ isPreviewMode: true, onClose });
+
+    renderForm({
+      isPreviewMode: true,
+      onClose,
+    });
 
     await user.click(screen.getByRole("button", { name: "Cancel" }));
 
@@ -208,7 +256,11 @@ describe("DropDuplicateForm", () => {
   it("closes the form when Cancel is clicked outside preview mode", async () => {
     const user = userEvent.setup();
     const onClose = vi.fn();
-    renderForm({ isPreviewMode: false, onClose });
+
+    renderForm({
+      isPreviewMode: false,
+      onClose,
+    });
 
     await user.click(screen.getByRole("button", { name: "Cancel" }));
 

--- a/dataloom-frontend/src/test/FillEmptyForm.test.jsx
+++ b/dataloom-frontend/src/test/FillEmptyForm.test.jsx
@@ -55,9 +55,11 @@ const renderForm = ({
   onClose = vi.fn(),
   saving = false,
   columns = ["amount", "created_at"],
+  pageSize = 50,
 } = {}) => {
   useProjectContext.mockReturnValue({
     columns,
+    pageSize,
     isPreviewMode,
     enterPreviewMode: mockEnterPreviewMode,
     cancelPreview: mockCancelPreview,
@@ -160,7 +162,7 @@ describe("FillEmptyForm", () => {
             fill_value: "N/A",
           },
         },
-        { preview: true },
+        { preview: true, page: 1, pageSize: 50 },
       );
     });
   });
@@ -184,7 +186,7 @@ describe("FillEmptyForm", () => {
             fill_value: null,
           },
         },
-        { preview: true },
+        { preview: true, page: 1, pageSize: 50 },
       );
     });
   });
@@ -203,7 +205,23 @@ describe("FillEmptyForm", () => {
         response.columns,
         response.rows,
         response.dtypes,
-        expect.objectContaining({ projectId: "project-123" }),
+        {
+          projectId: "project-123",
+          payload: {
+            operation_type: "fillEmpty",
+            fill_empty_params: {
+              index: null,
+              strategy: "custom",
+              fill_value: "0",
+            },
+          },
+        },
+        {
+          total_rows: undefined,
+          total_pages: undefined,
+          page: undefined,
+          page_size: undefined,
+        },
       );
     });
   });
@@ -304,5 +322,43 @@ describe("FillEmptyForm", () => {
 
     expect(onClose).toHaveBeenCalledTimes(1);
     expect(mockCancelPreview).not.toHaveBeenCalled();
+  });
+
+  it("enters preview mode using the transformation response and pagination metadata", async () => {
+    const user = userEvent.setup();
+
+    const response = {
+      columns: ["amount"],
+      rows: [[1]],
+      dtypes: { amount: "integer" },
+      total_rows: 38,
+      total_pages: 4,
+      page: 2,
+      page_size: 10,
+    };
+
+    transformProject.mockResolvedValue(response);
+
+    renderForm();
+
+    await user.type(screen.getByPlaceholderText("Enter value"), "0");
+    await user.click(screen.getByRole("button", { name: "Apply" }));
+
+    await waitFor(() => {
+      expect(mockEnterPreviewMode).toHaveBeenCalledWith(
+        response.columns,
+        response.rows,
+        response.dtypes,
+        expect.objectContaining({
+          projectId: "project-123",
+        }),
+        {
+          total_rows: response.total_rows,
+          total_pages: response.total_pages,
+          page: response.page,
+          page_size: response.page_size,
+        },
+      );
+    });
   });
 });

--- a/dataloom-frontend/src/test/FilterForm.test.jsx
+++ b/dataloom-frontend/src/test/FilterForm.test.jsx
@@ -45,8 +45,14 @@ const mockEnterPreviewMode = vi.fn();
 const mockCancelPreview = vi.fn();
 const mockHandleSave = vi.fn();
 
-const renderForm = ({ isPreviewMode = false, onClose = vi.fn(), saving = false } = {}) => {
+const renderForm = ({
+  isPreviewMode = false,
+  onClose = vi.fn(),
+  saving = false,
+  pageSize = 50,
+} = {}) => {
   useProjectContext.mockReturnValue({
+    pageSize,
     isPreviewMode,
     enterPreviewMode: mockEnterPreviewMode,
     cancelPreview: mockCancelPreview,
@@ -70,7 +76,14 @@ describe("FilterForm", () => {
     transformProject.mockResolvedValue({
       columns: ["amount", "created_at"],
       rows: [["100", "2026-07-18"]],
-      dtypes: { amount: "integer", created_at: "datetime" },
+      dtypes: {
+        amount: "integer",
+        created_at: "datetime",
+      },
+      total_rows: 2,
+      total_pages: 1,
+      page: 1,
+      page_size: 50,
     });
   });
 
@@ -81,7 +94,9 @@ describe("FilterForm", () => {
     expect(screen.getByLabelText("Column")).toBeInTheDocument();
     expect(screen.getByLabelText("Condition")).toBeInTheDocument();
     expect(screen.getByTestId("filter-value")).toBeInTheDocument();
+
     expect(screen.getByRole("button", { name: "Apply Filter" })).toBeInTheDocument();
+
     expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
   });
 
@@ -93,48 +108,86 @@ describe("FilterForm", () => {
 
   it("shows a validation error when no column is selected", async () => {
     const user = userEvent.setup();
+
     renderForm();
 
     await user.type(screen.getByTestId("filter-value"), "100");
+
     fireEvent.submit(screen.getByTestId("filter-form").querySelector("form"));
 
     await waitFor(() => {
       expect(screen.getByText("Please select a column.")).toBeInTheDocument();
     });
+
     expect(transformProject).not.toHaveBeenCalled();
     expect(mockEnterPreviewMode).not.toHaveBeenCalled();
   });
 
   it("submits the filter parameters for preview", async () => {
     const user = userEvent.setup();
+
     renderForm();
 
     await user.selectOptions(screen.getByLabelText("Column"), "amount");
+
     await user.selectOptions(screen.getByLabelText("Condition"), ">");
+
     await user.type(screen.getByTestId("filter-value"), "50");
-    await user.click(screen.getByRole("button", { name: "Apply Filter" }));
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Apply Filter",
+      }),
+    );
 
     await waitFor(() => {
       expect(transformProject).toHaveBeenCalledWith(
         "project-123",
         {
           operation_type: FILTER,
-          parameters: { column: "amount", condition: ">", value: "50" },
+          parameters: {
+            column: "amount",
+            condition: ">",
+            value: "50",
+          },
         },
-        { preview: true },
+        {
+          preview: true,
+          page: 1,
+          pageSize: 50,
+        },
       );
     });
   });
 
   it("enters preview mode using the transformation response", async () => {
     const user = userEvent.setup();
-    const response = { columns: ["amount"], rows: [[100]], dtypes: { amount: "integer" } };
+
+    const response = {
+      columns: ["amount"],
+      rows: [[100]],
+      dtypes: {
+        amount: "integer",
+      },
+      total_rows: 1,
+      total_pages: 1,
+      page: 1,
+      page_size: 50,
+    };
+
     transformProject.mockResolvedValue(response);
 
     renderForm();
+
     await user.selectOptions(screen.getByLabelText("Column"), "amount");
+
     await user.type(screen.getByTestId("filter-value"), "50");
-    await user.click(screen.getByRole("button", { name: "Apply Filter" }));
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Apply Filter",
+      }),
+    );
 
     await waitFor(() => {
       expect(mockEnterPreviewMode).toHaveBeenCalledWith(
@@ -145,8 +198,18 @@ describe("FilterForm", () => {
           projectId: "project-123",
           payload: {
             operation_type: FILTER,
-            parameters: { column: "amount", condition: "=", value: "50" },
+            parameters: {
+              column: "amount",
+              condition: "=",
+              value: "50",
+            },
           },
+        },
+        {
+          total_rows: response.total_rows,
+          total_pages: response.total_pages,
+          page: response.page,
+          page_size: response.page_size,
         },
       );
     });
@@ -154,7 +217,9 @@ describe("FilterForm", () => {
 
   it("disables the Apply Filter button while the request is pending", async () => {
     const user = userEvent.setup();
+
     let resolveTransform;
+
     transformProject.mockImplementation(
       () =>
         new Promise((resolve) => {
@@ -163,65 +228,139 @@ describe("FilterForm", () => {
     );
 
     renderForm();
+
     await user.selectOptions(screen.getByLabelText("Column"), "amount");
+
     await user.type(screen.getByTestId("filter-value"), "50");
-    await user.click(screen.getByRole("button", { name: "Apply Filter" }));
 
-    expect(screen.getByRole("button", { name: "Apply Filter" })).toBeDisabled();
+    await user.click(
+      screen.getByRole("button", {
+        name: "Apply Filter",
+      }),
+    );
 
-    resolveTransform({ columns: [], rows: [], dtypes: {} });
+    expect(
+      screen.getByRole("button", {
+        name: "Apply Filter",
+      }),
+    ).toBeDisabled();
+
+    resolveTransform({
+      columns: [],
+      rows: [],
+      dtypes: {},
+      total_rows: 0,
+      total_pages: 0,
+      page: 1,
+      page_size: 50,
+    });
 
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: "Apply Filter" })).not.toBeDisabled();
+      expect(
+        screen.getByRole("button", {
+          name: "Apply Filter",
+        }),
+      ).not.toBeDisabled();
     });
   });
 
   it("shows the backend error message when the filter request fails", async () => {
     const user = userEvent.setup();
+
     transformProject.mockRejectedValue({
-      response: { data: { detail: "Invalid filter expression." } },
+      response: {
+        data: {
+          detail: "Invalid filter expression.",
+        },
+      },
     });
 
     renderForm();
+
     await user.selectOptions(screen.getByLabelText("Column"), "amount");
+
     await user.type(screen.getByTestId("filter-value"), "50");
-    await user.click(screen.getByRole("button", { name: "Apply Filter" }));
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Apply Filter",
+      }),
+    );
 
     await waitFor(() => {
       expect(screen.getByText("Invalid filter expression.")).toBeInTheDocument();
     });
+
     expect(mockEnterPreviewMode).not.toHaveBeenCalled();
   });
 
   it("disables Apply Filter and displays Save Changes in preview mode", () => {
-    renderForm({ isPreviewMode: true });
+    renderForm({
+      isPreviewMode: true,
+    });
 
-    expect(screen.getByRole("button", { name: "Apply Filter" })).toBeDisabled();
-    expect(screen.getByRole("button", { name: "Save Changes" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: "Apply Filter",
+      }),
+    ).toBeDisabled();
+
+    expect(
+      screen.getByRole("button", {
+        name: "Save Changes",
+      }),
+    ).toBeInTheDocument();
   });
 
   it("calls the preview save handler when Save Changes is clicked", async () => {
     const user = userEvent.setup();
-    renderForm({ isPreviewMode: true });
 
-    await user.click(screen.getByRole("button", { name: "Save Changes" }));
+    renderForm({
+      isPreviewMode: true,
+    });
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Save Changes",
+      }),
+    );
 
     expect(mockHandleSave).toHaveBeenCalledTimes(1);
   });
 
   it("shows saving state while preview changes are being saved", () => {
-    renderForm({ isPreviewMode: true, saving: true });
+    renderForm({
+      isPreviewMode: true,
+      saving: true,
+    });
 
-    expect(screen.getByRole("button", { name: "Saving..." })).toBeDisabled();
-    expect(screen.getByRole("button", { name: "Apply Filter" })).toBeDisabled();
+    expect(
+      screen.getByRole("button", {
+        name: "Saving...",
+      }),
+    ).toBeDisabled();
+
+    expect(
+      screen.getByRole("button", {
+        name: "Apply Filter",
+      }),
+    ).toBeDisabled();
   });
 
   it("cancels preview mode when Cancel is clicked during preview", async () => {
     const user = userEvent.setup();
     const onClose = vi.fn();
-    renderForm({ isPreviewMode: true, onClose });
 
-    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    renderForm({
+      isPreviewMode: true,
+      onClose,
+    });
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Cancel",
+      }),
+    );
 
     expect(mockCancelPreview).toHaveBeenCalledTimes(1);
     expect(onClose).not.toHaveBeenCalled();
@@ -230,11 +369,68 @@ describe("FilterForm", () => {
   it("closes the form when Cancel is clicked outside preview mode", async () => {
     const user = userEvent.setup();
     const onClose = vi.fn();
-    renderForm({ isPreviewMode: false, onClose });
 
-    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    renderForm({
+      isPreviewMode: false,
+      onClose,
+    });
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Cancel",
+      }),
+    );
 
     expect(onClose).toHaveBeenCalledTimes(1);
     expect(mockCancelPreview).not.toHaveBeenCalled();
+  });
+
+  it("enters preview mode using pagination metadata", async () => {
+    const user = userEvent.setup();
+
+    const response = {
+      columns: ["amount"],
+      rows: [[100]],
+      dtypes: {
+        amount: "integer",
+      },
+      total_rows: 38,
+      total_pages: 4,
+      page: 2,
+      page_size: 10,
+    };
+
+    transformProject.mockResolvedValue(response);
+
+    renderForm({
+      pageSize: 10,
+    });
+
+    await user.selectOptions(screen.getByLabelText("Column"), "amount");
+
+    await user.type(screen.getByTestId("filter-value"), "50");
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Apply Filter",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mockEnterPreviewMode).toHaveBeenCalledWith(
+        response.columns,
+        response.rows,
+        response.dtypes,
+        expect.objectContaining({
+          projectId: "project-123",
+        }),
+        {
+          total_rows: response.total_rows,
+          total_pages: response.total_pages,
+          page: response.page,
+          page_size: response.page_size,
+        },
+      );
+    });
   });
 });

--- a/dataloom-frontend/src/test/GroupByForm.test.jsx
+++ b/dataloom-frontend/src/test/GroupByForm.test.jsx
@@ -76,9 +76,11 @@ const renderForm = ({
   onClose = vi.fn(),
   saving = false,
   columns = ["amount", "created_at", "region"],
+  pageSize = 50,
 } = {}) => {
   useProjectContext.mockReturnValue({
     columns,
+    pageSize,
     isPreviewMode,
     enterPreviewMode: mockEnterPreviewMode,
     cancelPreview: mockCancelPreview,
@@ -102,7 +104,14 @@ describe("GroupByForm", () => {
     transformProject.mockResolvedValue({
       columns: ["region", "amount"],
       rows: [["north", "100"]],
-      dtypes: { region: "string", amount: "integer" },
+      dtypes: {
+        region: "string",
+        amount: "integer",
+      },
+      total_rows: 1,
+      total_pages: 1,
+      page: 1,
+      page_size: 50,
     });
   });
 
@@ -110,9 +119,22 @@ describe("GroupByForm", () => {
     renderForm();
 
     expect(screen.getByLabelText("Group By Columns")).toBeInTheDocument();
+
     expect(screen.getByLabelText("Aggregation Column")).toBeInTheDocument();
+
     expect(screen.getByLabelText("Function")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Apply GroupBy" })).toBeInTheDocument();
+
+    expect(
+      screen.getByRole("button", {
+        name: "Apply GroupBy",
+      }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole("button", {
+        name: "Cancel",
+      }),
+    ).toBeInTheDocument();
   });
 
   it("uses sum as the default aggregation function", () => {
@@ -123,25 +145,48 @@ describe("GroupByForm", () => {
 
   it("disables Apply GroupBy until group columns and an aggregation column are selected", async () => {
     const user = userEvent.setup();
+
     renderForm();
 
-    expect(screen.getByRole("button", { name: "Apply GroupBy" })).toBeDisabled();
+    expect(
+      screen.getByRole("button", {
+        name: "Apply GroupBy",
+      }),
+    ).toBeDisabled();
 
     await user.selectOptions(screen.getByLabelText("Group By Columns"), "region");
-    expect(screen.getByRole("button", { name: "Apply GroupBy" })).toBeDisabled();
+
+    expect(
+      screen.getByRole("button", {
+        name: "Apply GroupBy",
+      }),
+    ).toBeDisabled();
 
     await user.selectOptions(screen.getByLabelText("Aggregation Column"), "amount");
-    expect(screen.getByRole("button", { name: "Apply GroupBy" })).not.toBeDisabled();
+
+    expect(
+      screen.getByRole("button", {
+        name: "Apply GroupBy",
+      }),
+    ).not.toBeDisabled();
   });
 
   it("submits the group by, aggregation column, and function", async () => {
     const user = userEvent.setup();
+
     renderForm();
 
     await user.selectOptions(screen.getByLabelText("Group By Columns"), "region");
+
     await user.selectOptions(screen.getByLabelText("Aggregation Column"), "amount");
+
     await user.selectOptions(screen.getByLabelText("Function"), "mean");
-    await user.click(screen.getByRole("button", { name: "Apply GroupBy" }));
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Apply GroupBy",
+      }),
+    );
 
     await waitFor(() => {
       expect(transformProject).toHaveBeenCalledWith(
@@ -154,38 +199,76 @@ describe("GroupByForm", () => {
             agg_function: "mean",
           },
         },
-        { preview: true },
+        {
+          preview: true,
+          page: 1,
+          pageSize: 50,
+        },
       );
     });
   });
 
   it("enters preview mode using the transformation response", async () => {
     const user = userEvent.setup();
+
     const response = {
       columns: ["region", "amount"],
       rows: [["north", 100]],
-      dtypes: { region: "string", amount: "integer" },
+      dtypes: {
+        region: "string",
+        amount: "integer",
+      },
+      total_rows: 1,
+      total_pages: 1,
+      page: 1,
+      page_size: 50,
     };
+
     transformProject.mockResolvedValue(response);
 
     renderForm();
+
     await user.selectOptions(screen.getByLabelText("Group By Columns"), "region");
+
     await user.selectOptions(screen.getByLabelText("Aggregation Column"), "amount");
-    await user.click(screen.getByRole("button", { name: "Apply GroupBy" }));
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Apply GroupBy",
+      }),
+    );
 
     await waitFor(() => {
       expect(mockEnterPreviewMode).toHaveBeenCalledWith(
         response.columns,
         response.rows,
         response.dtypes,
-        expect.objectContaining({ projectId: "project-123" }),
+        {
+          projectId: "project-123",
+          payload: {
+            operation_type: GROUPBY,
+            groupby_params: {
+              columns: ["region"],
+              agg_column: "amount",
+              agg_function: "sum",
+            },
+          },
+        },
+        {
+          total_rows: 1,
+          total_pages: 1,
+          page: 1,
+          page_size: 50,
+        },
       );
     });
   });
 
   it("shows applying state while the request is pending", async () => {
     const user = userEvent.setup();
+
     let resolveTransform;
+
     transformProject.mockImplementation(
       () =>
         new Promise((resolve) => {
@@ -194,77 +277,162 @@ describe("GroupByForm", () => {
     );
 
     renderForm();
+
     await user.selectOptions(screen.getByLabelText("Group By Columns"), "region");
+
     await user.selectOptions(screen.getByLabelText("Aggregation Column"), "amount");
-    await user.click(screen.getByRole("button", { name: "Apply GroupBy" }));
 
-    expect(screen.getByRole("button", { name: "Applying..." })).toBeDisabled();
+    await user.click(
+      screen.getByRole("button", {
+        name: "Apply GroupBy",
+      }),
+    );
 
-    resolveTransform({ columns: [], rows: [], dtypes: {} });
+    expect(
+      screen.getByRole("button", {
+        name: "Applying...",
+      }),
+    ).toBeDisabled();
+
+    resolveTransform({
+      columns: [],
+      rows: [],
+      dtypes: {},
+      total_rows: 0,
+      total_pages: 0,
+      page: 1,
+      page_size: 50,
+    });
 
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: "Apply GroupBy" })).not.toBeDisabled();
+      expect(
+        screen.getByRole("button", {
+          name: "Apply GroupBy",
+        }),
+      ).not.toBeDisabled();
     });
   });
 
   it("shows the backend error message when the group by request fails", async () => {
     const user = userEvent.setup();
+
     transformProject.mockRejectedValue({
-      response: { data: { detail: "Unable to group dataset." } },
+      response: {
+        data: {
+          detail: "Unable to group dataset.",
+        },
+      },
     });
 
     renderForm();
+
     await user.selectOptions(screen.getByLabelText("Group By Columns"), "region");
+
     await user.selectOptions(screen.getByLabelText("Aggregation Column"), "amount");
-    await user.click(screen.getByRole("button", { name: "Apply GroupBy" }));
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Apply GroupBy",
+      }),
+    );
 
     await waitFor(() => {
       expect(screen.getByText("Unable to group dataset.")).toBeInTheDocument();
     });
+
     expect(mockEnterPreviewMode).not.toHaveBeenCalled();
   });
 
   it("disables Apply GroupBy and displays Save Changes in preview mode", () => {
-    renderForm({ isPreviewMode: true });
+    renderForm({
+      isPreviewMode: true,
+    });
 
-    expect(screen.getByRole("button", { name: "Apply GroupBy" })).toBeDisabled();
-    expect(screen.getByRole("button", { name: "Save Changes" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: "Apply GroupBy",
+      }),
+    ).toBeDisabled();
+
+    expect(
+      screen.getByRole("button", {
+        name: "Save Changes",
+      }),
+    ).toBeInTheDocument();
   });
 
   it("calls the preview save handler when Save Changes is clicked", async () => {
     const user = userEvent.setup();
-    renderForm({ isPreviewMode: true });
 
-    await user.click(screen.getByRole("button", { name: "Save Changes" }));
+    renderForm({
+      isPreviewMode: true,
+    });
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Save Changes",
+      }),
+    );
 
     expect(mockHandleSave).toHaveBeenCalledTimes(1);
   });
 
   it("shows saving state while preview changes are being saved", () => {
-    renderForm({ isPreviewMode: true, saving: true });
+    renderForm({
+      isPreviewMode: true,
+      saving: true,
+    });
 
-    expect(screen.getByRole("button", { name: "Saving..." })).toBeDisabled();
+    expect(
+      screen.getByRole("button", {
+        name: "Saving...",
+      }),
+    ).toBeDisabled();
+
+    expect(
+      screen.getByRole("button", {
+        name: "Apply GroupBy",
+      }),
+    ).toBeDisabled();
   });
 
   it("cancels preview mode when Cancel is clicked during preview", async () => {
     const user = userEvent.setup();
     const onClose = vi.fn();
-    renderForm({ isPreviewMode: true, onClose });
 
-    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    renderForm({
+      isPreviewMode: true,
+      onClose,
+    });
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Cancel",
+      }),
+    );
 
     expect(mockCancelPreview).toHaveBeenCalledTimes(1);
+
     expect(onClose).not.toHaveBeenCalled();
   });
 
   it("closes the form when Cancel is clicked outside preview mode", async () => {
     const user = userEvent.setup();
     const onClose = vi.fn();
-    renderForm({ isPreviewMode: false, onClose });
 
-    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    renderForm({
+      isPreviewMode: false,
+      onClose,
+    });
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Cancel",
+      }),
+    );
 
     expect(onClose).toHaveBeenCalledTimes(1);
+
     expect(mockCancelPreview).not.toHaveBeenCalled();
   });
 
@@ -272,6 +440,7 @@ describe("GroupByForm", () => {
     const user = userEvent.setup();
 
     let resolveTransform;
+
     transformProject.mockImplementation(
       () =>
         new Promise((resolve) => {
@@ -282,8 +451,14 @@ describe("GroupByForm", () => {
     const { unmount } = renderForm();
 
     await user.selectOptions(screen.getByLabelText("Group By Columns"), "region");
+
     await user.selectOptions(screen.getByLabelText("Aggregation Column"), "amount");
-    await user.click(screen.getByRole("button", { name: "Apply GroupBy" }));
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Apply GroupBy",
+      }),
+    );
 
     unmount();
 
@@ -291,6 +466,10 @@ describe("GroupByForm", () => {
       columns: [],
       rows: [],
       dtypes: {},
+      total_rows: 0,
+      total_pages: 0,
+      page: 1,
+      page_size: 50,
     });
 
     await Promise.resolve();
@@ -302,6 +481,7 @@ describe("GroupByForm", () => {
     const user = userEvent.setup();
 
     let resolveTransform;
+
     transformProject.mockImplementationOnce(
       () =>
         new Promise((resolve) => {
@@ -312,8 +492,14 @@ describe("GroupByForm", () => {
     const { unmount } = renderForm();
 
     await user.selectOptions(screen.getByLabelText("Group By Columns"), "region");
+
     await user.selectOptions(screen.getByLabelText("Aggregation Column"), "amount");
-    await user.click(screen.getByRole("button", { name: "Apply GroupBy" }));
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Apply GroupBy",
+      }),
+    );
 
     unmount();
 
@@ -321,19 +507,33 @@ describe("GroupByForm", () => {
       columns: [],
       rows: [],
       dtypes: {},
+      total_rows: 0,
+      total_pages: 0,
+      page: 1,
+      page_size: 50,
     });
 
     transformProject.mockResolvedValue({
       columns: [],
       rows: [],
       dtypes: {},
+      total_rows: 0,
+      total_pages: 0,
+      page: 1,
+      page_size: 50,
     });
 
     renderForm();
 
     await user.selectOptions(screen.getByLabelText("Group By Columns"), "region");
+
     await user.selectOptions(screen.getByLabelText("Aggregation Column"), "amount");
-    await user.click(screen.getByRole("button", { name: "Apply GroupBy" }));
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Apply GroupBy",
+      }),
+    );
 
     await waitFor(() => {
       expect(transformProject).toHaveBeenCalledTimes(2);
@@ -347,6 +547,64 @@ describe("GroupByForm", () => {
 
     unmount();
 
-    expect(mockCancelPreview).toHaveBeenCalled();
+    expect(mockCancelPreview).toHaveBeenCalledTimes(1);
+  });
+
+  it("enters preview mode using the transformation response and pagination metadata", async () => {
+    const user = userEvent.setup();
+
+    const response = {
+      columns: ["region", "amount"],
+      rows: [["north", 100]],
+      dtypes: {
+        region: "string",
+        amount: "integer",
+      },
+      total_rows: 38,
+      total_pages: 4,
+      page: 2,
+      page_size: 10,
+    };
+
+    transformProject.mockResolvedValue(response);
+
+    renderForm({
+      pageSize: 10,
+    });
+
+    await user.selectOptions(screen.getByLabelText("Group By Columns"), "region");
+
+    await user.selectOptions(screen.getByLabelText("Aggregation Column"), "amount");
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Apply GroupBy",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mockEnterPreviewMode).toHaveBeenCalledWith(
+        response.columns,
+        response.rows,
+        response.dtypes,
+        expect.objectContaining({
+          projectId: "project-123",
+          payload: {
+            operation_type: GROUPBY,
+            groupby_params: {
+              columns: ["region"],
+              agg_column: "amount",
+              agg_function: "sum",
+            },
+          },
+        }),
+        {
+          total_rows: response.total_rows,
+          total_pages: response.total_pages,
+          page: response.page,
+          page_size: response.page_size,
+        },
+      );
+    });
   });
 });

--- a/dataloom-frontend/src/test/MeltForm.test.jsx
+++ b/dataloom-frontend/src/test/MeltForm.test.jsx
@@ -41,8 +41,14 @@ const mockEnterPreviewMode = vi.fn();
 const mockCancelPreview = vi.fn();
 const mockHandleSave = vi.fn();
 
-const renderForm = async ({ isPreviewMode = false, onClose = vi.fn(), saving = false } = {}) => {
+const renderForm = async ({
+  isPreviewMode = false,
+  onClose = vi.fn(),
+  saving = false,
+  pageSize = 50,
+} = {}) => {
   useProjectContext.mockReturnValue({
+    pageSize,
     isPreviewMode,
     enterPreviewMode: mockEnterPreviewMode,
     cancelPreview: mockCancelPreview,
@@ -59,23 +65,15 @@ const renderForm = async ({ isPreviewMode = false, onClose = vi.fn(), saving = f
     expect(getProjectDetails).toHaveBeenCalledWith("project-123");
   });
 
-  return { onClose, ...utils };
+  return {
+    onClose,
+    ...utils,
+  };
 };
 
 describe("MeltForm", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-
-    useProjectContext.mockReturnValue({
-      isPreviewMode: false,
-      enterPreviewMode: mockEnterPreviewMode,
-      cancelPreview: mockCancelPreview,
-    });
-
-    usePreviewSave.mockReturnValue({
-      saving: false,
-      handleSave: mockHandleSave,
-    });
 
     getProjectDetails.mockResolvedValue({
       columns: ["amount", "created_at", "region"],
@@ -88,6 +86,10 @@ describe("MeltForm", () => {
         variable: "string",
         value: "string",
       },
+      total_rows: 1,
+      total_pages: 1,
+      page: 1,
+      page_size: 50,
     });
   });
 
@@ -97,8 +99,18 @@ describe("MeltForm", () => {
     const multiSelects = screen.getAllByRole("listbox");
 
     expect(multiSelects).toHaveLength(2);
-    expect(screen.getByRole("button", { name: "Apply Melt" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+
+    expect(
+      screen.getByRole("button", {
+        name: "Apply Melt",
+      }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole("button", {
+        name: "Cancel",
+      }),
+    ).toBeInTheDocument();
   });
 
   it("shows an error if fetching columns fails", async () => {
@@ -118,7 +130,11 @@ describe("MeltForm", () => {
 
     await renderForm();
 
-    await user.click(screen.getByRole("button", { name: "Apply Melt" }));
+    await user.click(
+      screen.getByRole("button", {
+        name: "Apply Melt",
+      }),
+    );
 
     await waitFor(() => {
       expect(screen.getByText("Please select at least one ID variable.")).toBeInTheDocument();
@@ -137,7 +153,11 @@ describe("MeltForm", () => {
     await user.selectOptions(idSelect, "amount");
     await user.selectOptions(valueSelect, "amount");
 
-    await user.click(screen.getByRole("button", { name: "Apply Melt" }));
+    await user.click(
+      screen.getByRole("button", {
+        name: "Apply Melt",
+      }),
+    );
 
     await waitFor(() => {
       expect(
@@ -157,7 +177,11 @@ describe("MeltForm", () => {
 
     await user.selectOptions(idSelect, "amount");
 
-    await user.click(screen.getByRole("button", { name: "Apply Melt" }));
+    await user.click(
+      screen.getByRole("button", {
+        name: "Apply Melt",
+      }),
+    );
 
     await waitFor(() => {
       expect(transformProject).toHaveBeenCalledWith(
@@ -171,7 +195,11 @@ describe("MeltForm", () => {
             value_name: "value",
           },
         },
-        { preview: true },
+        {
+          preview: true,
+          page: 1,
+          pageSize: 50,
+        },
       );
     });
   });
@@ -187,6 +215,7 @@ describe("MeltForm", () => {
     await user.selectOptions(valueSelect, "region");
 
     const variableNameInput = screen.getByPlaceholderText("default: variable");
+
     const valueNameInput = screen.getByPlaceholderText("default: value");
 
     await user.clear(variableNameInput);
@@ -195,7 +224,11 @@ describe("MeltForm", () => {
     await user.clear(valueNameInput);
     await user.type(valueNameInput, "reading");
 
-    await user.click(screen.getByRole("button", { name: "Apply Melt" }));
+    await user.click(
+      screen.getByRole("button", {
+        name: "Apply Melt",
+      }),
+    );
 
     await waitFor(() => {
       expect(transformProject).toHaveBeenCalledWith(
@@ -209,18 +242,29 @@ describe("MeltForm", () => {
             value_name: "reading",
           },
         },
-        { preview: true },
+        {
+          preview: true,
+          page: 1,
+          pageSize: 50,
+        },
       );
     });
   });
 
-  it("enters preview mode using the transformation response", async () => {
+  it("enters preview mode using the transformation response and pagination metadata", async () => {
     const user = userEvent.setup();
 
     const response = {
       columns: ["variable", "value"],
       rows: [["amount", "100"]],
-      dtypes: {},
+      dtypes: {
+        variable: "string",
+        value: "string",
+      },
+      total_rows: 1,
+      total_pages: 1,
+      page: 1,
+      page_size: 50,
     };
 
     transformProject.mockResolvedValue(response);
@@ -231,22 +275,42 @@ describe("MeltForm", () => {
 
     await user.selectOptions(idSelect, "amount");
 
-    await user.click(screen.getByRole("button", { name: "Apply Melt" }));
+    await user.click(
+      screen.getByRole("button", {
+        name: "Apply Melt",
+      }),
+    );
 
     await waitFor(() => {
       expect(mockEnterPreviewMode).toHaveBeenCalledWith(
         response.columns,
         response.rows,
         response.dtypes,
-        expect.objectContaining({
+        {
           projectId: "project-123",
-        }),
+          payload: {
+            operation_type: "melt",
+            melt_params: {
+              id_vars: ["amount"],
+              value_vars: ["created_at", "region"],
+              var_name: "variable",
+              value_name: "value",
+            },
+          },
+        },
+        {
+          total_rows: 1,
+          total_pages: 1,
+          page: 1,
+          page_size: 50,
+        },
       );
     });
   });
 
   it("shows a processing state while the request is pending", async () => {
     const user = userEvent.setup();
+
     let resolveTransform;
 
     transformProject.mockImplementation(
@@ -262,7 +326,11 @@ describe("MeltForm", () => {
 
     await user.selectOptions(idSelect, "amount");
 
-    await user.click(screen.getByRole("button", { name: "Apply Melt" }));
+    await user.click(
+      screen.getByRole("button", {
+        name: "Apply Melt",
+      }),
+    );
 
     expect(
       screen.getByRole("button", {
@@ -274,6 +342,10 @@ describe("MeltForm", () => {
       columns: [],
       rows: [],
       dtypes: {},
+      total_rows: 0,
+      total_pages: 0,
+      page: 1,
+      page_size: 50,
     });
 
     await waitFor(() => {
@@ -302,7 +374,11 @@ describe("MeltForm", () => {
 
     await user.selectOptions(idSelect, "amount");
 
-    await user.click(screen.getByRole("button", { name: "Apply Melt" }));
+    await user.click(
+      screen.getByRole("button", {
+        name: "Apply Melt",
+      }),
+    );
 
     await waitFor(() => {
       expect(screen.getByText("Unable to melt dataset.")).toBeInTheDocument();
@@ -361,6 +437,7 @@ describe("MeltForm", () => {
     );
 
     expect(mockCancelPreview).toHaveBeenCalledTimes(1);
+
     expect(onClose).not.toHaveBeenCalled();
   });
 
@@ -380,6 +457,7 @@ describe("MeltForm", () => {
     );
 
     expect(onClose).toHaveBeenCalledTimes(1);
+
     expect(mockCancelPreview).not.toHaveBeenCalled();
   });
 });

--- a/dataloom-frontend/src/test/PivotTableForm.test.jsx
+++ b/dataloom-frontend/src/test/PivotTableForm.test.jsx
@@ -35,13 +35,13 @@ vi.mock("../Components/common/ColumnMultiSelect", () => ({
   ),
 }));
 
-// PivotTableForm renders two ColumnSelect instances (Column, Value) without a
-// distinguishing prop, so the mock tags them in render order for test lookup.
 let columnSelectRenderCount = 0;
+
 vi.mock("../Components/common/ColumnSelect", () => ({
   default: ({ value, onChange, placeholder }) => {
     const testId = `pivot-column-select-${columnSelectRenderCount % 2}`;
     columnSelectRenderCount += 1;
+
     return (
       <select data-testid={testId} value={value} onChange={(event) => onChange(event.target.value)}>
         <option value="">{placeholder}</option>
@@ -72,8 +72,14 @@ const mockEnterPreviewMode = vi.fn();
 const mockCancelPreview = vi.fn();
 const mockHandleSave = vi.fn();
 
-const renderForm = ({ isPreviewMode = false, onClose = vi.fn(), saving = false } = {}) => {
+const renderForm = ({
+  isPreviewMode = false,
+  onClose = vi.fn(),
+  saving = false,
+  pageSize = 50,
+} = {}) => {
   useProjectContext.mockReturnValue({
+    pageSize,
     isPreviewMode,
     enterPreviewMode: mockEnterPreviewMode,
     cancelPreview: mockCancelPreview,
@@ -98,11 +104,19 @@ const getColumnSelects = () => [
 describe("PivotTableForm", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    columnSelectRenderCount = 0;
 
     transformProject.mockResolvedValue({
       columns: ["region", "amount"],
       rows: [["north", "100"]],
-      dtypes: { region: "string", amount: "integer" },
+      dtypes: {
+        region: "string",
+        amount: "integer",
+      },
+      total_rows: 1,
+      total_pages: 1,
+      page: 1,
+      page_size: 50,
     });
   });
 
@@ -113,7 +127,10 @@ describe("PivotTableForm", () => {
     expect(screen.getByLabelText("Aggregation Function")).toBeInTheDocument();
     expect(screen.getByText("Column:")).toBeInTheDocument();
     expect(screen.getByText("Value:")).toBeInTheDocument();
+
     expect(screen.getByRole("button", { name: "Submit" })).toBeInTheDocument();
+
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
   });
 
   it("uses sum as the default aggregation function", () => {
@@ -124,39 +141,62 @@ describe("PivotTableForm", () => {
 
   it("shows a validation error when no index column is selected", async () => {
     const user = userEvent.setup();
+
     renderForm();
 
-    await user.click(screen.getByRole("button", { name: "Submit" }));
+    await user.click(
+      screen.getByRole("button", {
+        name: "Submit",
+      }),
+    );
 
     await waitFor(() => {
       expect(screen.getByText("Please select at least one index column.")).toBeInTheDocument();
     });
+
     expect(transformProject).not.toHaveBeenCalled();
   });
 
   it("shows a validation error when column or value is missing", async () => {
     const user = userEvent.setup();
+
     renderForm();
 
     await user.selectOptions(screen.getByLabelText("Index"), "region");
-    await user.click(screen.getByRole("button", { name: "Submit" }));
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Submit",
+      }),
+    );
 
     await waitFor(() => {
       expect(screen.getByText("Please select a column and a value.")).toBeInTheDocument();
     });
+
     expect(transformProject).not.toHaveBeenCalled();
   });
 
   it("submits index, column, value, and aggregation function", async () => {
     const user = userEvent.setup();
+
     renderForm();
 
     await user.selectOptions(screen.getByLabelText("Index"), "region");
+
     const [columnSelect, valueSelect] = getColumnSelects();
+
     await user.selectOptions(columnSelect, "created_at");
+
     await user.selectOptions(valueSelect, "amount");
+
     await user.selectOptions(screen.getByLabelText("Aggregation Function"), "mean");
-    await user.click(screen.getByRole("button", { name: "Submit" }));
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Submit",
+      }),
+    );
 
     await waitFor(() => {
       expect(transformProject).toHaveBeenCalledWith(
@@ -170,95 +210,197 @@ describe("PivotTableForm", () => {
             aggfun: "mean",
           },
         },
-        { preview: true },
+        {
+          preview: true,
+          page: 1,
+          pageSize: 50,
+        },
       );
     });
   });
 
   it("enters preview mode using the transformation response", async () => {
     const user = userEvent.setup();
+
     const response = {
       columns: ["region", "amount"],
       rows: [["north", 100]],
-      dtypes: { region: "string", amount: "integer" },
+      dtypes: {
+        region: "string",
+        amount: "integer",
+      },
+      total_rows: 1,
+      total_pages: 1,
+      page: 1,
+      page_size: 50,
     };
+
     transformProject.mockResolvedValue(response);
 
     renderForm();
+
     await user.selectOptions(screen.getByLabelText("Index"), "region");
+
     const [columnSelect, valueSelect] = getColumnSelects();
+
     await user.selectOptions(columnSelect, "created_at");
+
     await user.selectOptions(valueSelect, "amount");
-    await user.click(screen.getByRole("button", { name: "Submit" }));
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Submit",
+      }),
+    );
 
     await waitFor(() => {
       expect(mockEnterPreviewMode).toHaveBeenCalledWith(
         response.columns,
         response.rows,
         response.dtypes,
-        expect.objectContaining({ projectId: "project-123" }),
+        {
+          projectId: "project-123",
+          payload: {
+            operation_type: PIVOT_TABLES,
+            pivot_query: {
+              index: "region",
+              column: "created_at",
+              value: "amount",
+              aggfun: "sum",
+            },
+          },
+        },
+        {
+          total_rows: 1,
+          total_pages: 1,
+          page: 1,
+          page_size: 50,
+        },
       );
     });
   });
 
   it("shows the backend error message when the pivot request fails", async () => {
     const user = userEvent.setup();
+
     transformProject.mockRejectedValue({
-      response: { data: { detail: "Unable to build pivot table." } },
+      response: {
+        data: {
+          detail: "Unable to build pivot table.",
+        },
+      },
     });
 
     renderForm();
+
     await user.selectOptions(screen.getByLabelText("Index"), "region");
+
     const [columnSelect, valueSelect] = getColumnSelects();
+
     await user.selectOptions(columnSelect, "created_at");
+
     await user.selectOptions(valueSelect, "amount");
-    await user.click(screen.getByRole("button", { name: "Submit" }));
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Submit",
+      }),
+    );
 
     await waitFor(() => {
       expect(screen.getByText("Unable to build pivot table.")).toBeInTheDocument();
     });
+
     expect(mockEnterPreviewMode).not.toHaveBeenCalled();
   });
 
   it("disables Submit and displays Save Changes in preview mode", () => {
-    renderForm({ isPreviewMode: true });
+    renderForm({
+      isPreviewMode: true,
+    });
 
-    expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
-    expect(screen.getByRole("button", { name: "Save Changes" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: "Submit",
+      }),
+    ).toBeDisabled();
+
+    expect(
+      screen.getByRole("button", {
+        name: "Save Changes",
+      }),
+    ).toBeInTheDocument();
   });
 
   it("calls the preview save handler when Save Changes is clicked", async () => {
     const user = userEvent.setup();
-    renderForm({ isPreviewMode: true });
 
-    await user.click(screen.getByRole("button", { name: "Save Changes" }));
+    renderForm({
+      isPreviewMode: true,
+    });
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Save Changes",
+      }),
+    );
 
     expect(mockHandleSave).toHaveBeenCalledTimes(1);
   });
 
   it("shows saving state while preview changes are being saved", () => {
-    renderForm({ isPreviewMode: true, saving: true });
+    renderForm({
+      isPreviewMode: true,
+      saving: true,
+    });
 
-    expect(screen.getByRole("button", { name: "Saving..." })).toBeDisabled();
+    expect(
+      screen.getByRole("button", {
+        name: "Saving...",
+      }),
+    ).toBeDisabled();
+
+    expect(
+      screen.getByRole("button", {
+        name: "Submit",
+      }),
+    ).toBeDisabled();
   });
 
   it("cancels preview mode when Cancel is clicked during preview", async () => {
     const user = userEvent.setup();
     const onClose = vi.fn();
-    renderForm({ isPreviewMode: true, onClose });
 
-    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    renderForm({
+      isPreviewMode: true,
+      onClose,
+    });
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Cancel",
+      }),
+    );
 
     expect(mockCancelPreview).toHaveBeenCalledTimes(1);
+
     expect(onClose).not.toHaveBeenCalled();
   });
 
   it("closes the form when Cancel is clicked outside preview mode", async () => {
     const user = userEvent.setup();
     const onClose = vi.fn();
-    renderForm({ isPreviewMode: false, onClose });
 
-    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    renderForm({
+      isPreviewMode: false,
+      onClose,
+    });
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Cancel",
+      }),
+    );
 
     expect(onClose).toHaveBeenCalledTimes(1);
     expect(mockCancelPreview).not.toHaveBeenCalled();

--- a/dataloom-frontend/src/test/PreviewWorkflow.test.jsx
+++ b/dataloom-frontend/src/test/PreviewWorkflow.test.jsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import FilterForm from "../Components/forms/FilterForm";
 import TrimWhitespaceForm from "../Components/forms/TrimWhitespaceForm";
@@ -10,7 +10,11 @@ vi.mock("../api", () => ({
 
 const mockContext = {
   columns: ["City", "Amount", "Date"],
-  dtypes: { City: "string", Amount: "float", Date: "date" },
+  dtypes: {
+    City: "string",
+    Amount: "float",
+    Date: "date",
+  },
   columnOrder: [0, 1, 2],
   updateData: vi.fn(),
   enterPreviewMode: vi.fn(),
@@ -27,34 +31,48 @@ vi.mock("../context/ProjectContext", () => ({
 }));
 
 vi.mock("../context/HistoryRefreshContext", () => ({
-  useHistoryRefresh: () => ({ refreshLogs: vi.fn(), refreshCheckpoints: vi.fn() }),
+  useHistoryRefresh: () => ({
+    refreshLogs: vi.fn(),
+    refreshCheckpoints: vi.fn(),
+  }),
 }));
 
 beforeEach(() => {
   vi.resetAllMocks();
+
   mockContext.columnOrder = [0, 1, 2];
   mockContext.isPreviewMode = false;
   mockContext.pendingTransform = null;
+  mockContext.pageSize = 50;
 });
 
 describe("PreviewWorkflow — updateData propagation", () => {
-  it("calls enterPreviewMode with dtypes after successful transform", async () => {
+  it("calls enterPreviewMode with dtypes and pagination metadata after successful transform", async () => {
     transformProject.mockResolvedValueOnce({
       columns: ["City", "Amount"],
       rows: [["Paris", "300"]],
-      dtypes: { City: "string", Amount: "float" },
+      dtypes: {
+        City: "string",
+        Amount: "float",
+      },
+      total_rows: 1,
+      total_pages: 1,
+      page: 1,
+      page_size: 50,
     });
 
     const { getByTestId, getByText } = render(<FilterForm projectId="proj-1" onClose={vi.fn()} />);
 
-    // Fill required fields
-    // ColumnSelect renders a combobox button; open it and pick a column
-    const { fireEvent } = await import("@testing-library/react");
     fireEvent.click(getByTestId("filter-column"));
     fireEvent.click(getByText("City"));
 
     const valueInput = getByTestId("filter-value");
-    fireEvent.change(valueInput, { target: { value: "Paris" } });
+
+    fireEvent.change(valueInput, {
+      target: {
+        value: "Paris",
+      },
+    });
 
     fireEvent.click(getByText("Apply Filter"));
 
@@ -62,7 +80,10 @@ describe("PreviewWorkflow — updateData propagation", () => {
       expect(mockContext.enterPreviewMode).toHaveBeenCalledWith(
         ["City", "Amount"],
         [["Paris", "300"]],
-        { City: "string", Amount: "float" }, // <-- This was the missing argument causing the test to fail previously
+        {
+          City: "string",
+          Amount: "float",
+        },
         {
           payload: {
             operation_type: "filter",
@@ -74,6 +95,12 @@ describe("PreviewWorkflow — updateData propagation", () => {
           },
           projectId: "proj-1",
         },
+        {
+          total_rows: 1,
+          total_pages: 1,
+          page: 1,
+          page_size: 50,
+        },
       );
     });
   });
@@ -83,9 +110,13 @@ describe("PreviewWorkflow — updateData propagation", () => {
 
     const { getByTestId, getByText } = render(<FilterForm projectId="proj-1" onClose={vi.fn()} />);
 
-    const { fireEvent } = await import("@testing-library/react");
     const valueInput = getByTestId("filter-value");
-    fireEvent.change(valueInput, { target: { value: "Paris" } });
+
+    fireEvent.change(valueInput, {
+      target: {
+        value: "Paris",
+      },
+    });
 
     fireEvent.click(getByText("Apply Filter"));
 
@@ -96,18 +127,21 @@ describe("PreviewWorkflow — updateData propagation", () => {
 });
 
 describe("PreviewWorkflow — Newly migrated forms (TrimWhitespaceForm)", () => {
-  it("calls enterPreviewMode on apply", async () => {
+  it("calls enterPreviewMode with dtypes and pagination metadata on apply", async () => {
     transformProject.mockResolvedValueOnce({
       columns: ["City"],
       rows: [["Paris"]],
-      dtypes: { City: "string" },
+      dtypes: {
+        City: "string",
+      },
+      total_rows: 1,
+      total_pages: 1,
+      page: 1,
+      page_size: 50,
     });
 
     const { getByText } = render(<TrimWhitespaceForm projectId="proj-1" onClose={vi.fn()} />);
 
-    const { fireEvent } = await import("@testing-library/react");
-
-    // Select column (City) - it's a select button
     fireEvent.click(getByText("Select column..."));
     fireEvent.click(getByText("City"));
 
@@ -117,7 +151,9 @@ describe("PreviewWorkflow — Newly migrated forms (TrimWhitespaceForm)", () => 
       expect(mockContext.enterPreviewMode).toHaveBeenCalledWith(
         ["City"],
         [["Paris"]],
-        { City: "string" },
+        {
+          City: "string",
+        },
         {
           payload: {
             operation_type: "trimWhitespace",
@@ -127,20 +163,27 @@ describe("PreviewWorkflow — Newly migrated forms (TrimWhitespaceForm)", () => 
           },
           projectId: "proj-1",
         },
+        {
+          total_rows: 1,
+          total_pages: 1,
+          page: 1,
+          page_size: 50,
+        },
       );
     });
   });
 
   it("calls cancelPreview and stays open when cancelled in preview mode", async () => {
     mockContext.isPreviewMode = true;
+
     const onCloseMock = vi.fn();
 
     const { getByText } = render(<TrimWhitespaceForm projectId="proj-1" onClose={onCloseMock} />);
 
-    const { fireEvent } = await import("@testing-library/react");
     fireEvent.click(getByText("Cancel"));
 
     expect(mockContext.cancelPreview).toHaveBeenCalled();
+
     expect(onCloseMock).not.toHaveBeenCalled();
   });
 });

--- a/dataloom-frontend/src/test/SampleRowsForm.test.jsx
+++ b/dataloom-frontend/src/test/SampleRowsForm.test.jsx
@@ -23,8 +23,14 @@ const mockEnterPreviewMode = vi.fn();
 const mockCancelPreview = vi.fn();
 const mockHandleSave = vi.fn();
 
-const renderForm = ({ isPreviewMode = false, onClose = vi.fn(), saving = false } = {}) => {
+const renderForm = ({
+  isPreviewMode = false,
+  onClose = vi.fn(),
+  saving = false,
+  pageSize = 50,
+} = {}) => {
   useProjectContext.mockReturnValue({
+    pageSize,
     isPreviewMode,
     enterPreviewMode: mockEnterPreviewMode,
     cancelPreview: mockCancelPreview,
@@ -48,11 +54,13 @@ describe("SampleRowsForm", () => {
     transformProject.mockResolvedValue({
       columns: ["amount"],
       rows: [["100"]],
-      dtypes: { amount: "integer" },
+      dtypes: {
+        amount: "integer",
+      },
     });
   });
 
-  it("renders sample size, random seed inputs and buttons", () => {
+  it("renders sample size, random seed inputs, and buttons", () => {
     renderForm();
 
     expect(screen.getByPlaceholderText("e.g., 100")).toBeInTheDocument();
@@ -69,6 +77,7 @@ describe("SampleRowsForm", () => {
 
   it("shows an error for a non-positive sample size", async () => {
     const user = userEvent.setup();
+
     renderForm();
 
     const sampleSizeInput = screen.getByPlaceholderText("e.g., 100");
@@ -84,6 +93,7 @@ describe("SampleRowsForm", () => {
 
   it("shows an error for a random seed outside the valid range", async () => {
     const user = userEvent.setup();
+
     renderForm();
 
     const sampleSizeInput = screen.getByPlaceholderText("e.g., 100");
@@ -103,30 +113,49 @@ describe("SampleRowsForm", () => {
 
   it("submits with an explicit random seed", async () => {
     const user = userEvent.setup();
+
     renderForm();
 
     await user.type(screen.getByPlaceholderText("e.g., 100"), "10");
     await user.type(screen.getByPlaceholderText("e.g., 42"), "42");
-    await user.click(screen.getByRole("button", { name: "Apply Sample" }));
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Apply Sample",
+      }),
+    );
 
     await waitFor(() => {
       expect(transformProject).toHaveBeenCalledWith(
         "project-123",
         {
           operation_type: SAMPLE_ROWS,
-          sample_params: { sample_size: 10, random_seed: 42 },
+          sample_params: {
+            sample_size: 10,
+            random_seed: 42,
+          },
         },
-        { preview: true },
+        {
+          preview: true,
+          page: 1,
+          pageSize: 50,
+        },
       );
     });
   });
 
   it("auto-generates a random seed when none is provided", async () => {
     const user = userEvent.setup();
+
     renderForm();
 
     await user.type(screen.getByPlaceholderText("e.g., 100"), "10");
-    await user.click(screen.getByRole("button", { name: "Apply Sample" }));
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Apply Sample",
+      }),
+    );
 
     await waitFor(() => {
       expect(transformProject).toHaveBeenCalledWith(
@@ -138,78 +167,167 @@ describe("SampleRowsForm", () => {
             random_seed: expect.any(Number),
           },
         },
-        { preview: true },
+        {
+          preview: true,
+          page: 1,
+          pageSize: 50,
+        },
       );
     });
 
     const [, payload] = transformProject.mock.calls[0];
+
     expect(payload.sample_params.random_seed).toBeGreaterThanOrEqual(0);
     expect(payload.sample_params.random_seed).toBeLessThanOrEqual(4294967295);
   });
 
   it("enters preview mode using the transformation response", async () => {
     const user = userEvent.setup();
-    const response = { columns: ["amount"], rows: [[100]], dtypes: { amount: "integer" } };
+
+    const response = {
+      columns: ["amount"],
+      rows: [[100]],
+      dtypes: {
+        amount: "integer",
+      },
+      total_rows: 1,
+      total_pages: 1,
+      page: 1,
+      page_size: 50,
+    };
+
     transformProject.mockResolvedValue(response);
 
     renderForm();
+
     await user.type(screen.getByPlaceholderText("e.g., 100"), "10");
-    await user.click(screen.getByRole("button", { name: "Apply Sample" }));
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Apply Sample",
+      }),
+    );
 
     await waitFor(() => {
       expect(mockEnterPreviewMode).toHaveBeenCalledWith(
         response.columns,
         response.rows,
         response.dtypes,
-        expect.objectContaining({ projectId: "project-123" }),
+        {
+          projectId: "project-123",
+          payload: {
+            operation_type: SAMPLE_ROWS,
+            sample_params: {
+              sample_size: 10,
+              random_seed: expect.any(Number),
+            },
+          },
+        },
+        {
+          total_rows: 1,
+          total_pages: 1,
+          page: 1,
+          page_size: 50,
+        },
       );
     });
   });
 
   it("shows the backend error message when the request fails", async () => {
     const user = userEvent.setup();
+
     transformProject.mockRejectedValue({
-      response: { data: { detail: "Sample size exceeds row count." } },
+      response: {
+        data: {
+          detail: "Sample size exceeds row count.",
+        },
+      },
     });
 
     renderForm();
+
     await user.type(screen.getByPlaceholderText("e.g., 100"), "10");
-    await user.click(screen.getByRole("button", { name: "Apply Sample" }));
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Apply Sample",
+      }),
+    );
 
     await waitFor(() => {
       expect(screen.getByText("Sample size exceeds row count.")).toBeInTheDocument();
     });
+
     expect(mockEnterPreviewMode).not.toHaveBeenCalled();
   });
 
   it("disables Apply Sample and displays Save Changes in preview mode", () => {
-    renderForm({ isPreviewMode: true });
+    renderForm({
+      isPreviewMode: true,
+    });
 
-    expect(screen.getByRole("button", { name: "Apply Sample" })).toBeDisabled();
-    expect(screen.getByRole("button", { name: "Save Changes" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: "Apply Sample",
+      }),
+    ).toBeDisabled();
+
+    expect(
+      screen.getByRole("button", {
+        name: "Save Changes",
+      }),
+    ).toBeInTheDocument();
   });
 
   it("calls the preview save handler when Save Changes is clicked", async () => {
     const user = userEvent.setup();
-    renderForm({ isPreviewMode: true });
 
-    await user.click(screen.getByRole("button", { name: "Save Changes" }));
+    renderForm({
+      isPreviewMode: true,
+    });
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Save Changes",
+      }),
+    );
 
     expect(mockHandleSave).toHaveBeenCalledTimes(1);
   });
 
   it("shows saving state while preview changes are being saved", () => {
-    renderForm({ isPreviewMode: true, saving: true });
+    renderForm({
+      isPreviewMode: true,
+      saving: true,
+    });
 
-    expect(screen.getByRole("button", { name: "Saving..." })).toBeDisabled();
+    expect(
+      screen.getByRole("button", {
+        name: "Saving...",
+      }),
+    ).toBeDisabled();
+
+    expect(
+      screen.getByRole("button", {
+        name: "Apply Sample",
+      }),
+    ).toBeDisabled();
   });
 
   it("cancels preview mode when Cancel is clicked during preview", async () => {
     const user = userEvent.setup();
     const onClose = vi.fn();
-    renderForm({ isPreviewMode: true, onClose });
 
-    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    renderForm({
+      isPreviewMode: true,
+      onClose,
+    });
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Cancel",
+      }),
+    );
 
     expect(mockCancelPreview).toHaveBeenCalledTimes(1);
     expect(onClose).not.toHaveBeenCalled();
@@ -218,9 +336,17 @@ describe("SampleRowsForm", () => {
   it("closes the form when Cancel is clicked outside preview mode", async () => {
     const user = userEvent.setup();
     const onClose = vi.fn();
-    renderForm({ isPreviewMode: false, onClose });
 
-    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    renderForm({
+      isPreviewMode: false,
+      onClose,
+    });
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Cancel",
+      }),
+    );
 
     expect(onClose).toHaveBeenCalledTimes(1);
     expect(mockCancelPreview).not.toHaveBeenCalled();

--- a/dataloom-frontend/src/test/SortForm.test.jsx
+++ b/dataloom-frontend/src/test/SortForm.test.jsx
@@ -53,6 +53,7 @@ const mockHandleSave = vi.fn();
 const renderForm = ({ isPreviewMode = false, onClose = vi.fn(), saving = false } = {}) => {
   useProjectContext.mockReturnValue({
     isPreviewMode,
+    pageSize: 50,
     enterPreviewMode: mockEnterPreviewMode,
     cancelPreview: mockCancelPreview,
   });
@@ -162,7 +163,11 @@ describe("SortForm", () => {
             criteria: [{ column: "amount", ascending: false }],
           },
         },
-        { preview: true },
+        {
+          preview: true,
+          page: 1,
+          pageSize: 50,
+        },
       );
     });
   });
@@ -188,14 +193,27 @@ describe("SortForm", () => {
             ],
           },
         },
-        { preview: true },
+        {
+          preview: true,
+          page: 1,
+          pageSize: 50,
+        },
       );
     });
   });
 
   it("enters preview mode using the transformation response", async () => {
     const user = userEvent.setup();
-    const response = { columns: ["amount"], rows: [[100]], dtypes: { amount: "integer" } };
+    const response = {
+      columns: ["amount"],
+      rows: [[100]],
+      dtypes: { amount: "integer" },
+      total_rows: 1,
+      total_pages: 1,
+      page: 1,
+      page_size: 50,
+    };
+
     transformProject.mockResolvedValue(response);
 
     renderForm();
@@ -208,6 +226,12 @@ describe("SortForm", () => {
         response.rows,
         response.dtypes,
         expect.objectContaining({ projectId: "project-123" }),
+        {
+          total_rows: response.total_rows,
+          total_pages: response.total_pages,
+          page: response.page,
+          page_size: response.page_size,
+        },
       );
     });
   });
@@ -228,7 +252,15 @@ describe("SortForm", () => {
 
     expect(screen.getByRole("button", { name: "Applying..." })).toBeDisabled();
 
-    resolveTransform({ columns: [], rows: [], dtypes: {} });
+    resolveTransform({
+      columns: [],
+      rows: [],
+      dtypes: {},
+      total_rows: 0,
+      total_pages: 1,
+      page: 1,
+      page_size: 50,
+    });
 
     await waitFor(() => {
       expect(screen.getByRole("button", { name: "Apply Sort" })).not.toBeDisabled();
@@ -294,5 +326,31 @@ describe("SortForm", () => {
 
     expect(onClose).toHaveBeenCalledTimes(1);
     expect(mockCancelPreview).not.toHaveBeenCalled();
+  });
+
+  it("requests the first preview page using the current page size", async () => {
+    const user = userEvent.setup();
+
+    renderForm();
+
+    await user.selectOptions(screen.getByTestId("sort-column"), "amount");
+    await user.click(screen.getByRole("button", { name: "Apply Sort" }));
+
+    await waitFor(() => {
+      expect(transformProject).toHaveBeenCalledWith(
+        "project-123",
+        {
+          operation_type: SORT,
+          sort_params: {
+            criteria: [{ column: "amount", ascending: true }],
+          },
+        },
+        {
+          preview: true,
+          page: 1,
+          pageSize: 50,
+        },
+      );
+    });
   });
 });

--- a/dataloom-frontend/src/test/StringReplaceForm.test.jsx
+++ b/dataloom-frontend/src/test/StringReplaceForm.test.jsx
@@ -33,8 +33,16 @@ const mockEnterPreviewMode = vi.fn();
 const mockCancelPreview = vi.fn();
 const mockHandleSave = vi.fn();
 
-const renderForm = ({ isPreviewMode = false, onClose = vi.fn(), saving = false } = {}) => {
+const renderForm = ({
+  isPreviewMode = false,
+  onClose = vi.fn(),
+  saving = false,
+  columns = ["amount", "created_at"],
+  pageSize = 50,
+} = {}) => {
   useProjectContext.mockReturnValue({
+    columns,
+    pageSize,
     isPreviewMode,
     enterPreviewMode: mockEnterPreviewMode,
     cancelPreview: mockCancelPreview,
@@ -58,40 +66,58 @@ describe("StringReplaceForm", () => {
     transformProject.mockResolvedValue({
       columns: ["amount"],
       rows: [["100"]],
-      dtypes: { amount: "integer" },
+      dtypes: {
+        amount: "integer",
+      },
     });
   });
 
-  it("renders column, find, and replace controls", () => {
+  it("renders column, find, and replace controls with buttons", () => {
     renderForm();
 
     expect(screen.getByLabelText("Column")).toBeInTheDocument();
     expect(screen.getByPlaceholderText("Text to find")).toBeInTheDocument();
     expect(screen.getByPlaceholderText("Replacement text")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Apply" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
   });
 
   it("shows a validation error when no column is selected", async () => {
     const user = userEvent.setup();
+
     renderForm();
 
     await user.type(screen.getByPlaceholderText("Text to find"), "foo");
-    await user.click(screen.getByRole("button", { name: "Apply" }));
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Apply",
+      }),
+    );
 
     await waitFor(() => {
       expect(screen.getByText("Please select a column.")).toBeInTheDocument();
     });
+
     expect(transformProject).not.toHaveBeenCalled();
   });
 
   it("submits column, find value, and replace value", async () => {
     const user = userEvent.setup();
+
     renderForm();
 
     await user.selectOptions(screen.getByLabelText("Column"), "amount");
+
     await user.type(screen.getByPlaceholderText("Text to find"), "foo");
+
     await user.type(screen.getByPlaceholderText("Replacement text"), "bar");
-    await user.click(screen.getByRole("button", { name: "Apply" }));
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Apply",
+      }),
+    );
 
     await waitFor(() => {
       expect(transformProject).toHaveBeenCalledWith(
@@ -104,18 +130,29 @@ describe("StringReplaceForm", () => {
             replace_value: "bar",
           },
         },
-        { preview: true },
+        {
+          preview: true,
+          page: 1,
+          pageSize: 50,
+        },
       );
     });
   });
 
   it("allows an empty replace value", async () => {
     const user = userEvent.setup();
+
     renderForm();
 
     await user.selectOptions(screen.getByLabelText("Column"), "amount");
+
     await user.type(screen.getByPlaceholderText("Text to find"), "foo");
-    await user.click(screen.getByRole("button", { name: "Apply" }));
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Apply",
+      }),
+    );
 
     await waitFor(() => {
       expect(transformProject).toHaveBeenCalledWith(
@@ -128,17 +165,32 @@ describe("StringReplaceForm", () => {
             replace_value: "",
           },
         },
-        { preview: true },
+        {
+          preview: true,
+          page: 1,
+          pageSize: 50,
+        },
       );
     });
   });
 
   it("enters preview mode using the transformation response", async () => {
     const user = userEvent.setup();
-    const response = { columns: ["amount"], rows: [[100]], dtypes: { amount: "integer" } };
+
+    const response = {
+      columns: ["amount"],
+      rows: [[100]],
+      dtypes: { amount: "integer" },
+      total_rows: 1,
+      total_pages: 1,
+      page: 1,
+      page_size: 50,
+    };
+
     transformProject.mockResolvedValue(response);
 
     renderForm();
+
     await user.selectOptions(screen.getByLabelText("Column"), "amount");
     await user.type(screen.getByPlaceholderText("Text to find"), "foo");
     await user.click(screen.getByRole("button", { name: "Apply" }));
@@ -148,14 +200,24 @@ describe("StringReplaceForm", () => {
         response.columns,
         response.rows,
         response.dtypes,
-        expect.objectContaining({ projectId: "project-123" }),
+        expect.objectContaining({
+          projectId: "project-123",
+        }),
+        {
+          total_rows: 1,
+          total_pages: 1,
+          page: 1,
+          page_size: 50,
+        },
       );
     });
   });
 
   it("shows applying state while the request is pending", async () => {
     const user = userEvent.setup();
+
     let resolveTransform;
+
     transformProject.mockImplementation(
       () =>
         new Promise((resolve) => {
@@ -164,64 +226,135 @@ describe("StringReplaceForm", () => {
     );
 
     renderForm();
+
     await user.selectOptions(screen.getByLabelText("Column"), "amount");
+
     await user.type(screen.getByPlaceholderText("Text to find"), "foo");
-    await user.click(screen.getByRole("button", { name: "Apply" }));
 
-    expect(screen.getByRole("button", { name: "Applying..." })).toBeDisabled();
+    await user.click(
+      screen.getByRole("button", {
+        name: "Apply",
+      }),
+    );
 
-    resolveTransform({ columns: [], rows: [], dtypes: {} });
+    expect(
+      screen.getByRole("button", {
+        name: "Applying...",
+      }),
+    ).toBeDisabled();
+
+    resolveTransform({
+      columns: [],
+      rows: [],
+      dtypes: {},
+    });
 
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: "Apply" })).not.toBeDisabled();
+      expect(
+        screen.getByRole("button", {
+          name: "Apply",
+        }),
+      ).not.toBeDisabled();
     });
   });
 
   it("shows the backend error message when the request fails", async () => {
     const user = userEvent.setup();
+
     transformProject.mockRejectedValue({
-      response: { data: { detail: "Unable to replace text." } },
+      response: {
+        data: {
+          detail: "Unable to replace text.",
+        },
+      },
     });
 
     renderForm();
+
     await user.selectOptions(screen.getByLabelText("Column"), "amount");
+
     await user.type(screen.getByPlaceholderText("Text to find"), "foo");
-    await user.click(screen.getByRole("button", { name: "Apply" }));
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Apply",
+      }),
+    );
 
     await waitFor(() => {
       expect(screen.getByText("Unable to replace text.")).toBeInTheDocument();
     });
+
     expect(mockEnterPreviewMode).not.toHaveBeenCalled();
   });
 
   it("disables Apply and displays Save Changes in preview mode", () => {
-    renderForm({ isPreviewMode: true });
+    renderForm({
+      isPreviewMode: true,
+    });
 
-    expect(screen.getByRole("button", { name: "Apply" })).toBeDisabled();
-    expect(screen.getByRole("button", { name: "Save Changes" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: "Apply",
+      }),
+    ).toBeDisabled();
+
+    expect(
+      screen.getByRole("button", {
+        name: "Save Changes",
+      }),
+    ).toBeInTheDocument();
   });
 
   it("calls the preview save handler when Save Changes is clicked", async () => {
     const user = userEvent.setup();
-    renderForm({ isPreviewMode: true });
 
-    await user.click(screen.getByRole("button", { name: "Save Changes" }));
+    renderForm({
+      isPreviewMode: true,
+    });
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Save Changes",
+      }),
+    );
 
     expect(mockHandleSave).toHaveBeenCalledTimes(1);
   });
 
   it("shows saving state while preview changes are being saved", () => {
-    renderForm({ isPreviewMode: true, saving: true });
+    renderForm({
+      isPreviewMode: true,
+      saving: true,
+    });
 
-    expect(screen.getByRole("button", { name: "Saving..." })).toBeDisabled();
+    expect(
+      screen.getByRole("button", {
+        name: "Saving...",
+      }),
+    ).toBeDisabled();
+
+    expect(
+      screen.getByRole("button", {
+        name: "Apply",
+      }),
+    ).toBeDisabled();
   });
 
   it("cancels preview mode when Cancel is clicked during preview", async () => {
     const user = userEvent.setup();
     const onClose = vi.fn();
-    renderForm({ isPreviewMode: true, onClose });
 
-    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    renderForm({
+      isPreviewMode: true,
+      onClose,
+    });
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Cancel",
+      }),
+    );
 
     expect(mockCancelPreview).toHaveBeenCalledTimes(1);
     expect(onClose).not.toHaveBeenCalled();
@@ -230,9 +363,17 @@ describe("StringReplaceForm", () => {
   it("closes the form when Cancel is clicked outside preview mode", async () => {
     const user = userEvent.setup();
     const onClose = vi.fn();
-    renderForm({ isPreviewMode: false, onClose });
 
-    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    renderForm({
+      isPreviewMode: false,
+      onClose,
+    });
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Cancel",
+      }),
+    );
 
     expect(onClose).toHaveBeenCalledTimes(1);
     expect(mockCancelPreview).not.toHaveBeenCalled();

--- a/dataloom-frontend/src/test/TrimWhitespaceForm.test.jsx
+++ b/dataloom-frontend/src/test/TrimWhitespaceForm.test.jsx
@@ -39,10 +39,12 @@ const renderForm = ({
   isPreviewMode = false,
   onClose = vi.fn(),
   saving = false,
+  pageSize = 50,
   columns = ["amount", "created_at"],
 } = {}) => {
   useProjectContext.mockReturnValue({
     columns,
+    pageSize,
     isPreviewMode,
     enterPreviewMode: mockEnterPreviewMode,
     cancelPreview: mockCancelPreview,
@@ -74,9 +76,11 @@ describe("TrimWhitespaceForm", () => {
     renderForm();
 
     const select = screen.getByLabelText("Column");
+
     expect(select).toBeInTheDocument();
     expect(screen.getByText("All string columns")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Apply" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
   });
 
   it("shows a validation error when no column is selected", async () => {
@@ -88,6 +92,7 @@ describe("TrimWhitespaceForm", () => {
     await waitFor(() => {
       expect(screen.getByText("Please select a column.")).toBeInTheDocument();
     });
+
     expect(transformProject).not.toHaveBeenCalled();
   });
 
@@ -103,9 +108,15 @@ describe("TrimWhitespaceForm", () => {
         "project-123",
         {
           operation_type: TRIM_WHITESPACE,
-          trim_whitespace_params: { column: "amount" },
+          trim_whitespace_params: {
+            column: "amount",
+          },
         },
-        { preview: true },
+        {
+          preview: true,
+          page: 1,
+          pageSize: 50,
+        },
       );
     });
   });
@@ -115,6 +126,7 @@ describe("TrimWhitespaceForm", () => {
     renderForm();
 
     await user.selectOptions(screen.getByLabelText("Column"), "All string columns");
+
     await user.click(screen.getByRole("button", { name: "Apply" }));
 
     await waitFor(() => {
@@ -122,19 +134,36 @@ describe("TrimWhitespaceForm", () => {
         "project-123",
         {
           operation_type: TRIM_WHITESPACE,
-          trim_whitespace_params: { column: "All string columns" },
+          trim_whitespace_params: {
+            column: "All string columns",
+          },
         },
-        { preview: true },
+        {
+          preview: true,
+          page: 1,
+          pageSize: 50,
+        },
       );
     });
   });
 
   it("enters preview mode using the transformation response", async () => {
     const user = userEvent.setup();
-    const response = { columns: ["amount"], rows: [[100]], dtypes: { amount: "integer" } };
+
+    const response = {
+      columns: ["amount"],
+      rows: [[100]],
+      dtypes: { amount: "integer" },
+      total_rows: 1,
+      total_pages: 1,
+      page: 1,
+      page_size: 50,
+    };
+
     transformProject.mockResolvedValue(response);
 
     renderForm();
+
     await user.selectOptions(screen.getByLabelText("Column"), "amount");
     await user.click(screen.getByRole("button", { name: "Apply" }));
 
@@ -143,14 +172,30 @@ describe("TrimWhitespaceForm", () => {
         response.columns,
         response.rows,
         response.dtypes,
-        expect.objectContaining({ projectId: "project-123" }),
+        expect.objectContaining({
+          projectId: "project-123",
+          payload: {
+            operation_type: TRIM_WHITESPACE,
+            trim_whitespace_params: {
+              column: "amount",
+            },
+          },
+        }),
+        {
+          total_rows: 1,
+          total_pages: 1,
+          page: 1,
+          page_size: 50,
+        },
       );
     });
   });
 
   it("shows applying state while the request is pending", async () => {
     const user = userEvent.setup();
+
     let resolveTransform;
+
     transformProject.mockImplementation(
       () =>
         new Promise((resolve) => {
@@ -159,12 +204,17 @@ describe("TrimWhitespaceForm", () => {
     );
 
     renderForm();
+
     await user.selectOptions(screen.getByLabelText("Column"), "amount");
     await user.click(screen.getByRole("button", { name: "Apply" }));
 
     expect(screen.getByRole("button", { name: "Applying..." })).toBeDisabled();
 
-    resolveTransform({ columns: [], rows: [], dtypes: {} });
+    resolveTransform({
+      columns: [],
+      rows: [],
+      dtypes: {},
+    });
 
     await waitFor(() => {
       expect(screen.getByRole("button", { name: "Apply" })).not.toBeDisabled();
@@ -173,17 +223,24 @@ describe("TrimWhitespaceForm", () => {
 
   it("shows the backend error message when the request fails", async () => {
     const user = userEvent.setup();
+
     transformProject.mockRejectedValue({
-      response: { data: { detail: "Unable to trim whitespace." } },
+      response: {
+        data: {
+          detail: "Unable to trim whitespace.",
+        },
+      },
     });
 
     renderForm();
+
     await user.selectOptions(screen.getByLabelText("Column"), "amount");
     await user.click(screen.getByRole("button", { name: "Apply" }));
 
     await waitFor(() => {
       expect(screen.getByText("Unable to trim whitespace.")).toBeInTheDocument();
     });
+
     expect(mockEnterPreviewMode).not.toHaveBeenCalled();
   });
 
@@ -196,6 +253,7 @@ describe("TrimWhitespaceForm", () => {
 
   it("calls the preview save handler when Save Changes is clicked", async () => {
     const user = userEvent.setup();
+
     renderForm({ isPreviewMode: true });
 
     await user.click(screen.getByRole("button", { name: "Save Changes" }));
@@ -204,15 +262,23 @@ describe("TrimWhitespaceForm", () => {
   });
 
   it("shows saving state while preview changes are being saved", () => {
-    renderForm({ isPreviewMode: true, saving: true });
+    renderForm({
+      isPreviewMode: true,
+      saving: true,
+    });
 
     expect(screen.getByRole("button", { name: "Saving..." })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Apply" })).toBeDisabled();
   });
 
   it("cancels preview mode when Cancel is clicked during preview", async () => {
     const user = userEvent.setup();
     const onClose = vi.fn();
-    renderForm({ isPreviewMode: true, onClose });
+
+    renderForm({
+      isPreviewMode: true,
+      onClose,
+    });
 
     await user.click(screen.getByRole("button", { name: "Cancel" }));
 
@@ -223,11 +289,86 @@ describe("TrimWhitespaceForm", () => {
   it("closes the form when Cancel is clicked outside preview mode", async () => {
     const user = userEvent.setup();
     const onClose = vi.fn();
-    renderForm({ isPreviewMode: false, onClose });
+
+    renderForm({
+      isPreviewMode: false,
+      onClose,
+    });
 
     await user.click(screen.getByRole("button", { name: "Cancel" }));
 
     expect(onClose).toHaveBeenCalledTimes(1);
     expect(mockCancelPreview).not.toHaveBeenCalled();
+  });
+
+  it("does not call enterPreviewMode when the component unmounts during loading", async () => {
+    const user = userEvent.setup();
+
+    let resolveTransform;
+
+    transformProject.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveTransform = resolve;
+        }),
+    );
+
+    const { unmount } = renderForm();
+
+    await user.selectOptions(screen.getByLabelText("Column"), "amount");
+    await user.click(screen.getByRole("button", { name: "Apply" }));
+
+    unmount();
+
+    resolveTransform({
+      columns: [],
+      rows: [],
+      dtypes: {},
+    });
+
+    await Promise.resolve();
+
+    expect(mockEnterPreviewMode).not.toHaveBeenCalled();
+  });
+
+  it("allows re-submit after a cancelled in-flight request", async () => {
+    const user = userEvent.setup();
+
+    let resolveTransform;
+
+    transformProject.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveTransform = resolve;
+        }),
+    );
+
+    const { unmount } = renderForm();
+
+    await user.selectOptions(screen.getByLabelText("Column"), "amount");
+    await user.click(screen.getByRole("button", { name: "Apply" }));
+
+    unmount();
+
+    resolveTransform({
+      columns: [],
+      rows: [],
+      dtypes: {},
+    });
+
+    transformProject.mockResolvedValue({
+      columns: [],
+      rows: [],
+      dtypes: {},
+    });
+
+    renderForm();
+
+    await user.selectOptions(screen.getByLabelText("Column"), "amount");
+    await user.click(screen.getByRole("button", { name: "Apply" }));
+
+    await waitFor(() => {
+      expect(transformProject).toHaveBeenCalledTimes(2);
+    });
   });
 });


### PR DESCRIPTION
## Description

Implemented end-to-end preview pagination support for data transformation operations.

- Added pagination support to transformation preview requests.
- Updated transformation forms to pass `page` and `pageSize` when requesting preview data.
- Added pagination metadata handling including:
  - `total_rows`
  - `total_pages`
  - `page`
  - `page_size`
- Updated preview mode state to retain pagination metadata alongside the transformation payload.
- Added support for navigating through paginated preview results.
- Updated preview data fetching and state management to handle page changes.
- Updated transformation forms to work consistently with the new paginated preview flow.
- Updated and expanded tests for transformation forms and preview pagination.

Fixes #456 

## Type of Change

- [x] New feature

## How Has This Been Tested?

- [x] Existing tests pass
- [x] New tests added
- [x] Manual testing

Tested the complete preview pagination flow across transformation operations, including:

- Preview requests with `page` and `pageSize`
- Pagination metadata returned from the backend
- Navigating between preview pages
- Preview state updates when changing pages
- Transformation payload persistence during pagination
- Save Changes after previewing paginated results
- Loading and disabled states
- Validation errors
- Backend error handling
- Canceling preview mode
- Component unmount behavior during in-flight requests
- Re-submitting transformations after a cancelled request

## Screenshots (if applicable)

Not applicable.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally