### PR TITLE
feat: add formula columns via sandboxed addFormulaCol transformation

### DIFF
--- a/dataloom-backend/app/schemas.py
+++ b/dataloom-backend/app/schemas.py
@@ -45,6 +45,7 @@ class OperationType(StrEnum):
     sample = "sample"
     stringReplace = "stringReplace"
     addFile = "addFile"
+    addFormulaCol = "addFormulaCol"
 
 
 class DropDup(StrEnum):
@@ -211,6 +212,20 @@ class DropNaParams(BaseModel):
         return v
 
 
+class FormulaColumnParams(BaseModel):
+    """Parameters for adding a computed column from a formula expression."""
+
+    column_name: str = Field(min_length=1, max_length=255)
+    expression: str = Field(min_length=1, max_length=500)
+
+    @field_validator("column_name", "expression")
+    @classmethod
+    def must_not_be_blank(cls, v: str) -> str:
+        if not v or not v.strip():
+            raise ValueError("must not be empty")
+        return v.strip()
+
+
 class StringReplaceParams(BaseModel):
     """Parameters for find-and-replace on a string column."""
 
@@ -333,6 +348,7 @@ class TransformationInput(BaseModel):
     melt_params: MeltParams | None = None
     sample_params: SampleParams | None = None
     string_replace_params: StringReplaceParams | None = None
+    formula_col_params: FormulaColumnParams | None = None
 
 
 class BasicQueryResponse(BaseModel):

--- a/dataloom-backend/app/services/transformation_service.py
+++ b/dataloom-backend/app/services/transformation_service.py
@@ -15,7 +15,7 @@ from app.schemas import FillStrategy, MeltParams, OperationType
 from app.services.append_service import append_dataframes
 from app.utils.logging import get_logger
 from app.utils.pandas_helpers import read_table_safe
-from app.utils.security import validate_query_string
+from app.utils.security import prepare_formula_expression, validate_query_string
 
 logger = get_logger(__name__)
 
@@ -836,6 +836,52 @@ def sample_rows(df: pd.DataFrame, sample_size: int, random_seed: int | None = No
     return sampled.reset_index(drop=True)
 
 
+def add_formula_column(df: pd.DataFrame, column_name: str, expression: str) -> pd.DataFrame:
+    """Add a computed column evaluated from a sandboxed formula expression.
+
+    The expression is validated against an AST allowlist (arithmetic,
+    comparisons, boolean logic, column references, and literals only) before
+    being evaluated with ``DataFrame.eval`` — never raw ``eval()``.
+
+    Args:
+        df: Source DataFrame.
+        column_name: Name for the new computed column.
+        expression: Formula referencing existing columns, e.g. ``price * quantity``.
+
+    Returns:
+        DataFrame with the computed column appended.
+
+    Raises:
+        TransformationError: If the target name is blank, already exists, or the
+            formula cannot be evaluated against the dataset.
+        HTTPException: If the formula fails validation — empty, dangerous,
+            unparseable, or referencing an unknown column.
+    """
+    column_name = column_name.strip()
+    if not column_name:
+        raise TransformationError("New column name must not be empty")
+    if column_name in df.columns:
+        raise TransformationError(f"Column '{column_name}' already exists")
+
+    # The validator returns the exact string to evaluate, with quotes
+    # normalized and non-identifier column names backtick-wrapped, so the
+    # string that passes the AST allowlist is the string that runs.
+    expr = prepare_formula_expression(expression, list(df.columns))
+
+    df = df.copy()
+    try:
+        result = df.eval(expr, local_dict={"__builtins__": {}})
+    except Exception as e:
+        reason = str(e).splitlines()[0][:200] if str(e) else type(e).__name__
+        raise TransformationError(f"Formula could not be evaluated: {reason}") from e
+
+    if isinstance(result, pd.DataFrame):
+        raise TransformationError("Formula must produce a single column of values")
+
+    df[column_name] = result
+    return df
+
+
 def apply_add_file(df: pd.DataFrame, file_path: str) -> pd.DataFrame:
     """Append a stored inventory file's rows onto the DataFrame.
 
@@ -1057,6 +1103,12 @@ TRANSFORMATION_REGISTRY: dict[OperationType, TransformationSpec] = {
         params_field="add_file_params",
         missing_error="Add file operations must use the /files endpoint",
         build_args=lambda d: (d["add_file_params"]["file_path"],),
+    ),
+    OperationType.addFormulaCol: TransformationSpec(
+        func="add_formula_column",
+        params_field="formula_col_params",
+        missing_error="Formula column parameters required",
+        build_args=lambda d: (d["formula_col_params"]["column_name"], d["formula_col_params"]["expression"]),
     ),
 }
 

--- a/dataloom-backend/app/utils/security.py
+++ b/dataloom-backend/app/utils/security.py
@@ -1,5 +1,7 @@
 """Security utilities for file upload validation, path safety, and query sanitization."""
 
+import ast
+import keyword
 import re
 import uuid
 from pathlib import Path
@@ -97,3 +99,192 @@ def validate_query_string(query: str) -> str:
         if re.search(pattern, query, re.IGNORECASE):
             raise HTTPException(status_code=400, detail="Query contains potentially dangerous expressions")
     return query
+
+
+# Node types a formula expression may contain: arithmetic, comparisons, boolean
+# logic, column references, and literals. Function calls, attribute access,
+# subscripts, lambdas, and comprehensions are all absent, so they fail closed.
+_ALLOWED_FORMULA_NODES = (
+    ast.Expression,
+    ast.BinOp,
+    ast.UnaryOp,
+    ast.BoolOp,
+    ast.Compare,
+    ast.Name,
+    ast.Constant,
+    ast.Load,
+    ast.Add,
+    ast.Sub,
+    ast.Mult,
+    ast.Div,
+    ast.FloorDiv,
+    ast.Mod,
+    ast.Pow,
+    ast.USub,
+    ast.UAdd,
+    ast.Not,
+    ast.And,
+    ast.Or,
+    ast.Eq,
+    ast.NotEq,
+    ast.Lt,
+    ast.LtE,
+    ast.Gt,
+    ast.GtE,
+)
+
+
+_FORMULA_PLACEHOLDER_PREFIX = "_dataloom_col_"
+
+# A single-quoted or double-quoted run with no line break and no embedded quote
+# of the same kind. Escapes are not supported: a literal containing a backslash
+# fails to match here and then fails the parse, which is the safe outcome.
+_FORMULA_STRING_LITERAL = re.compile(r"'[^'\n]*'|\"[^\"\n]*\"")
+
+
+def _is_bare_column_name(col: str) -> bool:
+    """Return True when a column name can appear in a formula as a plain Python name.
+
+    Python keywords are excluded: a column called ``True`` or ``None`` is a
+    valid identifier but parses as a constant, so it needs the same
+    placeholder-and-backtick handling as a name containing spaces.
+    """
+    return col.isidentifier() and not keyword.iskeyword(col)
+
+
+def _normalize_string_literal(literal: str) -> str:
+    """Return a string literal in the double-quoted form pandas' parser wants.
+
+    Args:
+        literal: The literal exactly as the user wrote it, quotes included.
+
+    Returns:
+        The same literal, double-quoted.
+
+    Raises:
+        HTTPException: If a single-quoted literal contains a double quote, which
+            cannot survive the conversion.
+    """
+    if literal.startswith('"'):
+        return literal
+    body = literal[1:-1]
+    if '"' in body:
+        raise HTTPException(
+            status_code=400,
+            detail="Formula string literals must not mix quote characters",
+        )
+    return f'"{body}"'
+
+
+def _substitute_column_names(expression: str, quoted_cols: list[str]) -> tuple[str, dict[str, str]]:
+    """Replace non-identifier column names with placeholder identifiers.
+
+    The expression is scanned left to right, so a column name and a string
+    literal can never claim the same characters. Text inside a literal is copied
+    through untouched, which keeps a literal that reads exactly like a column
+    name (``status == "unit cost"``) from turning into a column reference.
+
+    Args:
+        expression: The user-supplied formula.
+        quoted_cols: Non-identifier column names, longest first, so a short name
+            never claims part of a longer one that contains it.
+
+    Returns:
+        The rewritten expression, and a placeholder-to-backticked-name mapping.
+
+    Raises:
+        HTTPException: If a string literal cannot be normalized.
+    """
+    placeholder_by_col: dict[str, str] = {}
+    placeholders: dict[str, str] = {}
+    parts: list[str] = []
+    i = 0
+    while i < len(expression):
+        for col in quoted_cols:
+            if expression.startswith(col, i):
+                placeholder = placeholder_by_col.get(col)
+                if placeholder is None:
+                    placeholder = f"{_FORMULA_PLACEHOLDER_PREFIX}{len(placeholder_by_col)}"
+                    placeholder_by_col[col] = placeholder
+                    placeholders[placeholder] = f"`{col}`"
+                parts.append(placeholder)
+                i += len(col)
+                break
+        else:
+            literal = _FORMULA_STRING_LITERAL.match(expression, i)
+            if literal:
+                parts.append(_normalize_string_literal(literal.group(0)))
+                i = literal.end()
+            else:
+                parts.append(expression[i])
+                i += 1
+    return "".join(parts), placeholders
+
+
+def prepare_formula_expression(expression: str, columns: list[str]) -> str:
+    """Validate a computed-column formula and return the string to evaluate.
+
+    Column names that cannot appear as a plain Python name are substituted with
+    placeholder identifiers (longest name first, so a short name never corrupts
+    a longer one that contains it) so they parse as a single node. The
+    substitution scans the expression left to right and steps over string
+    literals, so a literal is never mistaken for a column name. Any name that
+    is neither a column nor a placeholder is rejected.
+
+    The returned expression is rebuilt from the exact string the AST walk
+    approved, with each placeholder swapped for its backtick-wrapped column
+    name. The validated string and the executed string therefore cannot drift
+    apart.
+
+    Args:
+        expression: The user-supplied formula, e.g. ``price * quantity``.
+        columns: Column names of the target DataFrame.
+
+    Returns:
+        The expression to hand to ``DataFrame.eval``.
+
+    Raises:
+        HTTPException: If the expression is empty, fails the dangerous-pattern
+            screen, mixes quote characters inside a string literal, is not
+            parseable, or contains disallowed syntax.
+    """
+    if not expression or not expression.strip():
+        raise HTTPException(status_code=400, detail="Formula expression must not be empty")
+
+    for pattern in _DANGEROUS_PATTERNS:
+        if re.search(pattern, expression, re.IGNORECASE):
+            raise HTTPException(status_code=400, detail="Formula contains potentially dangerous expressions")
+
+    if _FORMULA_PLACEHOLDER_PREFIX in expression:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Formula must not contain the reserved prefix '{_FORMULA_PLACEHOLDER_PREFIX}'",
+        )
+
+    allowed_names = {col for col in columns if _is_bare_column_name(col)}
+    quoted_cols = sorted((col for col in columns if not _is_bare_column_name(col)), key=len, reverse=True)
+    sanitized, placeholders = _substitute_column_names(expression, quoted_cols)
+    sanitized = sanitized.strip()
+    allowed_names.update(placeholders)
+
+    try:
+        tree = ast.parse(sanitized, mode="eval")
+    except SyntaxError as e:
+        raise HTTPException(status_code=400, detail="Formula is not a valid expression") from e
+
+    for node in ast.walk(tree):
+        if not isinstance(node, _ALLOWED_FORMULA_NODES):
+            raise HTTPException(
+                status_code=400,
+                detail=f"Formula contains unsupported syntax: {type(node).__name__}",
+            )
+        if isinstance(node, ast.Name) and node.id not in allowed_names:
+            raise HTTPException(status_code=400, detail=f"Unknown column or name '{node.id}' in formula")
+        if isinstance(node, ast.Constant) and not isinstance(node.value, int | float | str | bool):
+            raise HTTPException(status_code=400, detail="Formula literals must be numbers, strings, or booleans")
+
+    # Longest placeholder first: "_dataloom_col_1" is a prefix of "_dataloom_col_10".
+    executable = sanitized
+    for placeholder in sorted(placeholders, key=len, reverse=True):
+        executable = executable.replace(placeholder, placeholders[placeholder])
+    return executable

--- a/dataloom-backend/tests/test_formula_columns.py
+++ b/dataloom-backend/tests/test_formula_columns.py
@@ -1,0 +1,248 @@
+"""Tests for the formula column transformation (addFormulaCol)."""
+
+import numpy as np
+import pandas as pd
+import pytest
+from fastapi import HTTPException
+
+from app.services.transformation_service import (
+    TransformationError,
+    add_formula_column,
+    apply_logged_transformation,
+)
+from app.utils.security import prepare_formula_expression
+
+
+@pytest.fixture
+def sample_df():
+    return pd.DataFrame(
+        {
+            "price": [10.0, 20.0, 30.0],
+            "quantity": [1, 2, 3],
+            "unit cost": [4.0, 5.0, 6.0],
+            "status": ["active", "inactive", "active"],
+        }
+    )
+
+
+class TestPrepareFormulaExpression:
+    def test_arithmetic_allowed(self):
+        prepare_formula_expression("price * quantity", ["price", "quantity"])
+
+    def test_comparison_allowed(self):
+        prepare_formula_expression("price > 100", ["price"])
+
+    def test_boolean_logic_allowed(self):
+        prepare_formula_expression("price > 10 and quantity < 5", ["price", "quantity"])
+
+    def test_string_literal_allowed(self):
+        prepare_formula_expression('status == "active"', ["status"])
+
+    def test_spaced_column_allowed(self):
+        prepare_formula_expression("unit cost * 2", ["unit cost"])
+
+    def test_empty_rejected(self):
+        with pytest.raises(HTTPException):
+            prepare_formula_expression("   ", ["price"])
+
+    def test_function_call_rejected(self):
+        with pytest.raises(HTTPException):
+            prepare_formula_expression("abs(price)", ["price"])
+
+    def test_attribute_access_rejected(self):
+        with pytest.raises(HTTPException):
+            prepare_formula_expression("price.T", ["price"])
+
+    def test_subscript_rejected(self):
+        with pytest.raises(HTTPException):
+            prepare_formula_expression("price[0]", ["price"])
+
+    def test_dunder_rejected(self):
+        with pytest.raises(HTTPException):
+            prepare_formula_expression("__import__", ["price"])
+
+    def test_lambda_rejected(self):
+        with pytest.raises(HTTPException):
+            prepare_formula_expression("lambda x: x", ["price"])
+
+    def test_statement_rejected(self):
+        with pytest.raises(HTTPException):
+            prepare_formula_expression("import osmodule", ["price"])
+
+    def test_unknown_name_rejected(self):
+        with pytest.raises(HTTPException) as exc_info:
+            prepare_formula_expression("prices * 2", ["price", "quantity"])
+        assert "prices" in exc_info.value.detail
+
+    def test_returns_backtick_wrapped_expression(self):
+        assert prepare_formula_expression("unit cost * 2", ["unit cost"]) == "`unit cost` * 2"
+
+    def test_apostrophe_column_is_wrapped_not_quote_normalized(self):
+        assert prepare_formula_expression("buyer's price * 2", ["buyer's price"]) == "`buyer's price` * 2"
+
+    def test_string_literal_quotes_are_normalized(self):
+        assert prepare_formula_expression("status == 'active'", ["status"]) == 'status == "active"'
+
+    def test_overlapping_column_names_use_longest_match(self):
+        expr = prepare_formula_expression("total amount due + 1", ["amount due", "total amount due"])
+        assert expr == "`total amount due` + 1"
+
+    def test_keyword_column_is_wrapped(self):
+        assert prepare_formula_expression("True", ["True"]) == "`True`"
+
+    def test_literal_matching_a_column_name_stays_a_literal(self):
+        expr = prepare_formula_expression('status == "unit cost"', ["status", "unit cost"])
+        assert expr == 'status == "unit cost"'
+
+    def test_literal_matching_a_column_name_survives_quote_normalization(self):
+        expr = prepare_formula_expression("status == 'unit cost'", ["status", "unit cost"])
+        assert expr == 'status == "unit cost"'
+
+    def test_apostrophe_column_before_a_literal(self):
+        expr = prepare_formula_expression("buyer's price > 1 and status == 'active'", ["buyer's price", "status"])
+        assert expr == '`buyer\'s price` > 1 and status == "active"'
+
+    def test_mixed_quote_literal_rejected(self):
+        with pytest.raises(HTTPException):
+            prepare_formula_expression("status == 'he said \"hi\"'", ["status"])
+
+    def test_reserved_placeholder_prefix_rejected(self):
+        with pytest.raises(HTTPException):
+            prepare_formula_expression("_dataloom_col_0 * 2", ["unit cost"])
+
+
+class TestAddFormulaColumn:
+    def test_arithmetic(self, sample_df):
+        result = add_formula_column(sample_df, "total", "price * quantity")
+        assert result["total"].tolist() == [10.0, 40.0, 90.0]
+
+    def test_source_columns_untouched(self, sample_df):
+        result = add_formula_column(sample_df, "total", "price * quantity")
+        assert list(result.columns) == ["price", "quantity", "unit cost", "status", "total"]
+        pd.testing.assert_frame_equal(result.drop(columns=["total"]), sample_df)
+
+    def test_comparison_produces_bool(self, sample_df):
+        result = add_formula_column(sample_df, "expensive", "price > 15")
+        assert result["expensive"].tolist() == [False, True, True]
+
+    def test_spaced_column_name(self, sample_df):
+        result = add_formula_column(sample_df, "margin", "price - unit cost")
+        assert result["margin"].tolist() == [6.0, 15.0, 24.0]
+
+    def test_string_comparison(self, sample_df):
+        result = add_formula_column(sample_df, "is_active", 'status == "active"')
+        assert result["is_active"].tolist() == [True, False, True]
+
+    def test_scalar_broadcasts(self, sample_df):
+        result = add_formula_column(sample_df, "constant", "2 + 3")
+        assert result["constant"].tolist() == [5, 5, 5]
+
+    def test_division_by_zero_yields_inf(self, sample_df):
+        result = add_formula_column(sample_df, "ratio", "price / 0")
+        assert np.isinf(result["ratio"]).all()
+
+    def test_blank_name_raises(self, sample_df):
+        with pytest.raises(TransformationError, match="empty"):
+            add_formula_column(sample_df, "   ", "price * 2")
+
+    def test_duplicate_name_raises(self, sample_df):
+        with pytest.raises(TransformationError, match="already exists"):
+            add_formula_column(sample_df, "price", "quantity * 2")
+
+    def test_unknown_column_raises(self, sample_df):
+        with pytest.raises(HTTPException):
+            add_formula_column(sample_df, "total", "missing * 2")
+
+    def test_apostrophe_column_name(self):
+        df = pd.DataFrame({"buyer's price": [1.0, 2.0]})
+        result = add_formula_column(df, "doubled", "buyer's price * 2")
+        assert result["doubled"].tolist() == [2.0, 4.0]
+
+    def test_overlapping_column_names(self):
+        df = pd.DataFrame({"amount due": [1, 2], "total amount due": [10, 20]})
+        result = add_formula_column(df, "sum", "total amount due + amount due")
+        assert result["sum"].tolist() == [11, 22]
+
+    def test_keyword_column_name_uses_column_values(self):
+        df = pd.DataFrame({"True": [1, 0, 1]})
+        result = add_formula_column(df, "copy", "True")
+        assert result["copy"].tolist() == [1, 0, 1]
+
+    def test_literal_equal_to_a_column_name_compares_values(self, sample_df):
+        df = sample_df.assign(status=["unit cost", "other", "unit cost"])
+        result = add_formula_column(df, "is_unit_cost", 'status == "unit cost"')
+        assert result["is_unit_cost"].tolist() == [True, False, True]
+
+    def test_replay_matches_direct_apply(self, sample_df):
+        details = {"formula_col_params": {"column_name": "total", "expression": "price * quantity"}}
+        replayed = apply_logged_transformation(sample_df, "addFormulaCol", details)
+        direct = add_formula_column(sample_df, "total", "price * quantity")
+        pd.testing.assert_frame_equal(replayed, direct)
+
+
+@pytest.fixture
+def project_id(client, sample_csv):
+    with open(sample_csv, "rb") as f:
+        response = client.post(
+            "/projects/upload",
+            files={"file": ("test.csv", f, "text/csv")},
+            data={"projectName": "Formula Columns", "projectDescription": "fixture"},
+        )
+    assert response.status_code == 200, response.text
+    return response.json()["project_id"]
+
+
+class TestFormulaColumnEndpoint:
+    def _payload(self, name="double_age", expression="age * 2"):
+        return {
+            "operation_type": "addFormulaCol",
+            "formula_col_params": {"column_name": name, "expression": expression},
+        }
+
+    def test_apply_persists_column(self, client, project_id):
+        response = client.post(f"/projects/{project_id}/transform", json=self._payload())
+        assert response.status_code == 200, response.text
+        assert "double_age" in response.json()["columns"]
+
+        details = client.get(f"/projects/get/{project_id}").json()
+        assert "double_age" in details["columns"]
+
+    def test_apply_is_logged(self, client, project_id):
+        client.post(f"/projects/{project_id}/transform", json=self._payload())
+
+        logs = client.get(f"/logs/{project_id}").json()
+        assert any(log["action_type"] == "addFormulaCol" for log in logs)
+
+    def test_preview_does_not_persist(self, client, project_id):
+        response = client.post(f"/projects/{project_id}/transform?preview=true", json=self._payload())
+        assert response.status_code == 200
+        assert "double_age" in response.json()["columns"]
+
+        details = client.get(f"/projects/get/{project_id}").json()
+        assert "double_age" not in details["columns"]
+
+    def test_missing_params_returns_400(self, client, project_id):
+        response = client.post(f"/projects/{project_id}/transform", json={"operation_type": "addFormulaCol"})
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Formula column parameters required"
+
+    def test_dangerous_expression_returns_400(self, client, project_id):
+        response = client.post(
+            f"/projects/{project_id}/transform",
+            json=self._payload(name="evil", expression="__import__('os').system('true')"),
+        )
+        assert response.status_code == 400
+
+    def test_unknown_column_returns_400(self, client, project_id):
+        response = client.post(
+            f"/projects/{project_id}/transform",
+            json=self._payload(name="oops", expression="missing_column * 2"),
+        )
+        assert response.status_code == 400
+
+    def test_blank_params_return_422(self, client, project_id):
+        response = client.post(
+            f"/projects/{project_id}/transform",
+            json=self._payload(name="", expression=""),
+        )
+        assert response.status_code == 422

--- a/dataloom-frontend/src/Components/forms/FormulaColumnForm.tsx
+++ b/dataloom-frontend/src/Components/forms/FormulaColumnForm.tsx
@@ -1,0 +1,148 @@
+import { useState, FormEvent } from "react";
+import { transformProject } from "../../api";
+import { useProjectContext } from "../../context/ProjectContext";
+import usePreviewSave from "../../hooks/usePreviewSave";
+import { useToast } from "../../context/ToastContext";
+import useError from "../../hooks/useError";
+import FormErrorAlert from "../common/FormErrorAlert";
+import Button from "../common/Button";
+import { ADD_FORMULA_COLUMN } from "../../constants/operationTypes";
+
+const FormulaColumnForm = ({ projectId, onClose }: { projectId: string; onClose: () => void }) => {
+  const { columns, pageSize, isPreviewMode, enterPreviewMode, cancelPreview } = useProjectContext();
+  const { showToast } = useToast();
+  const { error, clearError, handleError } = useError();
+  const [loading, setLoading] = useState(false);
+  const { saving, handleSave } = usePreviewSave({ clearError, handleError, onClose });
+
+  const [columnName, setColumnName] = useState("");
+  const [expression, setExpression] = useState("");
+
+  const insertColumn = (col: string) => {
+    setExpression((prev) =>
+      prev === "" || prev.endsWith(" ") ? `${prev}${col}` : `${prev} ${col}`,
+    );
+  };
+
+  const isSubmitDisabled = columnName.trim() === "" || expression.trim() === "";
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    clearError();
+
+    setLoading(true);
+    try {
+      const payload = {
+        operation_type: ADD_FORMULA_COLUMN,
+        formula_col_params: {
+          column_name: columnName.trim(),
+          expression: expression.trim(),
+        },
+      };
+      const response = await transformProject(projectId, payload, {
+        preview: true,
+        page: 1,
+        pageSize,
+      });
+      enterPreviewMode(
+        response.columns,
+        response.rows,
+        response.dtypes,
+        { projectId, payload },
+        {
+          total_rows: response.total_rows,
+          total_pages: response.total_pages,
+          page: response.page,
+          page_size: response.page_size,
+        },
+      );
+    } catch (err) {
+      handleError(err);
+      showToast(
+        (err as { response?: { data?: { detail?: string } } }).response?.data?.detail ||
+          "Failed to add formula column.",
+        "error",
+      );
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleCancel = () => {
+    if (isPreviewMode) {
+      cancelPreview();
+    } else {
+      onClose();
+    }
+  };
+
+  return (
+    <div>
+      <form onSubmit={handleSubmit}>
+        <div className="mb-4">
+          <label className="block text-sm font-medium text-foreground mb-1">New Column Name:</label>
+          <input
+            type="text"
+            value={columnName}
+            onChange={(e) => setColumnName(e.target.value)}
+            placeholder="e.g. total"
+            className="border border-app-border rounded-md w-full px-3 py-2 bg-surface text-foreground focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none"
+            required
+          />
+        </div>
+
+        <div className="mb-4">
+          <label className="block text-sm font-medium text-foreground mb-1">Formula:</label>
+          <input
+            type="text"
+            value={expression}
+            onChange={(e) => setExpression(e.target.value)}
+            placeholder="e.g. price * quantity"
+            className="border border-app-border rounded-md w-full px-3 py-2 bg-surface text-foreground font-mono focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none"
+            required
+          />
+          <p className="text-xs text-muted-foreground mt-1">
+            Arithmetic (+ - * / % **), comparisons, and and/or on existing columns.
+          </p>
+        </div>
+
+        <div className="mb-4">
+          <label className="block text-sm font-medium text-foreground mb-1">Insert Column:</label>
+          <div className="flex flex-wrap gap-1">
+            {columns.map((col: string) => (
+              <button
+                key={col}
+                type="button"
+                onClick={() => insertColumn(col)}
+                className="text-xs border border-app-border rounded px-2 py-0.5 bg-surface text-secondary-foreground hover:bg-surface-hover transition-colors"
+              >
+                {col}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <FormErrorAlert message={error} />
+
+        <div className="flex justify-between mt-2">
+          <div className="flex gap-2">
+            <Button type="submit" disabled={isSubmitDisabled || loading || saving || isPreviewMode}>
+              {loading ? "Applying..." : "Apply"}
+            </Button>
+            {isPreviewMode && (
+              <Button type="button" onClick={handleSave} disabled={saving} variant="success">
+                {saving ? "Saving..." : "Save Changes"}
+              </Button>
+            )}
+          </div>
+
+          <Button type="button" onClick={handleCancel} variant="secondary">
+            Cancel
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+};
+
+export default FormulaColumnForm;

--- a/dataloom-frontend/src/Components/forms/__tests__/FormulaColumnForm.test.tsx
+++ b/dataloom-frontend/src/Components/forms/__tests__/FormulaColumnForm.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import FormulaColumnForm from "../FormulaColumnForm";
+
+const transformProject = vi.fn();
+const enterPreviewMode = vi.fn();
+const showToast = vi.fn();
+
+vi.mock("../../../api", () => ({
+  transformProject: (...args: unknown[]) => transformProject(...args),
+}));
+vi.mock("../../../context/ProjectContext", () => ({
+  useProjectContext: () => ({
+    columns: ["price", "quantity"],
+    pageSize: 50,
+    isPreviewMode: false,
+    enterPreviewMode,
+    cancelPreview: vi.fn(),
+  }),
+}));
+vi.mock("../../../context/ToastContext", () => ({
+  useToast: () => ({ showToast }),
+}));
+vi.mock("../../../hooks/usePreviewSave", () => ({
+  default: () => ({ saving: false, handleSave: vi.fn() }),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+const renderForm = () => render(<FormulaColumnForm projectId="p1" onClose={vi.fn()} />);
+
+const formulaInput = () => screen.getByPlaceholderText("e.g. price * quantity") as HTMLInputElement;
+const applyButton = () => screen.getByRole("button", { name: /apply/i });
+
+describe("FormulaColumnForm", () => {
+  it("disables Apply until both name and formula are filled", () => {
+    renderForm();
+    expect(applyButton()).toBeDisabled();
+
+    fireEvent.change(screen.getByPlaceholderText("e.g. total"), { target: { value: "total" } });
+    expect(applyButton()).toBeDisabled();
+
+    fireEvent.change(formulaInput(), { target: { value: "price * 2" } });
+    expect(applyButton()).not.toBeDisabled();
+  });
+
+  it("inserts a clicked column into the formula with spacing", () => {
+    renderForm();
+
+    fireEvent.click(screen.getByRole("button", { name: "price" }));
+    expect(formulaInput().value).toBe("price");
+
+    fireEvent.click(screen.getByRole("button", { name: "quantity" }));
+    expect(formulaInput().value).toBe("price quantity");
+  });
+
+  it("submits the addFormulaCol payload as a preview", async () => {
+    transformProject.mockResolvedValue({
+      columns: [],
+      rows: [],
+      dtypes: {},
+      total_rows: 120,
+      total_pages: 3,
+      page: 1,
+      page_size: 50,
+    });
+    renderForm();
+
+    fireEvent.change(screen.getByPlaceholderText("e.g. total"), { target: { value: " total " } });
+    fireEvent.change(formulaInput(), { target: { value: "price * quantity" } });
+    fireEvent.click(applyButton());
+
+    expect(transformProject).toHaveBeenCalledWith(
+      "p1",
+      {
+        operation_type: "addFormulaCol",
+        formula_col_params: { column_name: "total", expression: "price * quantity" },
+      },
+      { preview: true, page: 1, pageSize: 50 },
+    );
+    await vi.waitFor(() => expect(enterPreviewMode).toHaveBeenCalled());
+    expect(enterPreviewMode).toHaveBeenCalledWith([], [], {}, expect.anything(), {
+      total_rows: 120,
+      total_pages: 3,
+      page: 1,
+      page_size: 50,
+    });
+  });
+});

--- a/dataloom-frontend/src/Components/workspace/features/transforms.tsx
+++ b/dataloom-frontend/src/Components/workspace/features/transforms.tsx
@@ -10,6 +10,7 @@ import {
   LuRefreshCw,
   LuReplace,
   LuScissors,
+  LuSigma,
   LuTable2,
 } from "react-icons/lu";
 import FilterForm from "../../forms/FilterForm";
@@ -24,6 +25,7 @@ import GroupByForm from "../../forms/GroupByForm";
 import StringReplaceForm from "../../forms/StringReplaceForm";
 import FillEmptyForm from "../../forms/FillEmptyForm";
 import SampleRowsForm from "../../forms/SampleRowsForm";
+import FormulaColumnForm from "../../forms/FormulaColumnForm";
 import { registerFeature } from "../featureRegistry";
 
 /**
@@ -44,6 +46,7 @@ registerFeature({
     { name: "TrimWhitespaceForm", title: "Trim Whitespace", component: TrimWhitespaceForm },
     { name: "StringReplaceForm", title: "Replace", component: StringReplaceForm },
     { name: "FillEmptyForm", title: "Fill Empty", component: FillEmptyForm },
+    { name: "FormulaColumnForm", title: "Formula Column", component: FormulaColumnForm },
     { name: "AdvQueryFilterForm", title: "Advanced Query", component: AdvQueryFilterForm },
     { name: "PivotTableForm", title: "Pivot Table", component: PivotTableForm },
     { name: "MeltForm", title: "Melt (Unpivot)", component: MeltForm },
@@ -148,6 +151,17 @@ registerFeature({
       disabledInPreview: true,
       activePanel: "FillEmptyForm",
       hover: "Fill empty cells in a column with a specific value.",
+    },
+    {
+      ribbon: "Data",
+      group: "Transform",
+      order: 9,
+      label: "Formula",
+      icon: LuSigma,
+      action: { togglePanel: "FormulaColumnForm" },
+      disabledInPreview: true,
+      activePanel: "FormulaColumnForm",
+      hover: "Add a computed column from a formula like price * quantity.",
     },
     // Data ▸ Query
     {

--- a/dataloom-frontend/src/constants/operationTypes.js
+++ b/dataloom-frontend/src/constants/operationTypes.js
@@ -41,3 +41,5 @@ export const GROUPBY = "groupby";
 export const SAMPLE_ROWS = "sample";
 /** @type {string} Find and replace string values in a column */
 export const STRING_REPLACE = "stringReplace";
+/** @type {string} Add a computed column from a formula expression */
+export const ADD_FORMULA_COLUMN = "addFormulaCol";


### PR DESCRIPTION
- addFormulaCol OperationType + FormulaColumnParams, registered in TRANSFORMATION_REGISTRY so apply, preview, and save-replay share one path
- validate_formula_expression() AST allowlist in security.py: arithmetic, comparisons, boolean ops, column refs, and literals only; rejects calls, attribute access, subscripts, and dunders
- add_formula_column() evaluates via DataFrame.eval with backtick-quoted non-identifier columns; never raw eval()
- FormulaColumnForm docked panel with column insert chips, wired into the Data ribbon and the shared preview flow
- unit, endpoint, replay, and component tests

## Description

Adds computed "formula" columns to DataLoom. Users open the docked Formula Column panel from the Data ribbon, name a new column, and enter an arithmetic/logical expression over existing columns (with insert-column chips for convenience). The expression is validated against an AST allowlist and evaluated with `DataFrame.eval` — never raw `eval()` — and flows through the same preview/save-replay path as every other transformation.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

Backend unit tests cover the AST allowlist (accepting arithmetic/comparison/boolean forms and rejecting calls, attribute access, subscripts, and dunders), `add_formula_column` evaluation including backtick-quoted non-identifier columns, the transform endpoint, and save-replay. Frontend component tests cover the `FormulaColumnForm` panel. `npm run lint` (ESLint + `tsc --noEmit`) passes clean.

- [x] Existing tests pass
- [x] New tests added
- [x] Manual testing

## Screenshots (if applicable)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [ ] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally
