### PR TITLE
feat: add profiling options dropdown to workspace tab bar '+' button

### DIFF
--- a/dataloom-frontend/src/Components/DataScreen.jsx
+++ b/dataloom-frontend/src/Components/DataScreen.jsx
@@ -57,7 +57,7 @@ function WorkspaceContent({ projectId }) {
       <MenuNavbar projectId={projectId} />
       <div className="flex min-h-0 flex-1 overflow-hidden">
         <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-          <WorkspaceTabBar onAddTab={() => openTab(DATASET_TAB)} />
+          <WorkspaceTabBar />
           <div className="flex min-h-0 flex-1 flex-col overflow-hidden">{renderActiveTab()}</div>
         </div>
         <RightPanel projectId={projectId} />

--- a/dataloom-frontend/src/Components/MenuNavbar.jsx
+++ b/dataloom-frontend/src/Components/MenuNavbar.jsx
@@ -10,7 +10,7 @@ import { usePanel } from "../context/PanelContext";
 import { useWorkspaceTabs } from "../context/WorkspaceTabsContext";
 import { useHistoryRefresh } from "../context/HistoryRefreshContext";
 import { useColumnProfilesView } from "../context/ColumnProfilesContext";
-import { DATASET_TAB } from "./workspace/DataSetTab";
+import { useColumnProfilesAction } from "./workspace/useProfilingMenu";
 import { getFeatureMenu } from "./workspace/featureRegistry";
 
 // Ribbon skeleton: the top tabs and the group order within each. Features and the
@@ -32,7 +32,7 @@ const MenuNavbar = ({ projectId }) => {
   const { activePanel, openPanel, togglePanel, closePanel } = usePanel();
   const { openTab, activeTabId } = useWorkspaceTabs();
   const { refreshLogs, refreshCheckpoints } = useHistoryRefresh();
-  const { showColumnProfiles, toggleColumnProfiles } = useColumnProfilesView();
+  const { showColumnProfiles } = useColumnProfilesView();
 
   const handleMouseEnter = (e, hoverText) => {
     if (!hoverText) return;
@@ -54,12 +54,8 @@ const MenuNavbar = ({ projectId }) => {
     setActiveTooltip(null);
   };
 
-  // Column profiles render inside the DataSet tab, so focus it when turning
-  // them on (re-opens it if the tab was closed).
-  const handleToggleColumnProfiles = () => {
-    if (!showColumnProfiles) openTab(DATASET_TAB);
-    toggleColumnProfiles();
-  };
+  // Shared with the tab bar dropdown so both entry points behave identically.
+  const handleToggleColumnProfiles = useColumnProfilesAction();
 
   const handleSave = () => setIsInputOpen(true);
 
@@ -298,7 +294,7 @@ const MenuNavbar = ({ projectId }) => {
             top: `${activeTooltip.top}px`,
             left: `${activeTooltip.left}px`,
           }}
-          className="fixed -translate-x-1/2 z-40 pointer-events-none px-2.5 py-1 text-xs font-medium text-white bg-slate-900/90 dark:bg-slate-800/95 backdrop-blur-sm rounded-md shadow-md border border-slate-700/50 max-w-xs text-center text-wrap"
+          className="fixed -translate-x-1/2 z-50 pointer-events-none px-2.5 py-1 text-xs text-foreground bg-surface border border-app-border rounded-md shadow-md max-w-xs text-center text-wrap"
         >
           {activeTooltip.text}
         </div>

--- a/dataloom-frontend/src/Components/workspace/SummaryTab.tsx
+++ b/dataloom-frontend/src/Components/workspace/SummaryTab.tsx
@@ -1,8 +1,16 @@
 import { useParams } from "react-router-dom";
-import { useWorkspaceTabs } from "../../context/WorkspaceTabsContext";
+import { useWorkspaceTabs, type WorkspaceTab } from "../../context/WorkspaceTabsContext";
 import { useProjectContext } from "../../context/ProjectContext";
 import useDatasetSummary from "../../hooks/useDatasetSummary";
 import DatasetSummaryPanel from "../profiling/DatasetSummaryPanel";
+
+// eslint-disable-next-line react-refresh/only-export-components
+export const SUMMARY_TAB: WorkspaceTab = {
+  id: "summary",
+  title: "Summary",
+  type: "summary",
+  closeable: true,
+};
 
 /**
  * Summary tab — the dataset-wide overview (row/column counts, dtypes, memory).

--- a/dataloom-frontend/src/Components/workspace/WorkspaceTabBar.tsx
+++ b/dataloom-frontend/src/Components/workspace/WorkspaceTabBar.tsx
@@ -1,23 +1,110 @@
+import { useState, useEffect, useRef } from "react";
 import { Plus, X } from "lucide-react";
 import { useWorkspaceTabs } from "../../context/WorkspaceTabsContext";
-
-interface WorkspaceTabBarProps {
-  /** When provided, renders a trailing "+" button that invokes this. */
-  onAddTab?: () => void;
-}
+import { useProfilingMenuItems } from "./useProfilingMenu";
 
 /**
  * VS Code–style tab strip for the project workspace. Reads open tabs from
  * WorkspaceTabsContext; selecting a tab activates it and the × closes it.
+ * The "+" button directly follows open tabs and opens a dropdown menu of the
+ * Profiling actions, derived from the feature registry via useProfilingMenu.
  */
-const WorkspaceTabBar = ({ onAddTab }: WorkspaceTabBarProps) => {
+const WorkspaceTabBar = () => {
   const { tabs, activeTabId, setActiveTab, closeTab } = useWorkspaceTabs();
+  const profilingOptions = useProfilingMenuItems();
+
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  /** Roving focus position within the menu, per the ARIA menu pattern. */
+  const [activeIndex, setActiveIndex] = useState(0);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const itemRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  const openDropdown = (index: number) => {
+    setActiveIndex(index);
+    setIsDropdownOpen(true);
+  };
+
+  /** Close and hand focus back to the trigger, so keyboard users aren't stranded. */
+  const closeDropdown = (refocus = true) => {
+    setIsDropdownOpen(false);
+    if (refocus) triggerRef.current?.focus();
+  };
+
+  // Close on click outside or Escape.
+  useEffect(() => {
+    if (!isDropdownOpen) return;
+
+    const handleClickOutside = (event: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setIsDropdownOpen(false);
+      }
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setIsDropdownOpen(false);
+        triggerRef.current?.focus();
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isDropdownOpen]);
+
+  // Move real focus to the active item so screen readers follow the menu.
+  useEffect(() => {
+    if (!isDropdownOpen) return;
+    itemRefs.current[activeIndex]?.focus();
+  }, [isDropdownOpen, activeIndex]);
+
+  const handleMenuKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    const lastIndex = profilingOptions.length - 1;
+    switch (event.key) {
+      case "ArrowDown":
+        event.preventDefault();
+        setActiveIndex((prev) => (prev >= lastIndex ? 0 : prev + 1));
+        break;
+      case "ArrowUp":
+        event.preventDefault();
+        setActiveIndex((prev) => (prev <= 0 ? lastIndex : prev - 1));
+        break;
+      case "Home":
+        event.preventDefault();
+        setActiveIndex(0);
+        break;
+      case "End":
+        event.preventDefault();
+        setActiveIndex(lastIndex);
+        break;
+      case "Tab":
+        // Tabbing out of a menu dismisses it; let focus continue naturally.
+        closeDropdown(false);
+        break;
+      default:
+        break;
+    }
+  };
+
+  const handleTriggerKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      openDropdown(0);
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      openDropdown(profilingOptions.length - 1);
+    }
+  };
 
   return (
     <div
       role="tablist"
       aria-label="Open tables"
-      className="flex h-9 shrink-0 items-stretch overflow-hidden border-b border-app-border bg-surface"
+      className="relative flex h-9 shrink-0 items-stretch border-b border-app-border bg-surface z-40"
     >
       {tabs.map((tab) => {
         const isActive = tab.id === activeTabId;
@@ -61,17 +148,58 @@ const WorkspaceTabBar = ({ onAddTab }: WorkspaceTabBarProps) => {
         );
       })}
 
-      {onAddTab && (
+      <div ref={dropdownRef} className="relative flex items-center shrink-0">
         <button
           type="button"
-          onClick={onAddTab}
-          aria-label="New tab"
+          ref={triggerRef}
+          onClick={() => (isDropdownOpen ? closeDropdown(false) : openDropdown(0))}
+          onKeyDown={handleTriggerKeyDown}
+          aria-label="Profiling options"
+          aria-expanded={isDropdownOpen}
+          aria-haspopup="menu"
           data-testid="workspace-tab-add"
-          className="flex shrink-0 items-center px-2 text-muted-foreground hover:bg-surface hover:text-gray-700"
+          className="flex h-full shrink-0 items-center px-3 text-muted-foreground hover:bg-surface-hover hover:text-foreground transition-colors border-r border-app-border"
         >
           <Plus className="h-4 w-4" />
         </button>
-      )}
+
+        {isDropdownOpen && (
+          <div
+            role="menu"
+            aria-label="Profiling options"
+            data-testid="workspace-add-tab-dropdown"
+            onKeyDown={handleMenuKeyDown}
+            className="absolute left-0 top-full mt-1 w-48 rounded-md border border-app-border bg-surface shadow-xl py-1 z-50"
+          >
+            <div className="px-3 py-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground border-b border-app-border/60 mb-1">
+              Profiling Options
+            </div>
+            {profilingOptions.map((opt, index) => {
+              const Icon = opt.icon;
+              return (
+                <button
+                  key={opt.id}
+                  type="button"
+                  role="menuitem"
+                  ref={(node) => {
+                    itemRefs.current[index] = node;
+                  }}
+                  tabIndex={index === activeIndex ? 0 : -1}
+                  data-testid={`workspace-add-tab-option-${opt.id}`}
+                  onClick={() => {
+                    opt.onClick();
+                    closeDropdown();
+                  }}
+                  className="flex w-full items-center gap-2.5 px-3 py-1.5 text-xs font-medium text-foreground hover:bg-surface-hover hover:text-blue-600 transition-colors text-left"
+                >
+                  <Icon className="h-4 w-4 shrink-0 text-muted-foreground" />
+                  <span>{opt.label}</span>
+                </button>
+              );
+            })}
+          </div>
+        )}
+      </div>
     </div>
   );
 };

--- a/dataloom-frontend/src/Components/workspace/features/dataset.tsx
+++ b/dataloom-frontend/src/Components/workspace/features/dataset.tsx
@@ -3,8 +3,10 @@ import { registerFeature } from "../featureRegistry";
 
 /**
  * DataSet feature — the built-in working-table tab. It has no ribbon menu item;
- * it's opened by the tab bar "+" and focused by the Profiling column-profiles
- * toggle. Re-exported here so DataScreen imports one feature module per feature.
+ * it opens with the workspace and is reopened (or refocused) by the Column
+ * Profiles action, from either the Profiling ribbon or the tab bar "+" menu,
+ * since the profiles render inside this table. Re-exported here so DataScreen
+ * imports one feature module per feature.
  */
 registerFeature({
   id: "dataset",

--- a/dataloom-frontend/src/Components/workspace/features/profiling.tsx
+++ b/dataloom-frontend/src/Components/workspace/features/profiling.tsx
@@ -1,14 +1,6 @@
 import { LuLayoutDashboard } from "react-icons/lu";
-import type { WorkspaceTab } from "../../../context/WorkspaceTabsContext";
-import { SummaryTab } from "../SummaryTab";
+import { SummaryTab, SUMMARY_TAB } from "../SummaryTab";
 import { registerFeature } from "../featureRegistry";
-
-const SUMMARY_TAB: WorkspaceTab = {
-  id: "summary",
-  title: "Summary",
-  type: "summary",
-  closeable: true,
-};
 
 /**
  * Profiling feature — the dataset Summary tab and its Profiling-ribbon menu item.

--- a/dataloom-frontend/src/Components/workspace/useProfilingMenu.ts
+++ b/dataloom-frontend/src/Components/workspace/useProfilingMenu.ts
@@ -1,0 +1,86 @@
+import { useCallback, useMemo } from "react";
+import type { IconType } from "react-icons";
+import { LuColumns3 } from "react-icons/lu";
+import { useWorkspaceTabs } from "../../context/WorkspaceTabsContext";
+import { usePanel } from "../../context/PanelContext";
+import { useColumnProfilesView } from "../../context/ColumnProfilesContext";
+import { DATASET_TAB } from "./DataSetTab";
+import { getFeatureMenu } from "./featureRegistry";
+
+/** Ribbon the profiling surfaces are registered under. */
+const PROFILING_RIBBON = "Profiling";
+
+/** Where the Column Profiles toggle sits among the registered Profiling items. */
+const COLUMN_PROFILES_ORDER = 1;
+
+/** A Profiling action ready to render as a menu entry. */
+export interface ProfilingMenuItem {
+  /** Stable slug derived from the label, used for test ids. */
+  id: string;
+  label: string;
+  icon: IconType;
+  onClick: () => void;
+}
+
+const slug = (label: string) => label.toLowerCase().replace(/\s+/g, "-");
+
+/**
+ * Toggle the inline column-profile row.
+ *
+ * Shared by the ribbon and the tab bar dropdown so the behaviour is defined
+ * once. The profiles render inside the DataSet table, so that tab is opened (or
+ * refocused) in both directions: gating the open on the current toggle state
+ * meant closing the tab while profiles were on left the next click flipping the
+ * flag with nothing visible happening, and no obvious way back to the data.
+ */
+export function useColumnProfilesAction(): () => void {
+  const { openTab } = useWorkspaceTabs();
+  const { toggleColumnProfiles } = useColumnProfilesView();
+
+  return useCallback(() => {
+    openTab(DATASET_TAB);
+    toggleColumnProfiles();
+  }, [openTab, toggleColumnProfiles]);
+}
+
+/**
+ * The Profiling menu as clickable items, derived from the feature registry so
+ * the tab bar dropdown and the ribbon cannot drift apart — adding a Profiling
+ * feature surfaces it in both. Column Profiles is spliced in at its ribbon
+ * order because it drives hook state rather than a declarative tab/panel action.
+ */
+export function useProfilingMenuItems(): ProfilingMenuItem[] {
+  const { openTab } = useWorkspaceTabs();
+  const { openPanel, togglePanel } = usePanel();
+  const toggleColumnProfiles = useColumnProfilesAction();
+
+  return useMemo(() => {
+    const registered = getFeatureMenu()
+      .filter((item) => item.ribbon === PROFILING_RIBBON)
+      .map((item) => ({
+        order: item.order,
+        id: slug(item.label),
+        label: item.label,
+        icon: item.icon,
+        onClick: () => {
+          const { openTab: tab, openPanel: panel, togglePanel: toggle } = item.action;
+          if (tab) openTab(tab);
+          if (panel) openPanel(panel);
+          if (toggle) togglePanel(toggle);
+        },
+      }));
+
+    return [
+      ...registered,
+      {
+        order: COLUMN_PROFILES_ORDER,
+        id: "column-profiles",
+        label: "Column Profiles",
+        icon: LuColumns3 as IconType,
+        onClick: toggleColumnProfiles,
+      },
+    ]
+      .sort((a, b) => a.order - b.order)
+      .map((item) => ({ id: item.id, label: item.label, icon: item.icon, onClick: item.onClick }));
+  }, [openTab, openPanel, togglePanel, toggleColumnProfiles]);
+}

--- a/dataloom-frontend/src/test/WorkspaceTabBar.test.tsx
+++ b/dataloom-frontend/src/test/WorkspaceTabBar.test.tsx
@@ -2,8 +2,16 @@ import { describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { WorkspaceTabsProvider, useWorkspaceTabs } from "../context/WorkspaceTabsContext";
+import { PanelProvider } from "../context/PanelContext";
+import { ColumnProfilesProvider, useColumnProfilesView } from "../context/ColumnProfilesContext";
 import WorkspaceTabBar from "../Components/workspace/WorkspaceTabBar";
 import type { ReactNode } from "react";
+
+// The dropdown is derived from the feature registry, which fills at import
+// time — the same modules DataScreen pulls in to populate the ribbon.
+import "../Components/workspace/features/profiling";
+import "../Components/workspace/features/charts";
+import "../Components/workspace/features/quality";
 
 const DATASET = { id: "dataset", title: "DataSet", type: "dataset", closeable: true };
 const PINNED = { id: "pinned", title: "Pinned", type: "x", closeable: false };
@@ -14,12 +22,23 @@ function ActiveProbe() {
   return <span data-testid="active-id">{activeTabId ?? "none"}</span>;
 }
 
+// Surfaces the column-profiles flag, which is otherwise only visible inside the table.
+function ProfilesProbe() {
+  const { showColumnProfiles } = useColumnProfilesView();
+  return <span data-testid="profiles-on">{String(showColumnProfiles)}</span>;
+}
+
 function renderBar(initialTabs: (typeof DATASET)[], children?: ReactNode) {
   return render(
     <WorkspaceTabsProvider projectId="p1" initialTabs={initialTabs}>
-      <WorkspaceTabBar />
-      <ActiveProbe />
-      {children}
+      <PanelProvider>
+        <ColumnProfilesProvider>
+          <WorkspaceTabBar />
+          <ActiveProbe />
+          <ProfilesProbe />
+          {children}
+        </ColumnProfilesProvider>
+      </PanelProvider>
     </WorkspaceTabsProvider>,
   );
 }
@@ -52,5 +71,188 @@ describe("WorkspaceTabBar", () => {
   it("omits the close button on non-closeable tabs", () => {
     renderBar([PINNED]);
     expect(screen.queryByTestId("workspace-tab-close-pinned")).not.toBeInTheDocument();
+  });
+
+  it("opens profiling dropdown menu when '+' is clicked", async () => {
+    const user = userEvent.setup();
+    renderBar([DATASET]);
+
+    await user.click(screen.getByTestId("workspace-tab-add"));
+
+    expect(screen.getByTestId("workspace-add-tab-dropdown")).toBeInTheDocument();
+    expect(screen.getByTestId("workspace-add-tab-option-summary")).toHaveTextContent("Summary");
+    expect(screen.getByTestId("workspace-add-tab-option-column-profiles")).toHaveTextContent(
+      "Column Profiles",
+    );
+    expect(screen.getByTestId("workspace-add-tab-option-charts")).toHaveTextContent("Charts");
+    expect(screen.getByTestId("workspace-add-tab-option-quality")).toHaveTextContent("Quality");
+  });
+
+  it("opens Summary tab when Summary option is clicked from '+' dropdown", async () => {
+    const user = userEvent.setup();
+    renderBar([DATASET]);
+
+    await user.click(screen.getByTestId("workspace-tab-add"));
+    await user.click(screen.getByTestId("workspace-add-tab-option-summary"));
+
+    expect(screen.getByTestId("active-id")).toHaveTextContent("summary");
+  });
+
+  it("opens Charts tab when Charts option is clicked from '+' dropdown", async () => {
+    const user = userEvent.setup();
+    renderBar([DATASET]);
+
+    await user.click(screen.getByTestId("workspace-tab-add"));
+    await user.click(screen.getByTestId("workspace-add-tab-option-charts"));
+
+    expect(screen.getByTestId("active-id")).toHaveTextContent("charts");
+  });
+
+  it("opens Quality tab when Quality option is clicked from '+' dropdown", async () => {
+    const user = userEvent.setup();
+    renderBar([DATASET]);
+
+    await user.click(screen.getByTestId("workspace-tab-add"));
+    await user.click(screen.getByTestId("workspace-add-tab-option-quality"));
+
+    expect(screen.getByTestId("active-id")).toHaveTextContent("quality");
+  });
+
+  it("lists the registered Profiling actions in ribbon order", async () => {
+    const user = userEvent.setup();
+    renderBar([DATASET]);
+
+    await user.click(screen.getByTestId("workspace-tab-add"));
+
+    // Derived from the feature registry, so this guards the ribbon's own
+    // ordering rather than a hand-maintained copy of it.
+    expect(screen.getAllByRole("menuitem").map((item) => item.textContent)).toEqual([
+      "Summary",
+      "Column Profiles",
+      "Charts",
+      "Quality",
+    ]);
+  });
+
+  describe("Column Profiles option", () => {
+    it("opens the DataSet tab and turns profiles on", async () => {
+      const user = userEvent.setup();
+      renderBar([DATASET, { id: "a", title: "Pivot", type: "x", closeable: true }]);
+      await user.click(screen.getByTestId("workspace-tab-a"));
+
+      await user.click(screen.getByTestId("workspace-tab-add"));
+      await user.click(screen.getByTestId("workspace-add-tab-option-column-profiles"));
+
+      expect(screen.getByTestId("active-id")).toHaveTextContent("dataset");
+      expect(screen.getByTestId("profiles-on")).toHaveTextContent("true");
+    });
+
+    it("turns profiles back off on a second use", async () => {
+      const user = userEvent.setup();
+      renderBar([DATASET]);
+
+      await user.click(screen.getByTestId("workspace-tab-add"));
+      await user.click(screen.getByTestId("workspace-add-tab-option-column-profiles"));
+      await user.click(screen.getByTestId("workspace-tab-add"));
+      await user.click(screen.getByTestId("workspace-add-tab-option-column-profiles"));
+
+      expect(screen.getByTestId("profiles-on")).toHaveTextContent("false");
+    });
+
+    it("reopens a closed DataSet tab even when profiles are already on", async () => {
+      const user = userEvent.setup();
+      const summary = { id: "summary", title: "Summary", type: "summary", closeable: true };
+      renderBar([DATASET, summary]);
+
+      // Profiles on, move away, then close the DataSet tab.
+      await user.click(screen.getByTestId("workspace-tab-add"));
+      await user.click(screen.getByTestId("workspace-add-tab-option-column-profiles"));
+      await user.click(screen.getByTestId("workspace-tab-summary"));
+      await user.click(screen.getByTestId("workspace-tab-close-dataset"));
+      expect(screen.queryByTestId("workspace-tab-dataset")).not.toBeInTheDocument();
+
+      // One click must bring the table back, rather than silently flipping the
+      // flag and leaving no visible route to the data.
+      await user.click(screen.getByTestId("workspace-tab-add"));
+      await user.click(screen.getByTestId("workspace-add-tab-option-column-profiles"));
+
+      expect(screen.getByTestId("workspace-tab-dataset")).toBeInTheDocument();
+      expect(screen.getByTestId("active-id")).toHaveTextContent("dataset");
+    });
+  });
+
+  describe("menu keyboard support", () => {
+    it("focuses the first item when the menu opens", async () => {
+      const user = userEvent.setup();
+      renderBar([DATASET]);
+
+      await user.click(screen.getByTestId("workspace-tab-add"));
+
+      expect(screen.getByTestId("workspace-add-tab-option-summary")).toHaveFocus();
+    });
+
+    it("moves focus with the arrow keys and wraps at both ends", async () => {
+      const user = userEvent.setup();
+      renderBar([DATASET]);
+      await user.click(screen.getByTestId("workspace-tab-add"));
+
+      await user.keyboard("{ArrowDown}");
+      expect(screen.getByTestId("workspace-add-tab-option-column-profiles")).toHaveFocus();
+
+      await user.keyboard("{ArrowUp}");
+      expect(screen.getByTestId("workspace-add-tab-option-summary")).toHaveFocus();
+
+      // Wraps backwards from the first item to the last.
+      await user.keyboard("{ArrowUp}");
+      expect(screen.getByTestId("workspace-add-tab-option-quality")).toHaveFocus();
+
+      // And forwards from the last back to the first.
+      await user.keyboard("{ArrowDown}");
+      expect(screen.getByTestId("workspace-add-tab-option-summary")).toHaveFocus();
+    });
+
+    it("jumps to the last and first items with End and Home", async () => {
+      const user = userEvent.setup();
+      renderBar([DATASET]);
+      await user.click(screen.getByTestId("workspace-tab-add"));
+
+      await user.keyboard("{End}");
+      expect(screen.getByTestId("workspace-add-tab-option-quality")).toHaveFocus();
+
+      await user.keyboard("{Home}");
+      expect(screen.getByTestId("workspace-add-tab-option-summary")).toHaveFocus();
+    });
+
+    it("opens from the trigger with ArrowDown", async () => {
+      const user = userEvent.setup();
+      renderBar([DATASET]);
+      screen.getByTestId("workspace-tab-add").focus();
+
+      await user.keyboard("{ArrowDown}");
+
+      expect(screen.getByTestId("workspace-add-tab-dropdown")).toBeInTheDocument();
+      expect(screen.getByTestId("workspace-add-tab-option-summary")).toHaveFocus();
+    });
+
+    it("closes on Escape and returns focus to the '+' button", async () => {
+      const user = userEvent.setup();
+      renderBar([DATASET]);
+      await user.click(screen.getByTestId("workspace-tab-add"));
+
+      await user.keyboard("{Escape}");
+
+      expect(screen.queryByTestId("workspace-add-tab-dropdown")).not.toBeInTheDocument();
+      expect(screen.getByTestId("workspace-tab-add")).toHaveFocus();
+    });
+
+    it("returns focus to the '+' button after choosing an item", async () => {
+      const user = userEvent.setup();
+      renderBar([DATASET]);
+      await user.click(screen.getByTestId("workspace-tab-add"));
+
+      await user.click(screen.getByTestId("workspace-add-tab-option-summary"));
+
+      expect(screen.getByTestId("workspace-tab-add")).toHaveFocus();
+    });
   });
 });


### PR DESCRIPTION
## Description

Added a dropdown popover menu to the workspace tab bar `+` button directly adjacent to open tabs (`DataSet x [+]`). Clicking the `+` icon now displays all options from the **Profiling** menu:
- **Summary**: Opens the dataset summary tab.
- **Column Profiles**: Toggles inline column profiles on the table.
- **Charts**: Opens the charts tab and docks the chart builder panel.
- **Quality**: Opens the data quality report tab and docks the quality config panel.

Additionally, updated menu navbar tooltips to use clean theme-aware surface styling and fixed z-index popover layering over sticky table headers.

Fixes #464 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

Ran unit tests, linter, formatting checks, and local manual verification.

- [x] Existing tests pass
- [x] New tests added
- [x] Manual testing

## Screenshots 

<img width="1710" height="1112" alt="image" src="https://github.com/user-attachments/assets/db502879-c460-4e3e-a040-56b77df39a6b" />


## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally
