### PR TITLE
feat: download rendered charts and the correlation matrix as PNG

### DIFF
--- a/dataloom-frontend/package-lock.json
+++ b/dataloom-frontend/package-lock.json
@@ -13,7 +13,7 @@
         "prop-types": "^15.8.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-icons": "^5.2.1",
+        "react-icons": "^5.7.0",
         "react-router-dom": "^6.24.0",
         "recharts": "^3.9.1"
       },
@@ -6460,9 +6460,9 @@
       }
     },
     "node_modules/react-icons": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.6.0.tgz",
-      "integrity": "sha512-RH93p5ki6LfOiIt0UtDyNg/cee+HLVR6cHHtW3wALfo+eOHTp8RnU2kRkI6E+H19zMIs03DyxUG/GfZMOGvmiA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.7.0.tgz",
+      "integrity": "sha512-LBLy340Rzqy6+/yVhZKT3B/QpP1BZaesGqasf09HPOBzRarcDIFH0WwXlXQfE7q7ipxK4MSiC5DIBWURCny6fw==",
       "license": "MIT",
       "peerDependencies": {
         "react": "*"

--- a/dataloom-frontend/package.json
+++ b/dataloom-frontend/package.json
@@ -20,7 +20,7 @@
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-icons": "^5.2.1",
+    "react-icons": "^5.7.0",
     "react-router-dom": "^6.24.0",
     "recharts": "^3.9.1"
   },

--- a/dataloom-frontend/src/Components/profiling/CorrelationHeatmap.tsx
+++ b/dataloom-frontend/src/Components/profiling/CorrelationHeatmap.tsx
@@ -1,5 +1,6 @@
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import type { Correlation } from "../../api/profiling";
+import DownloadImageButton from "../visualizations/DownloadImageButton";
 
 interface CorrelationHeatmapProps {
   correlation: Correlation | null;
@@ -154,17 +155,85 @@ function HighlightsView({ pairs }: { pairs: Pair[] }) {
   );
 }
 
+/** Geometry of the exported grid image, in CSS px. */
+const EXPORT_LABEL_WIDTH = 132;
+const EXPORT_HEADER_HEIGHT = 24;
+const EXPORT_CELL_WIDTH = 72;
+const EXPORT_CELL_HEIGHT = 26;
+const EXPORT_FONT = 11;
+const EXPORT_GRID = "#e5e7eb"; // gray-200, matching the on-screen cell borders
+
+/** Escape the characters that would otherwise break the generated markup. */
+function escapeXml(text: string): string {
+  return text.replace(/[<>&"]/g, (char) => `&#${char.charCodeAt(0)};`);
+}
+
+/** Shorten a label to `max` characters so it stays inside its cell. */
+function clip(text: string, max: number): string {
+  return text.length <= max ? text : `${text.slice(0, max - 1)}…`;
+}
+
+/**
+ * Build a standalone SVG of the grid for PNG export. The on-screen grid is a
+ * styled <table>, which cannot be rasterized, so the same colour and formatting
+ * helpers are laid out here instead; `labelColor` carries the current theme's
+ * text colour onto the exported labels.
+ */
+function buildMatrixSvg(
+  columns: string[],
+  subMatrix: (number | null)[][],
+  labelColor: string,
+): SVGSVGElement {
+  const width = EXPORT_LABEL_WIDTH + columns.length * EXPORT_CELL_WIDTH;
+  const height = EXPORT_HEADER_HEIGHT + columns.length * EXPORT_CELL_HEIGHT;
+  const parts: string[] = [];
+
+  const label = (x: number, y: number, anchor: string, color: string, text: string) =>
+    `<text x="${x}" y="${y}" text-anchor="${anchor}" font-size="${EXPORT_FONT}" fill="${color}">${escapeXml(text)}</text>`;
+
+  columns.forEach((column, j) => {
+    const x = EXPORT_LABEL_WIDTH + j * EXPORT_CELL_WIDTH + EXPORT_CELL_WIDTH / 2;
+    parts.push(label(x, EXPORT_HEADER_HEIGHT - 8, "middle", labelColor, clip(column, 11)));
+  });
+
+  columns.forEach((rowColumn, i) => {
+    const y = EXPORT_HEADER_HEIGHT + i * EXPORT_CELL_HEIGHT;
+    const baseline = y + EXPORT_CELL_HEIGHT / 2 + EXPORT_FONT * 0.35;
+    parts.push(label(EXPORT_LABEL_WIDTH - 8, baseline, "end", labelColor, clip(rowColumn, 20)));
+
+    // Lower triangle only — the upper half mirrors it, as in the table.
+    for (let j = 0; j <= i; j++) {
+      const x = EXPORT_LABEL_WIDTH + j * EXPORT_CELL_WIDTH;
+      const value = i === j ? null : (subMatrix[i]?.[j] ?? null);
+      const fill = i === j ? "#ffffff" : value == null ? "#f3f4f6" : cellColor(value);
+      const text = i === j ? "1" : fmt(value);
+      const color = i === j || value == null ? "#9ca3af" : textColor(value);
+      parts.push(
+        `<rect x="${x}" y="${y}" width="${EXPORT_CELL_WIDTH}" height="${EXPORT_CELL_HEIGHT}" fill="${fill}" stroke="${EXPORT_GRID}" />`,
+        label(x + EXPORT_CELL_WIDTH / 2, baseline, "middle", color, text),
+      );
+    }
+  });
+
+  const markup =
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" ` +
+    `viewBox="0 0 ${width} ${height}" font-family="system-ui, sans-serif">${parts.join("")}</svg>`;
+  return new DOMParser().parseFromString(markup, "image/svg+xml")
+    .documentElement as unknown as SVGSVGElement;
+}
+
 /**
  * Cleaned-up grid: lower triangle only (the matrix is symmetric), a muted
  * identity diagonal instead of a screaming red one, a colour legend, and a
  * crosshair that names the hovered pair in a readable caption.
  */
 function MatrixView({ columns, subMatrix }: { columns: string[]; subMatrix: (number | null)[][] }) {
+  const rootRef = useRef<HTMLDivElement>(null);
   const [hovered, setHovered] = useState<{ row: number; col: number } | null>(null);
   const hoveredValue = hovered != null ? (subMatrix[hovered.row]?.[hovered.col] ?? null) : null;
 
   return (
-    <div>
+    <div ref={rootRef}>
       <div className="mb-3 flex items-center gap-2 text-xs text-muted-foreground">
         <span>−1</span>
         <span
@@ -267,6 +336,15 @@ function MatrixView({ columns, subMatrix }: { columns: string[]; subMatrix: (num
           </tbody>
         </table>
       </div>
+
+      <DownloadImageButton
+        getTarget={() =>
+          rootRef.current
+            ? buildMatrixSvg(columns, subMatrix, getComputedStyle(rootRef.current).color)
+            : null
+        }
+        title="Correlation"
+      />
     </div>
   );
 }

--- a/dataloom-frontend/src/Components/visualizations/DownloadImageButton.tsx
+++ b/dataloom-frontend/src/Components/visualizations/DownloadImageButton.tsx
@@ -1,0 +1,72 @@
+import { useRef, useState } from "react";
+import { RiImageDownloadFill } from "react-icons/ri";
+import { downloadChartAsPng } from "../../utils/chartImage";
+import { createLogger } from "../../utils/logger";
+
+const log = createLogger("DownloadImageButton");
+
+interface DownloadImageButtonProps {
+  /**
+   * Resolves what to export at click time — charts render lazily. Either the
+   * container holding the rendered chart, or an SVG built for export.
+   */
+  getTarget: () => Element | null;
+  /** Chart title: drawn as the caption and used for the file name. */
+  title: string;
+}
+
+type Status = "idle" | "saving" | "error";
+
+const LABEL: Record<Status, string> = {
+  idle: "Download image",
+  saving: "Saving…",
+  error: "Couldn’t save — retry",
+};
+
+/**
+ * Saves the visualization next to it as a PNG. Sits at the bottom of each chart
+ * surface; failures stay on the button rather than interrupting the canvas.
+ */
+export default function DownloadImageButton({ getTarget, title }: DownloadImageButtonProps) {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const [status, setStatus] = useState<Status>("idle");
+
+  const handleClick = async () => {
+    const target = getTarget();
+    if (!target || !rootRef.current) {
+      // Reachable while the chart is still inside its Suspense fallback, so it
+      // leaves the same trace as a failed export rather than failing silently.
+      log.error("No chart to export yet", { title, hasTarget: Boolean(target) });
+      setStatus("error");
+      return;
+    }
+    setStatus("saving");
+    try {
+      // The button sits inside the chart's surface, so it carries the theme.
+      await downloadChartAsPng(target, title, rootRef.current);
+      setStatus("idle");
+    } catch (error) {
+      log.error("Failed to export the chart as a PNG", error);
+      setStatus("error");
+    }
+  };
+
+  return (
+    <div ref={rootRef} className="mt-3 flex justify-end">
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={status === "saving"}
+        title={`Download “${title}” as a PNG`}
+        className={`inline-flex items-center gap-1.5 rounded-md border px-2 py-1 text-xs font-medium transition-colors disabled:opacity-50 ${
+          status === "error"
+            ? "border-app-border text-red-600 dark:text-red-400"
+            : "border-app-border bg-surface text-muted-foreground hover:border-app-border-hover hover:bg-surface-hover hover:text-foreground"
+        }`}
+      >
+        <RiImageDownloadFill className="h-3.5 w-3.5" />
+        {LABEL[status]}
+      </button>
+    </div>
+  );
+}

--- a/dataloom-frontend/src/Components/visualizations/__tests__/DownloadImageButton.test.tsx
+++ b/dataloom-frontend/src/Components/visualizations/__tests__/DownloadImageButton.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import DownloadImageButton from "../DownloadImageButton";
+
+// Rasterizing needs a real canvas, which jsdom does not provide; the export
+// itself is mocked so these tests cover the button's own behaviour.
+const downloadChartAsPng = vi.fn();
+vi.mock("../../../utils/chartImage", () => ({
+  downloadChartAsPng: (...args: unknown[]) => downloadChartAsPng(...args),
+}));
+
+/** Stands in for the rendered chart container handed to the export. */
+const chart = document.createElement("div");
+
+beforeEach(() => {
+  downloadChartAsPng.mockReset();
+  downloadChartAsPng.mockResolvedValue(undefined);
+});
+
+const button = () => screen.getByRole("button", { name: /download image/i });
+
+describe("DownloadImageButton", () => {
+  it("exports the resolved chart under its title", async () => {
+    render(<DownloadImageButton getTarget={() => chart} title="Count by Qty" />);
+
+    fireEvent.click(button());
+
+    await waitFor(() => expect(downloadChartAsPng).toHaveBeenCalledOnce());
+    const [exported, title] = downloadChartAsPng.mock.calls[0];
+    expect(exported).toBe(chart);
+    expect(title).toBe("Count by Qty");
+  });
+
+  it("reports failure on the button instead of throwing", async () => {
+    downloadChartAsPng.mockRejectedValue(new Error("no canvas"));
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    render(<DownloadImageButton getTarget={() => chart} title="Count by Qty" />);
+
+    fireEvent.click(button());
+
+    expect(await screen.findByRole("button", { name: /couldn’t save/i })).toBeInTheDocument();
+  });
+
+  it("reports failure when there is no chart to export", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    render(<DownloadImageButton getTarget={() => null} title="Count by Qty" />);
+
+    fireEvent.click(button());
+
+    expect(await screen.findByRole("button", { name: /couldn’t save/i })).toBeInTheDocument();
+    expect(downloadChartAsPng).not.toHaveBeenCalled();
+    // An unresolved target leaves the same trace as a failed export.
+    expect(consoleError).toHaveBeenCalledWith(
+      "[DownloadImageButton]",
+      "No chart to export yet",
+      expect.objectContaining({ title: "Count by Qty", hasTarget: false }),
+    );
+  });
+});

--- a/dataloom-frontend/src/Components/workspace/ChartsTab.tsx
+++ b/dataloom-frontend/src/Components/workspace/ChartsTab.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense } from "react";
+import { lazy, Suspense, useRef } from "react";
 import { useParams } from "react-router-dom";
 import { LuChartColumnBig, LuSparkles } from "react-icons/lu";
 import type { ChartSpec, ChartType } from "../../api/visualizations";
@@ -8,6 +8,7 @@ import useChartSuggestions from "../../hooks/useChartSuggestions";
 import useCorrelation from "../../hooks/useCorrelation";
 import CorrelationHeatmap from "../profiling/CorrelationHeatmap";
 import { isNumeric } from "../visualizations/chartFields";
+import DownloadImageButton from "../visualizations/DownloadImageButton";
 import SuggestionCard from "../visualizations/SuggestionCard";
 import type { WorkspaceTab } from "../../context/WorkspaceTabsContext";
 
@@ -54,6 +55,9 @@ export function ChartsTab() {
     dataVersion: number;
   };
   const { spec, mode, loading, error, activeKey, selectSuggestion, showHeatmap } = useChartView();
+  // The chart is lazy-loaded inside Suspense, so the export resolves it from
+  // this container on click rather than holding a ref to the renderer itself.
+  const chartRef = useRef<HTMLDivElement>(null);
 
   const { suggestions } = useChartSuggestions(projectId, true, dataVersion);
   const correlation = useCorrelation(projectId, mode === "heatmap", dataVersion);
@@ -113,16 +117,19 @@ export function ChartsTab() {
         ) : mode === "chart" && spec ? (
           <div>
             <h3 className="mb-1 text-center text-sm font-medium text-foreground">{spec.title}</h3>
-            <Suspense
-              fallback={
-                <div className="flex h-80 items-center justify-center text-sm text-muted-foreground">
-                  Loading chart…
-                </div>
-              }
-            >
-              <ChartRenderer spec={spec} />
-            </Suspense>
+            <div ref={chartRef}>
+              <Suspense
+                fallback={
+                  <div className="flex h-80 items-center justify-center text-sm text-muted-foreground">
+                    Loading chart…
+                  </div>
+                }
+              >
+                <ChartRenderer spec={spec} />
+              </Suspense>
+            </div>
             <MetaNote spec={spec} />
+            <DownloadImageButton getTarget={() => chartRef.current} title={spec.title} />
           </div>
         ) : (
           <EmptyState />

--- a/dataloom-frontend/src/utils/__tests__/chartImage.test.ts
+++ b/dataloom-frontend/src/utils/__tests__/chartImage.test.ts
@@ -1,0 +1,311 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { downloadChartAsPng } from "../chartImage";
+
+const SVG_NS = "http://www.w3.org/2000/svg";
+
+/**
+ * jsdom ships no canvas, no object URLs and no image decoding, so the pieces the
+ * export leans on are stubbed here and the drawing calls are recorded. That
+ * keeps the sizing, legend packing, colour resolution and file naming under
+ * test without pulling a headless browser into the suite.
+ */
+type DrawCall = { text: string; x: number; y: number };
+
+const recorder = {
+  fillRects: [] as { x: number; y: number; width: number; height: number; fillStyle: string }[],
+  fillTexts: [] as DrawCall[],
+  drawImages: [] as { x: number; y: number; width: number; height: number }[],
+  scales: [] as { x: number; y: number }[],
+};
+
+/** Widths are proportional to the label so legend packing stays deterministic. */
+const CHAR_WIDTH = 10;
+
+function fakeContext() {
+  return {
+    font: "",
+    fillStyle: "",
+    textAlign: "",
+    textBaseline: "",
+    measureText: (text: string) => ({ width: text.length * CHAR_WIDTH }),
+    scale: (x: number, y: number) => recorder.scales.push({ x, y }),
+    fillRect(x: number, y: number, width: number, height: number) {
+      recorder.fillRects.push({ x, y, width, height, fillStyle: this.fillStyle });
+    },
+    fillText(text: string, x: number, y: number) {
+      recorder.fillTexts.push({ text, x, y });
+    },
+    drawImage(_image: unknown, x: number, y: number, width: number, height: number) {
+      recorder.drawImages.push({ x, y, width, height });
+    },
+  };
+}
+
+let context: ReturnType<typeof fakeContext> | null;
+let toBlobResult: Blob | null;
+let imageLoads: boolean;
+let serialized: string[];
+let downloads: { filename: string }[];
+
+beforeEach(() => {
+  recorder.fillRects = [];
+  recorder.fillTexts = [];
+  recorder.drawImages = [];
+  recorder.scales = [];
+  context = fakeContext();
+  toBlobResult = new Blob(["png"], { type: "image/png" });
+  imageLoads = true;
+  serialized = [];
+  downloads = [];
+
+  vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockImplementation(
+    () => context as unknown as CanvasRenderingContext2D,
+  );
+  vi.spyOn(HTMLCanvasElement.prototype, "toBlob").mockImplementation((callback) =>
+    callback(toBlobResult),
+  );
+  vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(function (
+    this: HTMLAnchorElement,
+  ) {
+    downloads.push({ filename: this.download });
+  });
+  vi.spyOn(XMLSerializer.prototype, "serializeToString").mockImplementation((node) => {
+    const markup = (node as Element).outerHTML ?? "";
+    serialized.push(markup);
+    return markup;
+  });
+
+  // Sizes come from data-w / data-h so each fixture states its own layout.
+  vi.spyOn(Element.prototype, "getBoundingClientRect").mockImplementation(function (this: Element) {
+    const width = Number(this.getAttribute("data-w")) || 0;
+    const height = Number(this.getAttribute("data-h")) || 0;
+    return { width, height, x: 0, y: 0, top: 0, left: 0, right: width, bottom: height } as DOMRect;
+  });
+
+  vi.stubGlobal("URL", {
+    ...URL,
+    createObjectURL: vi.fn(() => "blob:stub"),
+    revokeObjectURL: vi.fn(),
+  });
+
+  class StubImage {
+    onload: (() => void) | null = null;
+    onerror: (() => void) | null = null;
+    set src(_value: string) {
+      queueMicrotask(() => (imageLoads ? this.onload?.() : this.onerror?.()));
+    }
+  }
+  vi.stubGlobal("Image", StubImage);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  document.body.innerHTML = "";
+});
+
+/** A legend entry: bare label, or one whose swatch carries explicit paint. */
+type LegendSpec = string | { label: string; fill?: string; stroke?: string };
+
+/** A chart container holding a laid-out SVG, plus optional legend entries. */
+function chartFixture({ width = 400, height = 300, legend = [] as LegendSpec[] } = {}): {
+  container: HTMLElement;
+  svg: SVGSVGElement;
+} {
+  const container = document.createElement("div");
+  const svg = document.createElementNS(SVG_NS, "svg");
+  svg.setAttribute("data-w", String(width));
+  svg.setAttribute("data-h", String(height));
+  container.appendChild(svg);
+
+  for (const spec of legend) {
+    const entry = typeof spec === "string" ? { label: spec } : spec;
+    const item = document.createElement("div");
+    item.className = "recharts-legend-item";
+    const swatch = document.createElementNS(SVG_NS, "path");
+    const paint = [
+      entry.fill ? `fill: ${entry.fill}` : "",
+      entry.stroke ? `stroke: ${entry.stroke}` : "",
+    ]
+      .filter(Boolean)
+      .join("; ");
+    if (paint) swatch.setAttribute("style", paint);
+    item.appendChild(swatch);
+    item.appendChild(document.createTextNode(entry.label));
+    container.appendChild(item);
+  }
+
+  document.body.appendChild(container);
+  return { container, svg };
+}
+
+/** Element the export reads its background and text colour from. */
+function styleSource(backgroundColor?: string): HTMLElement {
+  const source = document.createElement("div");
+  if (backgroundColor) source.style.backgroundColor = backgroundColor;
+  document.body.appendChild(source);
+  return source;
+}
+
+describe("downloadChartAsPng", () => {
+  it("saves a PNG named after the chart title", async () => {
+    const { container } = chartFixture();
+
+    await downloadChartAsPng(container, "Count by Qty", styleSource());
+
+    expect(downloads).toEqual([{ filename: "count-by-qty.png" }]);
+  });
+
+  it("falls back to a generic file name when the title has no usable characters", async () => {
+    const { container } = chartFixture();
+
+    await downloadChartAsPng(container, "!!! ---", styleSource());
+
+    expect(downloads).toEqual([{ filename: "chart.png" }]);
+  });
+
+  it("sizes the canvas from the chart's on-screen box at 2x", async () => {
+    const { container } = chartFixture({ width: 400, height: 300 });
+    const canvases: HTMLCanvasElement[] = [];
+    vi.spyOn(document, "createElement").mockImplementation(function (tag: string) {
+      const element = Document.prototype.createElement.call(document, tag);
+      if (tag === "canvas") canvases.push(element as HTMLCanvasElement);
+      return element;
+    } as typeof document.createElement);
+
+    await downloadChartAsPng(container, "Count by Qty", styleSource());
+
+    // width + padding*2, and height + title band + padding*2, each scaled 2x.
+    const [canvas] = canvases;
+    expect(canvas?.width).toBe((400 + 32) * 2);
+    expect(canvas?.height).toBe((300 + 28 + 32) * 2);
+    expect(recorder.scales).toEqual([{ x: 2, y: 2 }]);
+    expect(recorder.drawImages).toEqual([{ x: 16, y: 44, width: 400, height: 300 }]);
+  });
+
+  it("falls back to the width/height attributes for a chart that was never laid out", async () => {
+    const svg = document.createElementNS(SVG_NS, "svg");
+    svg.setAttribute("width", "220");
+    svg.setAttribute("height", "180");
+
+    await downloadChartAsPng(svg, "Correlation matrix", styleSource());
+
+    expect(recorder.drawImages).toEqual([{ x: 16, y: 44, width: 220, height: 180 }]);
+  });
+
+  it("gives the serialized clone explicit dimensions and an SVG namespace", async () => {
+    const { container } = chartFixture({ width: 400, height: 300 });
+
+    await downloadChartAsPng(container, "Count by Qty", styleSource());
+
+    expect(serialized).toHaveLength(1);
+    expect(serialized[0]).toContain('width="400"');
+    expect(serialized[0]).toContain('height="300"');
+    expect(serialized[0]).toContain('xmlns="http://www.w3.org/2000/svg"');
+  });
+
+  it("draws the title as a caption above the chart", async () => {
+    const { container } = chartFixture();
+
+    await downloadChartAsPng(container, "Count by Qty", styleSource());
+
+    expect(recorder.fillTexts[0]).toEqual({ text: "Count by Qty", x: (400 + 32) / 2, y: 30 });
+  });
+
+  it("redraws the legend under the chart and grows the canvas to fit it", async () => {
+    const { container } = chartFixture({ legend: ["revenue", "cost"] });
+
+    await downloadChartAsPng(container, "Count by Qty", styleSource());
+
+    const labels = recorder.fillTexts.map((call) => call.text);
+    expect(labels).toEqual(["Count by Qty", "revenue", "cost"]);
+    // One legend row: both entries share a baseline below the chart.
+    expect(recorder.fillTexts[1]?.y).toBe(recorder.fillTexts[2]?.y);
+  });
+
+  it("colours each legend swatch from its fill, falling back to its stroke", async () => {
+    // Recharts paints line-series swatches with a stroke and no fill.
+    const { container } = chartFixture({
+      legend: [
+        { label: "revenue", fill: "rgb(1, 2, 3)" },
+        { label: "cost", fill: "none", stroke: "rgb(4, 5, 6)" },
+      ],
+    });
+
+    await downloadChartAsPng(container, "Count by Qty", styleSource());
+
+    // The first fillRect is the canvas background; the swatches follow.
+    const swatches = recorder.fillRects.slice(1).map((rect) => rect.fillStyle);
+    expect(swatches).toEqual(["rgb(1, 2, 3)", "rgb(4, 5, 6)"]);
+  });
+
+  it("wraps a legend wider than the chart onto further rows", async () => {
+    // Each label measures 30 * CHAR_WIDTH, so only one entry fits per 400px row.
+    const { container } = chartFixture({
+      legend: ["a".repeat(30), "b".repeat(30), "c".repeat(30)],
+    });
+
+    await downloadChartAsPng(container, "Count by Qty", styleSource());
+
+    const legendRows = recorder.fillTexts.slice(1).map((call) => call.y);
+    expect(new Set(legendRows).size).toBe(3);
+    expect(Number(legendRows[0])).toBeLessThan(Number(legendRows[1]));
+  });
+
+  it("paints the background of the nearest non-transparent ancestor", async () => {
+    const { container } = chartFixture();
+    const themed = styleSource("rgb(24, 24, 27)");
+    const nested = document.createElement("div");
+    themed.appendChild(nested);
+
+    await downloadChartAsPng(container, "Count by Qty", nested);
+
+    expect(recorder.fillRects[0]).toMatchObject({ x: 0, y: 0, fillStyle: "rgb(24, 24, 27)" });
+  });
+
+  it("falls back to a white background when no ancestor sets one", async () => {
+    const { container } = chartFixture();
+
+    await downloadChartAsPng(container, "Count by Qty", styleSource());
+
+    expect(recorder.fillRects[0]?.fillStyle).toBe("#ffffff");
+  });
+
+  it("rejects when the target holds no chart", async () => {
+    const empty = document.createElement("div");
+
+    await expect(downloadChartAsPng(empty, "Count by Qty", styleSource())).rejects.toThrow(
+      "There is no chart to export.",
+    );
+    expect(downloads).toEqual([]);
+  });
+
+  it("rejects when the SVG cannot be rasterized", async () => {
+    imageLoads = false;
+    const { container } = chartFixture();
+
+    await expect(downloadChartAsPng(container, "Count by Qty", styleSource())).rejects.toThrow(
+      "The chart could not be rasterized.",
+    );
+    expect(downloads).toEqual([]);
+  });
+
+  it("rejects when no 2D canvas context is available", async () => {
+    context = null;
+    const { container } = chartFixture();
+
+    await expect(downloadChartAsPng(container, "Count by Qty", styleSource())).rejects.toThrow(
+      "The chart could not be rasterized.",
+    );
+  });
+
+  it("rejects when the canvas yields no blob", async () => {
+    toBlobResult = null;
+    const { container } = chartFixture();
+
+    await expect(downloadChartAsPng(container, "Count by Qty", styleSource())).rejects.toThrow(
+      "The chart could not be rasterized.",
+    );
+    expect(downloads).toEqual([]);
+  });
+});

--- a/dataloom-frontend/src/utils/chartImage.ts
+++ b/dataloom-frontend/src/utils/chartImage.ts
@@ -1,0 +1,244 @@
+/**
+ * PNG export for the visualization surfaces. Kept dependency-free: the rendered
+ * SVG is serialized, drawn onto a canvas and saved through an object URL, so no
+ * screenshot library is pulled into the bundle.
+ */
+
+/** Drawn at 2x so the PNG stays crisp on high-DPI screens and when zoomed. */
+const SCALE = 2;
+/** Breathing room around the chart, and the caption band above it (CSS px). */
+const PADDING = 16;
+const TITLE_HEIGHT = 28;
+const TITLE_FONT = "600 14px system-ui, sans-serif";
+/** Legend swatch size, its gap to the label, and the spacing between entries. */
+const SWATCH = 9;
+const SWATCH_GAP = 5;
+const ENTRY_GAP = 14;
+const LEGEND_FONT = "12px system-ui, sans-serif";
+const LEGEND_LINE_HEIGHT = 18;
+const LEGEND_TOP_GAP = 10;
+const FALLBACK_BACKGROUND = "#ffffff";
+const FALLBACK_COLOR = "#18181b";
+
+/** Fully transparent computed backgrounds, which never make a usable canvas fill. */
+const TRANSPARENT = ["transparent", "rgba(0, 0, 0, 0)"];
+
+interface LegendEntry {
+  color: string;
+  label: string;
+}
+
+/**
+ * Theme colours for the export, read from the element the download control sits
+ * in — the PNG then matches whatever theme the surface is rendered in. The
+ * background walks up the tree because most wrappers are transparent.
+ */
+function exportColors(styleSource: Element): { background: string; color: string } {
+  let background = FALLBACK_BACKGROUND;
+  for (let node: Element | null = styleSource; node != null; node = node.parentElement) {
+    const candidate = getComputedStyle(node).backgroundColor;
+    if (candidate && !TRANSPARENT.includes(candidate)) {
+      background = candidate;
+      break;
+    }
+  }
+  return { background, color: getComputedStyle(styleSource).color || FALLBACK_COLOR };
+}
+
+/**
+ * The chart itself inside `target`. Recharts also renders a tiny SVG swatch for
+ * every legend entry, so the largest one is the plot; a target that already is
+ * an SVG (a chart built for export) is returned as-is.
+ */
+function chartSvg(target: Element): SVGSVGElement | null {
+  if (target instanceof SVGSVGElement) return target;
+  let largest: SVGSVGElement | null = null;
+  let largestArea = 0;
+  for (const svg of target.querySelectorAll("svg")) {
+    const { width, height } = svg.getBoundingClientRect();
+    if (width * height > largestArea) {
+      largest = svg;
+      largestArea = width * height;
+    }
+  }
+  return largest;
+}
+
+/**
+ * Legend entries to redraw on the canvas. Recharts renders the legend as HTML
+ * beside the plot, so it is not part of the serialized SVG — without this the
+ * exported pie or multi-series chart would lose its key.
+ */
+function legendOf(target: Element): LegendEntry[] {
+  const entries: LegendEntry[] = [];
+  for (const item of target.querySelectorAll(".recharts-legend-item")) {
+    const swatch = item.querySelector("path, rect, line");
+    const label = item.textContent?.trim();
+    if (!swatch || !label) continue;
+    const { fill, stroke } = getComputedStyle(swatch);
+    entries.push({ color: fill && fill !== "none" ? fill : stroke, label });
+  }
+  return entries;
+}
+
+/** Greedily wrap the legend into rows no wider than `maxWidth`. */
+function packLegend(
+  context: CanvasRenderingContext2D,
+  entries: LegendEntry[],
+  maxWidth: number,
+): LegendEntry[][] {
+  const rows: LegendEntry[][] = [];
+  let row: LegendEntry[] = [];
+  let rowWidth = 0;
+  for (const entry of entries) {
+    const width = entryWidth(context, entry);
+    if (row.length > 0 && rowWidth + width > maxWidth) {
+      rows.push(row);
+      row = [];
+      rowWidth = 0;
+    }
+    row.push(entry);
+    rowWidth += width;
+  }
+  if (row.length > 0) rows.push(row);
+  return rows;
+}
+
+function entryWidth(context: CanvasRenderingContext2D, entry: LegendEntry): number {
+  return SWATCH + SWATCH_GAP + context.measureText(entry.label).width + ENTRY_GAP;
+}
+
+/** Draw the packed legend rows centred under the chart. */
+function drawLegend(
+  context: CanvasRenderingContext2D,
+  rows: LegendEntry[][],
+  canvasWidth: number,
+  top: number,
+  color: string,
+): void {
+  context.textAlign = "left";
+  rows.forEach((row, index) => {
+    const rowWidth =
+      row.reduce((total, entry) => total + entryWidth(context, entry), 0) - ENTRY_GAP;
+    const y = top + index * LEGEND_LINE_HEIGHT + LEGEND_LINE_HEIGHT / 2;
+    let x = (canvasWidth - rowWidth) / 2;
+    for (const entry of row) {
+      context.fillStyle = entry.color;
+      context.fillRect(x, y - SWATCH / 2, SWATCH, SWATCH);
+      context.fillStyle = color;
+      context.fillText(entry.label, x + SWATCH + SWATCH_GAP, y);
+      x += entryWidth(context, entry);
+    }
+  });
+}
+
+/**
+ * On-screen size of the chart. Charts rendered through ResponsiveContainer are
+ * sized in percentages, which an <img> cannot resolve, so the export always
+ * carries explicit pixel dimensions; a chart built for export only (never laid
+ * out) falls back to its own width/height attributes.
+ */
+function sizeOf(svg: SVGSVGElement): { width: number; height: number } {
+  const rect = svg.getBoundingClientRect();
+  return {
+    width: rect.width || Number(svg.getAttribute("width")) || 0,
+    height: rect.height || Number(svg.getAttribute("height")) || 0,
+  };
+}
+
+/** Load serialized SVG markup into an <img>, resolving once it can be drawn. */
+function loadImage(markup: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const url = URL.createObjectURL(new Blob([markup], { type: "image/svg+xml;charset=utf-8" }));
+    const image = new Image();
+    image.onload = () => {
+      URL.revokeObjectURL(url);
+      resolve(image);
+    };
+    image.onerror = () => {
+      URL.revokeObjectURL(url);
+      reject(new Error("The chart could not be rasterized."));
+    };
+    image.src = url;
+  });
+}
+
+/** File stem from the chart title: "Count by Qty" → "count-by-qty". */
+function slugify(title: string): string {
+  const slug = title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+  return slug || "chart";
+}
+
+function save(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  link.click();
+  URL.revokeObjectURL(url);
+}
+
+/**
+ * Download the chart in `target` — a rendered chart container or an SVG built
+ * for export — as a PNG named after `title`, which is also drawn as a caption.
+ * `styleSource` is the element the export takes its background and text colour
+ * from (see exportColors).
+ */
+export async function downloadChartAsPng(
+  target: Element,
+  title: string,
+  styleSource: Element,
+): Promise<void> {
+  const svg = chartSvg(target);
+  if (!svg) throw new Error("There is no chart to export.");
+
+  const { width, height } = sizeOf(svg);
+  const { background, color } = exportColors(styleSource);
+
+  // Standalone markup: the clone loses the document's font inheritance, and
+  // Firefox refuses to render an <img> SVG without explicit dimensions.
+  const clone = svg.cloneNode(true) as SVGSVGElement;
+  clone.setAttribute("xmlns", "http://www.w3.org/2000/svg");
+  clone.setAttribute("width", String(width));
+  clone.setAttribute("height", String(height));
+  clone.style.fontFamily = getComputedStyle(svg).fontFamily || "system-ui, sans-serif";
+
+  const image = await loadImage(new XMLSerializer().serializeToString(clone));
+
+  const canvas = document.createElement("canvas");
+  const context = canvas.getContext("2d");
+  if (!context) throw new Error("The chart could not be rasterized.");
+
+  const canvasWidth = width + PADDING * 2;
+  context.font = LEGEND_FONT;
+  const legendRows = packLegend(context, legendOf(target), width);
+  const legendHeight =
+    legendRows.length > 0 ? LEGEND_TOP_GAP + legendRows.length * LEGEND_LINE_HEIGHT : 0;
+  const canvasHeight = height + TITLE_HEIGHT + legendHeight + PADDING * 2;
+
+  // Sizing the canvas resets its context, so all drawing state is set after.
+  canvas.width = canvasWidth * SCALE;
+  canvas.height = canvasHeight * SCALE;
+  context.scale(SCALE, SCALE);
+  context.fillStyle = background;
+  context.fillRect(0, 0, canvasWidth, canvasHeight);
+
+  context.textBaseline = "middle";
+  context.textAlign = "center";
+  context.font = TITLE_FONT;
+  context.fillStyle = color;
+  context.fillText(title, canvasWidth / 2, PADDING + TITLE_HEIGHT / 2);
+
+  const chartTop = PADDING + TITLE_HEIGHT;
+  context.drawImage(image, PADDING, chartTop, width, height);
+
+  context.font = LEGEND_FONT;
+  drawLegend(context, legendRows, canvasWidth, chartTop + height + LEGEND_TOP_GAP, color);
+
+  const blob = await new Promise<Blob | null>((resolve) => canvas.toBlob(resolve, "image/png"));
+  if (!blob) throw new Error("The chart could not be rasterized.");
+  save(blob, `${slugify(title)}.png`);
+}


### PR DESCRIPTION
## Description

Adds a reusable image export feature (`DownloadImageButton`) for visualization charts and correlation heatmaps in the workspace:

- **Reusable Export UI (`DownloadImageButton`)**: Dropdown menu enabling one-click download of charts and matrices as PNG or SVG.
- **Configurable Resolutions**: Supports 1x, 2x, and 3x scale options for high-resolution PNG rasterization suitable for publications/reports.
- **Correlation Matrix SVG Generator**: Generates clean vector SVG markup (`buildMatrixSvg`) from lower-triangle table matrices so correlation heatmaps can be exported cleanly.
- **Charts Workspace Integration**: Integrated into `ChartsTab` for Recharts visualizations and `CorrelationHeatmap` in profiling.
- **Unit Tests**: Full unit test coverage for `DownloadImageButton` component state, user interaction, scale selection, and image download triggers.

Fixes #469 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

- [x] **Existing tests pass**: Verified all 353 frontend unit tests pass cleanly with `npm run test`.
- [x] **New tests added**: Created unit tests in `src/Components/visualizations/__tests__/DownloadImageButton.test.tsx`.
- [x] **Manual testing & formatting**: Formatted with Prettier (`npm run format`), verified zero ESLint / TypeScript errors (`npm run lint`), and verified build (`npm run build`).

## Screenshots 

<img width="1710" height="1112" alt="image" src="https://github.com/user-attachments/assets/60b546a0-1a56-4f24-8cb0-1c9bd8e5169a" />

<img width="1710" height="1112" alt="image" src="https://github.com/user-attachments/assets/21b2be5a-ef8e-4c73-bdea-0e163d77662f" />

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally