### PR TITLE
fix: replace invalid RiImageDownloadFill icon export

### DIFF
--- a/dataloom-frontend/src/Components/visualizations/DownloadImageButton.tsx
+++ b/dataloom-frontend/src/Components/visualizations/DownloadImageButton.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState } from "react";
-import { RiFileDownloadFill } from "react-icons/ri";
+import { RiDownload2Fill } from "react-icons/ri";
 import { downloadChartAsPng } from "../../utils/chartImage";
 import { createLogger } from "../../utils/logger";
 
@@ -64,7 +64,7 @@ export default function DownloadImageButton({ getTarget, title }: DownloadImageB
             : "border-app-border bg-surface text-muted-foreground hover:border-app-border-hover hover:bg-surface-hover hover:text-foreground"
         }`}
       >
-        <RiFileDownloadFill className="h-3.5 w-3.5" />
+        <RiDownload2Fill className="h-3.5 w-3.5" />
         {LABEL[status]}
       </button>
     </div>


### PR DESCRIPTION
## Description

Replaced the invalid `RiImageDownloadFill` icon import with a valid icon from `react-icons/ri`.

The invalid export was causing the Vite application to fail at runtime with:

```text
Uncaught SyntaxError: The requested module '/node_modules/.vite/deps/react-icons_ri.js' does not provide an export named 'RiImageDownloadFill'
```

Fixes #475 

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

The application was started locally using the Vite development server and the affected component was verified to load without the module export error.

- [x] Existing tests pass
- [x] Manual testing

## Screenshots
<img width="154" height="59" alt="Screenshot 2026-08-04 at 20 48 14" src="https://github.com/user-attachments/assets/35bd59bc-008e-4301-a5de-78e32bfea085" />


## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally