### PR TITLE
test: improve pagination HTTP semantics test consistency

### DIFF
--- a/dataloom-backend/tests/test_transform_http_semantics.py
+++ b/dataloom-backend/tests/test_transform_http_semantics.py
@@ -399,15 +399,13 @@ def test_transform_preview_pagination(client, pagination_project, extra_params, 
 @pytest.mark.parametrize(
     "invalid_params",
     [
-        {"page": 0, "page_size": 50},
-        {"page": 1, "page_size": 0},
-        {"page": 1, "page_size": 101},
+        pytest.param({"page": 0, "page_size": 50}, id="page_below_minimum"),
+        pytest.param({"page": 1, "page_size": 0}, id="page_size_below_minimum"),
+        pytest.param({"page": 1, "page_size": 101}, id="page_size_above_maximum"),
     ],
-    ids=["page_below_minimum", "page_size_below_minimum", "page_size_above_maximum"],
 )
 def test_transform_preview_rejects_out_of_bounds_query_params(client, pagination_project, invalid_params):
-    # The endpoint declares page/page_size via Query(..., ge=1, le=100); values
-    # outside that range must 422, not silently clamp.
+    # page and page_size must be at least 1; page_size is also capped at 100.
     project_id = pagination_project["project_id"]
 
     response = client.post(


### PR DESCRIPTION
## Description

Improve the pagination HTTP semantics tests by correcting an inaccurate validation comment and making pytest parametrization IDs consistent with the rest of the test file.

The changes clarify that only `page_size` has an upper bound of 100, while `page` only has a minimum value of 1. The invalid query parameter cases now use per-case `pytest.param(..., id="...")` IDs to match the existing convention.

Fixes #479 

## Type of Change

- [x] Improve consistency of test cases

## How Has This Been Tested?

The existing pagination HTTP semantics tests were reviewed to ensure the changes only affect test comments and parametrization style.

- [x] Existing tests pass
- [x] Manual testing

## Screenshots

Not applicable.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally