### PR TITLE
fix(api): align response types with the backend schemas

### DIFF
--- a/dataloom-frontend/src/Components/Table.tsx
+++ b/dataloom-frontend/src/Components/Table.tsx
@@ -128,8 +128,8 @@ const Table = ({ projectId, showColumnProfiles = false }: TableProps) => {
     dataVersion,
   );
 
-  // The API types rows as unknown[][]; this component also handles the
-  // column-keyed object form, so narrow to the local superset here.
+  // The API types response rows as CellValue[][]; this component also handles
+  // the column-keyed object form, so narrow to the local superset here.
   const applyTransform = (input: TransformationInput) =>
     transformProject(projectId, input) as unknown as Promise<TransformResponse>;
 

--- a/dataloom-frontend/src/api/index.ts
+++ b/dataloom-frontend/src/api/index.ts
@@ -15,12 +15,12 @@ export {
   getProjectMeta,
   getProjects,
 } from "./projects";
-export type { ExportOptions, ExportResult, ProjectDetails } from "./projects";
+export type { ExportOptions, ExportResult } from "./projects";
 export { getLogs, getCheckpoints, deleteCheckpoint } from "./logs";
 export type { Checkpoint, LogEntry } from "./logs";
 export { transformProject, groupByTransform, undoLastTransformation } from "./transforms";
 export type { TransformationInput, TransformOptions, TransformResult } from "./transforms";
-export type { CellValue, Pagination, ProjectSummary, TableResponse } from "./types";
+export type { CellValue, Pagination, ProjectDetails, ProjectSummary, TableResponse } from "./types";
 export { signup, signin, logout, getCurrentUser } from "./auth";
 export {
   getDatasetSummary,

--- a/dataloom-frontend/src/api/projects.ts
+++ b/dataloom-frontend/src/api/projects.ts
@@ -3,14 +3,7 @@
  * @module api/projects
  */
 import client from "./client";
-import type { Pagination, ProjectSummary, TableResponse } from "./types";
-
-/** Backend `ProjectResponse` — full project payload with paginated rows. */
-export interface ProjectDetails extends TableResponse, Pagination {
-  filename: string;
-  file_path: string;
-  project_id: string;
-}
+import type { ProjectDetails, ProjectSummary } from "./types";
 
 /** Export options accepted by {@link exportProject}. */
 export interface ExportOptions {

--- a/dataloom-frontend/src/api/transforms.ts
+++ b/dataloom-frontend/src/api/transforms.ts
@@ -3,7 +3,7 @@
  * @module api/transforms
  */
 import client from "./client";
-import type { Pagination, TableResponse } from "./types";
+import type { Pagination, ProjectDetails, TableResponse } from "./types";
 
 /** Backend `BasicQueryResponse` — pagination is present on preview requests. */
 export interface TransformResult extends TableResponse, Partial<Pagination> {
@@ -75,7 +75,7 @@ export const groupByTransform = async (
  * @param projectId - The project ID.
  * @returns Updated project data with rows and columns.
  */
-export const undoLastTransformation = async (projectId: string): Promise<TransformResult> => {
+export const undoLastTransformation = async (projectId: string): Promise<ProjectDetails> => {
   const response = await client.post(`/projects/${projectId}/undo`);
   return response.data;
 };

--- a/dataloom-frontend/src/api/types.ts
+++ b/dataloom-frontend/src/api/types.ts
@@ -13,7 +13,7 @@
  * A single table cell. The backend serialises every cell as a JSON scalar;
  * `undefined` arises on the client from sparse index access.
  */
-export type CellValue = string | number | null | undefined;
+export type CellValue = string | number | boolean | null | undefined;
 
 /** Tabular payload common to transform and project responses. */
 export interface TableResponse {
@@ -37,4 +37,11 @@ export interface ProjectSummary {
   name: string;
   description: string | null;
   last_modified: string;
+}
+
+/** Backend `ProjectResponse` — full project payload with paginated rows. */
+export interface ProjectDetails extends TableResponse, Pagination {
+  filename: string;
+  file_path: string;
+  project_id: string;
 }

--- a/dataloom-frontend/src/context/ProjectContext.tsx
+++ b/dataloom-frontend/src/context/ProjectContext.tsx
@@ -7,10 +7,9 @@ import {
   useMemo,
   type ReactNode,
 } from "react";
-import { getProjectDetails, type TransformationInput } from "../api";
+import { getProjectDetails, type CellValue, type TransformationInput } from "../api";
 
-/** A single table cell value. `undefined` arises from sparse index access. */
-export type CellValue = string | number | null | undefined;
+export type { CellValue };
 
 /** Pagination metadata as the backend spells it, plus the camelCase alias. */
 export interface PaginationInfo {
@@ -192,9 +191,7 @@ export function ProjectProvider({ children }: { children: ReactNode }) {
         setProjectId(data.project_id);
         setProjectName(data.filename);
         setColumns(data.columns);
-        // The endpoint types rows as unknown[][] because the backend echoes raw
-        // JSON; the table has always treated them as scalar cells.
-        setRows(data.rows as CellValue[][]);
+        setRows(data.rows);
         setDtypes(data.dtypes || {});
         setTotalRows(data.total_rows);
         setTotalPages(data.total_pages);


### PR DESCRIPTION
## Description

Applies the three review findings on #484, which landed on main before they were addressed. Types and comments only; no behaviour changes.

**`undoLastTransformation` returned the wrong shape** (`src/api/transforms.ts`)
`POST /projects/{id}/undo` declares `response_model=schemas.ProjectResponse`, and the handler always sets `page`, `page_size`, `total_rows` and `total_pages`. It was typed as `TransformResult` (the `BasicQueryResponse` shape), which adds an `operation_type` the endpoint never returns and marks the pagination fields optional. It is now `ProjectDetails`, the same type `getProjectDetails` uses.

`ProjectDetails` moved from `src/api/projects.ts` into `src/api/types.ts`, because two API modules now share it and `types.ts` is documented as the home for shared shapes. The barrel keeps the export, so no consumer import changed.

**`CellValue` omitted `boolean`** (`src/api/types.ts`)
Cast-to-boolean is a supported transform, and `dataframe_to_response` serialises the resulting native `bool` values straight into `rows`, so the API does return `true`/`false` cells. `CellValue` is now `string | number | boolean | null | undefined`.

`ProjectContext` declared its own `CellValue` without `boolean`, which broke `tsc` once the shared type widened. It now reuses the API type, and the `as CellValue[][]` cast on `data.rows` that the duplicate type required is gone.

**Stale comment** (`src/Components/Table.tsx`)
The comment above `applyTransform` said the API types rows as `unknown[][]`. Response rows are `CellValue[][]` via `TableResponse`, so the comment now says that.

Related: #484

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

`npm run lint` (eslint + `tsc --noEmit`) is clean, and `npm run test` passes 423 tests across 60 files. The `CellValue` widening is what surfaced the duplicate type in `ProjectContext`, so `tsc` covers that fix directly.

- [x] Existing tests pass
- [ ] New tests added
- [ ] Manual testing

## Screenshots (if applicable)

None; no UI changes.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally
