### PR TITLE
chore: migrate the common components to TypeScript

### DIFF
--- a/dataloom-frontend/src/Components/common/Button.tsx
+++ b/dataloom-frontend/src/Components/common/Button.tsx
@@ -1,12 +1,5 @@
-/**
- * Reusable button component with variant and size support.
- * @param {Object} props
- * @param {'primary'|'secondary'|'danger'|'ghost'|'success'} [props.variant='primary'] - Visual style variant.
- * @param {'sm'|'md'} [props.size='md'] - Button size.
- * @param {React.ReactNode} props.children - Button content.
- * @param {string} [props.className] - Additional CSS classes.
- * @param {Object} [props.rest] - Additional props passed to the button element.
- */
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+
 const VARIANT_CLASSES = {
   primary: "bg-accent text-white hover:bg-accent-hover focus:ring-accent",
 
@@ -25,13 +18,28 @@ const SIZE_CLASSES = {
   md: "px-4 py-2",
 };
 
+export type ButtonVariant = keyof typeof VARIANT_CLASSES;
+export type ButtonSize = keyof typeof SIZE_CLASSES;
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  /** Visual style variant. */
+  variant?: ButtonVariant;
+  /** Button size. */
+  size?: ButtonSize;
+  children?: ReactNode;
+  className?: string;
+}
+
+/**
+ * Reusable button component with variant and size support.
+ */
 export default function Button({
   variant = "primary",
   size = "md",
   children,
   className = "",
   ...rest
-}) {
+}: ButtonProps) {
   return (
     <button
       className={`rounded-md font-medium transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed ${

--- a/dataloom-frontend/src/Components/common/ConfirmDialog.tsx
+++ b/dataloom-frontend/src/Components/common/ConfirmDialog.tsx
@@ -1,15 +1,26 @@
 import Modal from "./Modal";
 import Button from "./Button";
 
+interface ConfirmDialogProps {
+  /** Whether dialog is visible. */
+  isOpen: boolean;
+  /** Confirmation message. */
+  message: string;
+  /** Callback on confirmation. */
+  onConfirm: () => void;
+  /** Callback on cancellation. */
+  onCancel: () => void;
+}
+
 /**
  * Confirmation dialog replacing window.confirm().
- * @param {Object} props
- * @param {boolean} props.isOpen - Whether dialog is visible.
- * @param {string} props.message - Confirmation message.
- * @param {Function} props.onConfirm - Callback on confirmation.
- * @param {Function} props.onCancel - Callback on cancellation.
  */
-export default function ConfirmDialog({ isOpen, message, onConfirm, onCancel }) {
+export default function ConfirmDialog({
+  isOpen,
+  message,
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
   return (
     <Modal isOpen={isOpen} onClose={onCancel} title="Confirm">
       <p className="mb-6 text-foreground">{message}</p>

--- a/dataloom-frontend/src/Components/common/DataLoomLogo.tsx
+++ b/dataloom-frontend/src/Components/common/DataLoomLogo.tsx
@@ -1,10 +1,13 @@
+interface DataLoomLogoProps {
+  /** Additional CSS classes for sizing. */
+  className?: string;
+}
+
 /**
  * DataLoom logo — 2×2 interlaced bar weave pattern.
  * Uses currentColor so it inherits the parent's text color.
- * @param {Object} props
- * @param {string} [props.className] - Additional CSS classes for sizing.
  */
-export default function DataLoomLogo({ className = "" }) {
+export default function DataLoomLogo({ className = "" }: DataLoomLogoProps) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/dataloom-frontend/src/Components/common/DtypeBadge.tsx
+++ b/dataloom-frontend/src/Components/common/DtypeBadge.tsx
@@ -1,6 +1,4 @@
-import PropTypes from "prop-types";
-
-const DTYPE_STYLES = {
+const DTYPE_STYLES: Record<string, string> = {
   int: "bg-blue-100 text-blue-700",
   float: "bg-teal-100 text-teal-700",
   str: "bg-green-100 text-green-700",
@@ -8,7 +6,12 @@ const DTYPE_STYLES = {
   bool: "bg-orange-100 text-orange-700",
 };
 
-const DtypeBadge = ({ dtype, className = "ml-1.5" }) => {
+interface DtypeBadgeProps {
+  dtype?: string | null;
+  className?: string;
+}
+
+const DtypeBadge = ({ dtype, className = "ml-1.5" }: DtypeBadgeProps) => {
   if (!dtype) return null;
 
   const style = DTYPE_STYLES[dtype] || "bg-gray-100 text-gray-700";
@@ -20,11 +23,6 @@ const DtypeBadge = ({ dtype, className = "ml-1.5" }) => {
       {dtype}
     </span>
   );
-};
-
-DtypeBadge.propTypes = {
-  dtype: PropTypes.string,
-  className: PropTypes.string,
 };
 
 export default DtypeBadge;

--- a/dataloom-frontend/src/Components/common/ErrorBoundary.tsx
+++ b/dataloom-frontend/src/Components/common/ErrorBoundary.tsx
@@ -1,19 +1,28 @@
-import { Component } from "react";
+import { Component, type ErrorInfo, type ReactNode } from "react";
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+}
 
 /**
  * React error boundary that catches render errors and displays a fallback UI.
  */
-export default class ErrorBoundary extends Component {
-  constructor(props) {
+export default class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
     super(props);
     this.state = { hasError: false, error: null };
   }
 
-  static getDerivedStateFromError(error) {
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
     return { hasError: true, error };
   }
 
-  componentDidCatch(error, errorInfo) {
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     console.error("[ErrorBoundary]", error, errorInfo);
   }
 

--- a/dataloom-frontend/src/Components/common/FormErrorAlert.tsx
+++ b/dataloom-frontend/src/Components/common/FormErrorAlert.tsx
@@ -1,6 +1,8 @@
-import PropTypes from "prop-types";
+interface FormErrorAlertProps {
+  message?: string | null;
+}
 
-const FormErrorAlert = ({ message }) => {
+const FormErrorAlert = ({ message }: FormErrorAlertProps) => {
   if (!message) return null;
 
   return (
@@ -8,10 +10,6 @@ const FormErrorAlert = ({ message }) => {
       {message}
     </div>
   );
-};
-
-FormErrorAlert.propTypes = {
-  message: PropTypes.string,
 };
 
 export default FormErrorAlert;

--- a/dataloom-frontend/src/Components/common/InputDialog.tsx
+++ b/dataloom-frontend/src/Components/common/InputDialog.tsx
@@ -1,6 +1,15 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, type FormEvent } from "react";
 import Modal from "./Modal";
 import Button from "./Button";
+
+interface InputDialogProps {
+  isOpen: boolean;
+  message: string;
+  defaultValue?: string;
+  onSubmit: (value: string) => void;
+  onCancel: () => void;
+  required?: boolean;
+}
 
 export default function InputDialog({
   isOpen,
@@ -9,7 +18,7 @@ export default function InputDialog({
   onSubmit,
   onCancel,
   required = false,
-}) {
+}: InputDialogProps) {
   const [value, setValue] = useState(defaultValue);
 
   useEffect(() => {
@@ -18,7 +27,7 @@ export default function InputDialog({
     }
   }, [isOpen, defaultValue]);
 
-  const handleSubmit = (e) => {
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     onSubmit(value);
   };

--- a/dataloom-frontend/src/Components/common/LoadingSpinner.tsx
+++ b/dataloom-frontend/src/Components/common/LoadingSpinner.tsx
@@ -1,9 +1,12 @@
+interface LoadingSpinnerProps {
+  /** Text shown below spinner. */
+  message?: string;
+}
+
 /**
  * Loading spinner indicator.
- * @param {Object} props
- * @param {string} [props.message="Loading..."] - Text shown below spinner.
  */
-export default function LoadingSpinner({ message = "Loading..." }) {
+export default function LoadingSpinner({ message = "Loading..." }: LoadingSpinnerProps) {
   return (
     <div className="flex flex-col items-center justify-center p-8" aria-busy="true">
       <div className="w-8 h-8 border-4 border-app-border border-t-blue-500 rounded-full animate-spin" />

--- a/dataloom-frontend/src/Components/common/Modal.tsx
+++ b/dataloom-frontend/src/Components/common/Modal.tsx
@@ -1,20 +1,33 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, type ReactNode } from "react";
+
+interface ModalProps {
+  /** Whether the modal is visible. */
+  isOpen: boolean;
+  /** Callback to close the modal. */
+  onClose: () => void;
+  /** Modal title text. */
+  title?: string;
+  /** Modal body content. */
+  children: ReactNode;
+  /** Optional width/spacing classes for the dialog shell. */
+  className?: string;
+}
 
 /**
  * Accessible modal dialog component.
- * @param {Object} props
- * @param {boolean} props.isOpen - Whether the modal is visible.
- * @param {Function} props.onClose - Callback to close the modal.
- * @param {string} [props.title] - Modal title text.
- * @param {React.ReactNode} props.children - Modal body content.
- * @param {string} [props.className] - Optional width/spacing classes for the dialog shell.
  */
-export default function Modal({ isOpen, onClose, title, children, className = "max-w-lg" }) {
-  const dialogRef = useRef(null);
+export default function Modal({
+  isOpen,
+  onClose,
+  title,
+  children,
+  className = "max-w-lg",
+}: ModalProps) {
+  const dialogRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (!isOpen) return;
-    const handleKeyDown = (e) => {
+    const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === "Escape") onClose();
     };
     document.addEventListener("keydown", handleKeyDown);

--- a/dataloom-frontend/src/Components/common/Toast.tsx
+++ b/dataloom-frontend/src/Components/common/Toast.tsx
@@ -7,15 +7,24 @@ const TYPE_CLASSES = {
   warning: "border-l-yellow-500",
 };
 
+/** The severities a toast can carry. */
+export type ToastType = keyof typeof TYPE_CLASSES;
+
+interface ToastProps {
+  /** Toast message text. */
+  message: string;
+  /** Toast visual type. */
+  type?: ToastType;
+  /** Callback when toast should be removed. */
+  onDismiss: () => void;
+  /** Auto-dismiss duration in ms. */
+  duration?: number;
+}
+
 /**
  * Single toast notification component.
- * @param {Object} props
- * @param {string} props.message - Toast message text.
- * @param {'success'|'error'|'info'|'warning'} [props.type='info'] - Toast visual type.
- * @param {Function} props.onDismiss - Callback when toast should be removed.
- * @param {number} [props.duration=3000] - Auto-dismiss duration in ms.
  */
-export default function Toast({ message, type = "info", onDismiss, duration = 3000 }) {
+export default function Toast({ message, type = "info", onDismiss, duration = 3000 }: ToastProps) {
   useEffect(() => {
     const timer = setTimeout(onDismiss, duration);
     return () => clearTimeout(timer);

--- a/dataloom-frontend/src/Components/common/__tests__/Button.test.tsx
+++ b/dataloom-frontend/src/Components/common/__tests__/Button.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
+import type { ButtonSize, ButtonVariant } from "../Button";
 
 import Button from "../Button";
 
@@ -59,7 +60,7 @@ describe("Button", () => {
   });
 
   it("falls back to primary for unknown variant", () => {
-    render(<Button variant="unknown">Fallback</Button>);
+    render(<Button variant={"unknown" as ButtonVariant}>Fallback</Button>);
 
     const button = screen.getByRole("button");
 
@@ -87,7 +88,7 @@ describe("Button", () => {
   });
 
   it("falls back to medium for an unknown size", () => {
-    render(<Button size="unknown">Fallback size</Button>);
+    render(<Button size={"unknown" as ButtonSize}>Fallback size</Button>);
 
     const button = screen.getByRole("button");
 

--- a/dataloom-frontend/src/Components/common/__tests__/DtypeBadge.test.tsx
+++ b/dataloom-frontend/src/Components/common/__tests__/DtypeBadge.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
 import DtypeBadge from "../DtypeBadge";
 
 describe("DtypeBadge", () => {

--- a/dataloom-frontend/src/Components/common/__tests__/Modal.test.tsx
+++ b/dataloom-frontend/src/Components/common/__tests__/Modal.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
 import userEvent from "@testing-library/user-event";
 import Modal from "../Modal";
 
@@ -56,7 +57,8 @@ describe("Modal", () => {
     );
     // Click on the overlay (the outermost div)
     const overlay = screen.getByRole("dialog").parentElement;
-    await user.click(overlay);
+    expect(overlay).not.toBeNull();
+    await user.click(overlay!);
     expect(onClose).toHaveBeenCalledOnce();
   });
 

--- a/dataloom-frontend/src/context/ToastContext.tsx
+++ b/dataloom-frontend/src/context/ToastContext.tsx
@@ -1,8 +1,7 @@
 import { createContext, useContext, useState, useCallback, type ReactNode } from "react";
-import Toast from "../Components/common/Toast";
+import Toast, { type ToastType } from "../Components/common/Toast";
 
-/** The severities a toast can carry. */
-export type ToastType = "success" | "error" | "info" | "warning";
+export type { ToastType };
 
 interface ToastEntry {
   id: number;


### PR DESCRIPTION
## Description

Third PR of the TypeScript migration, split up so each piece stays reviewable. Follows #483 (utils/constants/config), #485 (contexts and hooks) and #486 (api response types). This one is rebased onto current `main` and stands on its own — the diff is a single commit.

- Converts the 10 `Components/common/*` components and their 3 tests to `.tsx`
- Drops the `prop-types` blocks from `DtypeBadge` and `FormErrorAlert`; the dependency itself goes once the last consumer is converted
- Types `Button` props as `ButtonHTMLAttributes` so the spread rest keeps working, and exports `ButtonVariant`/`ButtonSize` for the fallback tests
- Types `ErrorBoundary` as `Component<Props, State>`
- Moves `ToastType` to `Toast`, which owns `TYPE_CLASSES`, and re-exports it from `ToastContext` so existing importers are unaffected

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

Housekeeping — no user-facing change.

## How Has This Been Tested?

- [x] Existing tests pass
- [ ] New tests added
- [x] Manual testing

`npm run lint` (ESLint + `tsc --noEmit`) clean and all 423 frontend tests pass locally. Test files touched by the migration were renamed, not rewritten.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally
