### PR TITLE
fix(cors): cover Vite fallback ports

### DIFF
--- a/dataloom-backend/.env.example
+++ b/dataloom-backend/.env.example
@@ -2,8 +2,8 @@
 DATABASE_URL="postgresql://user:password@localhost:5432/dataloom"
 
 # CORS allowed origins (JSON array)
-CORS_ORIGINS=["http://localhost:3200", "http://localhost:3201"]
-# Optional regex for additional local Vite fallback ports (3202+). Leave empty in production.
+CORS_ORIGINS=["http://localhost:3200"]
+# Optional regex for local Vite fallback ports in the 3200 range. Leave empty in production.
 CORS_ORIGIN_REGEX=http://localhost:32\d{2}
 
 # Directory for uploaded CSV files

--- a/dataloom-backend/.env.example
+++ b/dataloom-backend/.env.example
@@ -2,7 +2,9 @@
 DATABASE_URL="postgresql://user:password@localhost:5432/dataloom"
 
 # CORS allowed origins (JSON array)
-CORS_ORIGINS=["http://localhost:3200"]
+CORS_ORIGINS=["http://localhost:3200", "http://localhost:3201"]
+# Optional regex for additional local Vite fallback ports (3202+). Leave empty in production.
+CORS_ORIGIN_REGEX=http://localhost:32\d{2}
 
 # Directory for uploaded CSV files
 UPLOAD_DIR=uploads

--- a/dataloom-backend/app/config.py
+++ b/dataloom-backend/app/config.py
@@ -18,6 +18,7 @@ class Settings(BaseSettings):
         max_upload_size_bytes: Maximum allowed upload file size in bytes.
         allowed_extensions: List of permitted file extensions for upload.
         cors_origins: List of allowed CORS origin URLs.
+        cors_origin_regex: Optional regex for additional allowed CORS origins.
         debug: Enable debug mode for verbose logging.
         jwt_secret: Secret key used to sign JWT auth tokens.
         jwt_algorithm: Algorithm used to sign JWT auth tokens.
@@ -34,7 +35,8 @@ class Settings(BaseSettings):
     upload_dir: str = "uploads"
     max_upload_size_bytes: int = 10_485_760  # 10 MB
     allowed_extensions: list[str] = [".csv", ".tsv", ".json", ".xlsx", ".parquet"]
-    cors_origins: list[str] = ["http://localhost:3200"]
+    cors_origins: list[str] = ["http://localhost:3200", "http://localhost:3201"]
+    cors_origin_regex: str | None = r"http://localhost:32\d{2}"
     debug: bool = False
     jwt_secret: str
     jwt_algorithm: str = "HS256"

--- a/dataloom-backend/app/config.py
+++ b/dataloom-backend/app/config.py
@@ -35,8 +35,8 @@ class Settings(BaseSettings):
     upload_dir: str = "uploads"
     max_upload_size_bytes: int = 10_485_760  # 10 MB
     allowed_extensions: list[str] = [".csv", ".tsv", ".json", ".xlsx", ".parquet"]
-    cors_origins: list[str] = ["http://localhost:3200", "http://localhost:3201"]
-    cors_origin_regex: str | None = r"http://localhost:32\d{2}"
+    cors_origins: list[str] = ["http://localhost:3200"]
+    cors_origin_regex: str | None = None
     debug: bool = False
     jwt_secret: str
     jwt_algorithm: str = "HS256"

--- a/dataloom-backend/app/main.py
+++ b/dataloom-backend/app/main.py
@@ -61,9 +61,11 @@ async def lifespan(app):
 
 app = FastAPI(lifespan=lifespan)
 
+_settings = get_settings()
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=get_settings().cors_origins,
+    allow_origins=_settings.cors_origins,
+    allow_origin_regex=_settings.cors_origin_regex,
     allow_credentials=True,
     allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE"],
     allow_headers=["*"],

--- a/dataloom-backend/tests/conftest.py
+++ b/dataloom-backend/tests/conftest.py
@@ -6,6 +6,8 @@ import os
 # Auth-related settings must exist before app modules load the cached Settings.
 os.environ.setdefault("JWT_SECRET", "test-jwt-secret-key-for-the-dataloom-suite")
 os.environ.setdefault("COOKIE_SECURE", "false")
+# Exercise the local development CORS range while keeping the production default disabled.
+os.environ.setdefault("CORS_ORIGIN_REGEX", r"http://localhost:32\d{2}")
 
 os.environ.setdefault("SMTP_USERNAME", "test@example.com")
 os.environ.setdefault("SMTP_PASSWORD", "test-password")

--- a/dataloom-backend/tests/test_cors.py
+++ b/dataloom-backend/tests/test_cors.py
@@ -1,0 +1,30 @@
+"""Tests for CORS configuration."""
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+class TestCorsOrigins:
+    def test_fallback_vite_port_allowed(self):
+        with TestClient(app) as client:
+            response = client.options(
+                "/projects/recent",
+                headers={
+                    "Origin": "http://localhost:3201",
+                    "Access-Control-Request-Method": "GET",
+                },
+            )
+        assert response.status_code == 200
+        assert response.headers.get("access-control-allow-origin") == "http://localhost:3201"
+
+    def test_unrelated_origin_rejected(self):
+        with TestClient(app) as client:
+            response = client.options(
+                "/projects/recent",
+                headers={
+                    "Origin": "http://evil.example.com",
+                    "Access-Control-Request-Method": "GET",
+                },
+            )
+        assert "access-control-allow-origin" not in response.headers

--- a/dataloom-backend/tests/test_cors.py
+++ b/dataloom-backend/tests/test_cors.py
@@ -2,6 +2,7 @@
 
 from fastapi.testclient import TestClient
 
+from app.config import Settings
 from app.main import app
 
 
@@ -11,12 +12,12 @@ class TestCorsOrigins:
             response = client.options(
                 "/projects/recent",
                 headers={
-                    "Origin": "http://localhost:3201",
+                    "Origin": "http://localhost:3210",
                     "Access-Control-Request-Method": "GET",
                 },
             )
         assert response.status_code == 200
-        assert response.headers.get("access-control-allow-origin") == "http://localhost:3201"
+        assert response.headers.get("access-control-allow-origin") == "http://localhost:3210"
 
     def test_unrelated_origin_rejected(self):
         with TestClient(app) as client:
@@ -28,3 +29,9 @@ class TestCorsOrigins:
                 },
             )
         assert "access-control-allow-origin" not in response.headers
+
+    def test_origin_regex_is_disabled_by_default(self, monkeypatch):
+        monkeypatch.delenv("CORS_ORIGIN_REGEX", raising=False)
+        settings = Settings(database_url="sqlite:///./test.db", jwt_secret="test-secret")
+
+        assert settings.cors_origin_regex is None


### PR DESCRIPTION
Fixes #195

The backend now accepts local Vite fallback ports through an optional CORS regex. The production default remains restricted to `http://localhost:3200`; `.env.example` enables the `32xx` range for local development. `vite.config.js` remains unchanged, so Vite can continue to choose an available fallback port.

Added CORS coverage for a regex-only port (`3210`), an unrelated origin rejection, and the production-safe disabled regex default.

Validation:
- 3 CORS tests passed.
- Ruff check and format passed.
- The full backend run collected 760 tests but exceeded the 10-minute local timeout during teardown.

---
This change was prepared with AI assistance under human direction and review.