### PR TITLE
fix: accept Vite's CORS fallback origin and pin its dev port

### DIFF
--- a/dataloom-backend/.env.example
+++ b/dataloom-backend/.env.example
@@ -1,8 +1,9 @@
 # PostgreSQL connection string
 DATABASE_URL="postgresql://user:password@localhost:5432/dataloom"
 
-# CORS allowed origins (JSON array)
-CORS_ORIGINS=["http://localhost:3200"]
+# CORS allowed origins (JSON array). Includes 3201 for Vite's fallback port
+# when 3200 is already bound.
+CORS_ORIGINS=["http://localhost:3200", "http://localhost:3201"]
 
 # Directory for uploaded CSV files
 UPLOAD_DIR=uploads

--- a/dataloom-backend/app/config.py
+++ b/dataloom-backend/app/config.py
@@ -34,7 +34,11 @@ class Settings(BaseSettings):
     upload_dir: str = "uploads"
     max_upload_size_bytes: int = 10_485_760  # 10 MB
     allowed_extensions: list[str] = [".csv", ".tsv", ".json", ".xlsx", ".parquet"]
-    cors_origins: list[str] = ["http://localhost:3200"]
+    # http://localhost:3201 covers Vite's own fallback when 3200 is already
+    # bound (e.g. a second `npm run dev`); the frontend also pins strictPort
+    # so a third conflicting instance fails loudly instead of drifting past
+    # this list.
+    cors_origins: list[str] = ["http://localhost:3200", "http://localhost:3201"]
     debug: bool = False
     jwt_secret: str
     jwt_algorithm: str = "HS256"

--- a/dataloom-backend/tests/test_cors.py
+++ b/dataloom-backend/tests/test_cors.py
@@ -1,0 +1,38 @@
+"""CORS origin allowlist behavior (#195).
+
+Vite falls back from 3200 to 3201 when the primary port is already bound, so
+the backend must accept both — and must still reject an origin that isn't on
+the list.
+"""
+
+
+class TestCorsOrigins:
+    def test_allows_the_primary_dev_origin(self, anon_client):
+        response = anon_client.options(
+            "/auth/signin",
+            headers={
+                "Origin": "http://localhost:3200",
+                "Access-Control-Request-Method": "POST",
+            },
+        )
+        assert response.headers.get("access-control-allow-origin") == "http://localhost:3200"
+
+    def test_allows_the_vite_fallback_origin(self, anon_client):
+        response = anon_client.options(
+            "/auth/signin",
+            headers={
+                "Origin": "http://localhost:3201",
+                "Access-Control-Request-Method": "POST",
+            },
+        )
+        assert response.headers.get("access-control-allow-origin") == "http://localhost:3201"
+
+    def test_rejects_an_unrelated_origin(self, anon_client):
+        response = anon_client.options(
+            "/auth/signin",
+            headers={
+                "Origin": "http://evil.example.com",
+                "Access-Control-Request-Method": "POST",
+            },
+        )
+        assert "access-control-allow-origin" not in response.headers

--- a/dataloom-frontend/vite.config.js
+++ b/dataloom-frontend/vite.config.js
@@ -6,5 +6,8 @@ export default defineConfig({
   plugins: [react()],
   server: {
     port: 3200,
+    // Refuse to start on a fallback port when 3200 is taken, rather than
+    // silently moving to an origin the backend's CORS allowlist rejects.
+    strictPort: true,
   },
 });


### PR DESCRIPTION
## Description

`cors_origins` defaulted to the single origin `http://localhost:3200`, and Vite's dev server silently falls back to `3201` when 3200 is already bound (e.g. a second `npm run dev`). Every request from that fallback origin then failed CORS with nothing pointing at the port as the cause.

Fixes #195

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

- [x] Existing tests pass
- [x] New tests added
- [ ] Manual testing

**Choice made for the frontend half:** the issue offered two options — pin the port with `strictPort`, or widen the accepted origins to cover the fallback range. I did **both**, but for different reasons: `cors_origins` is widened to `[3200, 3201]` because that's the concrete, reported failure and the issue's own acceptance criteria requires it regardless of the frontend choice. `vite.config.js` additionally gets `strictPort: true` so a *third* conflicting dev instance fails loudly at startup (naming the port) instead of silently drifting to 3202, which the widened allowlist still wouldn't cover — matching the issue's framing that the real problem is Vite failing silently rather than the port number itself.

No wildcard origin was introduced alongside `allow_credentials=True` — `cors_origins` is still an explicit list.

Added `tests/test_cors.py`: asserts an OPTIONS preflight from `http://localhost:3200` and `http://localhost:3201` both get `access-control-allow-origin` echoed back, and one from an unrelated origin does not. Confirmed the fallback-origin test fails against the old single-origin default (`git stash` on `app/config.py`, re-ran): the preflight came back 400 with no CORS header, reproducing the exact reported failure.

```
DATABASE_URL=sqlite:///./test.db uv run pytest
# 760 passed
uv run ruff check app/config.py tests/test_cors.py
# All checks passed!
uv run ruff format --check app/config.py tests/test_cors.py
# 2 files already formatted
```

I did not run the frontend lint/e2e suite (no Playwright/Postgres set up in this pass) — the `vite.config.js` change is a single documented property addition (`strictPort: true`), reviewed by hand for syntax.

## Screenshots (if applicable)

N/A — no UI change, dev-server and CORS config only.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed (`.env.example` updated to match)
- [x] My changes generate no new warnings
- [x] Tests pass locally (backend; frontend/e2e not run in this pass, see above)