### PR TITLE
docs: clarify that issue assignment is not required

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,17 @@
 
 Thank you for your interest in contributing to DataLoom! This document provides guidelines and instructions for contributing.
 
+## Picking Up Work
+
+You do not need to be assigned to an issue before you contribute. Assignment is not compulsory.
+
+You can start in either of these two ways:
+
+- Open a pull request for an existing issue. Link the issue in the pull request description.
+- Open a new issue for the bug or the feature, then open a pull request for it.
+
+For a large change, comment on the issue before you start. This tells the other contributors what you work on, and it prevents duplicate pull requests.
+
 ## Getting Started
 
 1. **Fork** the repository on GitHub.


### PR DESCRIPTION
## What

Adds a **Picking Up Work** section to `CONTRIBUTING.md`.

## Why

New contributors often wait for an issue to be assigned to them before they start. That wait is not necessary in this repository, and the guide did not say so.

## The new section says

- You do not need an assignment to contribute.
- You can open a pull request for an existing issue and link that issue.
- You can also open a new issue first, then open the pull request for it.
- For a large change, comment on the issue before you start, so that others do not duplicate the work.

Documentation only. No code changes.