### PR TITLE
fix(frontend): use Apply instead of Submit on transform forms

### DIFF
--- a/dataloom-frontend/src/Components/forms/AdvQueryFilterForm.tsx
+++ b/dataloom-frontend/src/Components/forms/AdvQueryFilterForm.tsx
@@ -80,7 +80,7 @@ const AdvQueryFilterForm = ({ projectId, onClose, onCapture }: TransformFormProp
         <div className="flex justify-between">
           <div className="flex gap-2">
             <Button disabled={loading || saving || isPreviewMode} type="submit">
-              Submit
+              Apply
             </Button>
             {isPreviewMode && (
               <Button type="button" onClick={handleSave} disabled={saving} variant="success">

--- a/dataloom-frontend/src/Components/forms/DropDuplicateForm.tsx
+++ b/dataloom-frontend/src/Components/forms/DropDuplicateForm.tsx
@@ -92,7 +92,7 @@ const DropDuplicateForm = ({ projectId, onClose, onCapture }: TransformFormProps
         <div className="flex justify-between">
           <div className="flex gap-2">
             <Button type="submit" disabled={saving || isPreviewMode}>
-              Submit
+              Apply
             </Button>
             {isPreviewMode && (
               <Button type="button" onClick={handleSave} disabled={saving} variant="success">

--- a/dataloom-frontend/src/Components/forms/PivotTableForm.tsx
+++ b/dataloom-frontend/src/Components/forms/PivotTableForm.tsx
@@ -107,7 +107,7 @@ const PivotTableForm = ({ projectId, onClose, onCapture }: TransformFormProps) =
         <div className="flex justify-between">
           <div className="flex gap-2">
             <Button type="submit" disabled={loading || saving || isPreviewMode}>
-              {loading ? "Submitting..." : "Submit"}
+              {loading ? "Applying..." : "Apply"}
             </Button>
             {isPreviewMode && (
               <Button type="button" onClick={handleSave} disabled={saving} variant="success">

--- a/dataloom-frontend/src/test/AdvQueryFilterForm.test.jsx
+++ b/dataloom-frontend/src/test/AdvQueryFilterForm.test.jsx
@@ -66,7 +66,7 @@ describe("AdvQueryFilterForm", () => {
     renderForm();
 
     expect(screen.getByPlaceholderText("e.g., col1 > 10 and col2 < 5")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Submit" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Apply" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
   });
 
@@ -81,7 +81,7 @@ describe("AdvQueryFilterForm", () => {
     renderForm();
 
     await user.type(screen.getByPlaceholderText("e.g., col1 > 10 and col2 < 5"), "amount > 10");
-    await user.click(screen.getByRole("button", { name: "Submit" }));
+    await user.click(screen.getByRole("button", { name: "Apply" }));
 
     await waitFor(() => {
       expect(transformProject).toHaveBeenCalledWith(
@@ -116,7 +116,7 @@ describe("AdvQueryFilterForm", () => {
     renderForm();
 
     await user.type(screen.getByPlaceholderText("e.g., col1 > 10 and col2 < 5"), "amount > 10");
-    await user.click(screen.getByRole("button", { name: "Submit" }));
+    await user.click(screen.getByRole("button", { name: "Apply" }));
 
     await waitFor(() => {
       expect(mockEnterPreviewMode).toHaveBeenCalledWith(
@@ -141,7 +141,7 @@ describe("AdvQueryFilterForm", () => {
     renderForm({ pageSize: 10 });
 
     await user.type(screen.getByPlaceholderText("e.g., col1 > 10 and col2 < 5"), "amount > 10");
-    await user.click(screen.getByRole("button", { name: "Submit" }));
+    await user.click(screen.getByRole("button", { name: "Apply" }));
 
     await waitFor(() => {
       expect(transformProject).toHaveBeenCalledWith(
@@ -159,7 +159,7 @@ describe("AdvQueryFilterForm", () => {
     });
   });
 
-  it("disables Submit while the request is pending", async () => {
+  it("disables Apply while the request is pending", async () => {
     const user = userEvent.setup();
     let resolveTransform;
 
@@ -173,9 +173,9 @@ describe("AdvQueryFilterForm", () => {
     renderForm();
 
     await user.type(screen.getByPlaceholderText("e.g., col1 > 10 and col2 < 5"), "amount > 10");
-    await user.click(screen.getByRole("button", { name: "Submit" }));
+    await user.click(screen.getByRole("button", { name: "Apply" }));
 
-    expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Apply" })).toBeDisabled();
 
     resolveTransform({
       columns: [],
@@ -188,7 +188,7 @@ describe("AdvQueryFilterForm", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: "Submit" })).not.toBeDisabled();
+      expect(screen.getByRole("button", { name: "Apply" })).not.toBeDisabled();
     });
   });
 
@@ -206,7 +206,7 @@ describe("AdvQueryFilterForm", () => {
     renderForm();
 
     await user.type(screen.getByPlaceholderText("e.g., col1 > 10 and col2 < 5"), "amount >>");
-    await user.click(screen.getByRole("button", { name: "Submit" }));
+    await user.click(screen.getByRole("button", { name: "Apply" }));
 
     await waitFor(() => {
       expect(screen.getByText("Invalid query syntax.")).toBeInTheDocument();
@@ -215,10 +215,10 @@ describe("AdvQueryFilterForm", () => {
     expect(mockEnterPreviewMode).not.toHaveBeenCalled();
   });
 
-  it("disables Submit and displays Save Changes in preview mode", () => {
+  it("disables Apply and displays Save Changes in preview mode", () => {
     renderForm({ isPreviewMode: true });
 
-    expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Apply" })).toBeDisabled();
     expect(screen.getByRole("button", { name: "Save Changes" })).toBeInTheDocument();
   });
 

--- a/dataloom-frontend/src/test/DropDuplicateForm.test.jsx
+++ b/dataloom-frontend/src/test/DropDuplicateForm.test.jsx
@@ -93,7 +93,7 @@ describe("DropDuplicateForm", () => {
 
     expect(screen.getByLabelText("Columns")).toBeInTheDocument();
     expect(screen.getByLabelText("Keep")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Submit" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Apply" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
   });
 
@@ -107,7 +107,7 @@ describe("DropDuplicateForm", () => {
     const user = userEvent.setup();
     renderForm();
 
-    await user.click(screen.getByRole("button", { name: "Submit" }));
+    await user.click(screen.getByRole("button", { name: "Apply" }));
 
     await waitFor(() => {
       expect(screen.getByText("Please select at least one column.")).toBeInTheDocument();
@@ -122,7 +122,7 @@ describe("DropDuplicateForm", () => {
 
     await user.selectOptions(screen.getByLabelText("Columns"), ["amount", "created_at"]);
     await user.selectOptions(screen.getByLabelText("Keep"), "last");
-    await user.click(screen.getByRole("button", { name: "Submit" }));
+    await user.click(screen.getByRole("button", { name: "Apply" }));
 
     await waitFor(() => {
       expect(transformProject).toHaveBeenCalledWith(
@@ -161,7 +161,7 @@ describe("DropDuplicateForm", () => {
     renderForm();
 
     await user.selectOptions(screen.getByLabelText("Columns"), ["amount"]);
-    await user.click(screen.getByRole("button", { name: "Submit" }));
+    await user.click(screen.getByRole("button", { name: "Apply" }));
 
     await waitFor(() => {
       expect(mockEnterPreviewMode).toHaveBeenCalledWith(
@@ -202,7 +202,7 @@ describe("DropDuplicateForm", () => {
     renderForm();
 
     await user.selectOptions(screen.getByLabelText("Columns"), ["amount"]);
-    await user.click(screen.getByRole("button", { name: "Submit" }));
+    await user.click(screen.getByRole("button", { name: "Apply" }));
 
     await waitFor(() => {
       expect(screen.getByText("Unable to drop duplicates.")).toBeInTheDocument();
@@ -211,10 +211,10 @@ describe("DropDuplicateForm", () => {
     expect(mockEnterPreviewMode).not.toHaveBeenCalled();
   });
 
-  it("disables Submit and displays Save Changes in preview mode", () => {
+  it("disables Apply and displays Save Changes in preview mode", () => {
     renderForm({ isPreviewMode: true });
 
-    expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Apply" })).toBeDisabled();
     expect(screen.getByRole("button", { name: "Save Changes" })).toBeInTheDocument();
   });
 
@@ -235,7 +235,7 @@ describe("DropDuplicateForm", () => {
     });
 
     expect(screen.getByRole("button", { name: "Saving..." })).toBeDisabled();
-    expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Apply" })).toBeDisabled();
   });
 
   it("cancels preview mode when Cancel is clicked during preview", async () => {

--- a/dataloom-frontend/src/test/PivotTableForm.test.jsx
+++ b/dataloom-frontend/src/test/PivotTableForm.test.jsx
@@ -128,7 +128,7 @@ describe("PivotTableForm", () => {
     expect(screen.getByText("Column:")).toBeInTheDocument();
     expect(screen.getByText("Value:")).toBeInTheDocument();
 
-    expect(screen.getByRole("button", { name: "Submit" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Apply" })).toBeInTheDocument();
 
     expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
   });
@@ -146,7 +146,7 @@ describe("PivotTableForm", () => {
 
     await user.click(
       screen.getByRole("button", {
-        name: "Submit",
+        name: "Apply",
       }),
     );
 
@@ -166,7 +166,7 @@ describe("PivotTableForm", () => {
 
     await user.click(
       screen.getByRole("button", {
-        name: "Submit",
+        name: "Apply",
       }),
     );
 
@@ -194,7 +194,7 @@ describe("PivotTableForm", () => {
 
     await user.click(
       screen.getByRole("button", {
-        name: "Submit",
+        name: "Apply",
       }),
     );
 
@@ -249,7 +249,7 @@ describe("PivotTableForm", () => {
 
     await user.click(
       screen.getByRole("button", {
-        name: "Submit",
+        name: "Apply",
       }),
     );
 
@@ -303,7 +303,7 @@ describe("PivotTableForm", () => {
 
     await user.click(
       screen.getByRole("button", {
-        name: "Submit",
+        name: "Apply",
       }),
     );
 
@@ -314,14 +314,14 @@ describe("PivotTableForm", () => {
     expect(mockEnterPreviewMode).not.toHaveBeenCalled();
   });
 
-  it("disables Submit and displays Save Changes in preview mode", () => {
+  it("disables Apply and displays Save Changes in preview mode", () => {
     renderForm({
       isPreviewMode: true,
     });
 
     expect(
       screen.getByRole("button", {
-        name: "Submit",
+        name: "Apply",
       }),
     ).toBeDisabled();
 
@@ -362,7 +362,7 @@ describe("PivotTableForm", () => {
 
     expect(
       screen.getByRole("button", {
-        name: "Submit",
+        name: "Apply",
       }),
     ).toBeDisabled();
   });


### PR DESCRIPTION
## Description

Drop Duplicates, Advanced Query Filter and Pivot Table were labelling their primary button "Submit", while the rest of the transform forms use "Apply". Pivot Table's pending state also said "Submitting...".

Changed all three to match what TrimWhitespaceForm and CastDataTypeForm already do:

- `DropDuplicateForm.tsx` -> Apply
- `AdvQueryFilterForm.tsx` -> Apply
- `PivotTableForm.tsx` -> Apply, with "Applying..." while the request is in flight

Only the button text changed, no logic. The `handleSubmit` / `onSubmit` / `type="submit"` identifiers are untouched since those are just form mechanics.

I also renamed a few test descriptions that still said "Submit" so they don't go stale.

Fixes #442

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update


## Screenshots

<img width="800" height="514" alt="image" src="https://github.com/user-attachments/assets/036baf57-682e-4132-bd89-88c290b47cab" />

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [ ] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally
