### PR TITLE
feat(frontend): add table loading skeleton and shared empty state

### DIFF
--- a/dataloom-frontend/src/Components/Homescreen.jsx
+++ b/dataloom-frontend/src/Components/Homescreen.jsx
@@ -15,6 +15,7 @@ import { CiMenuKebab } from "react-icons/ci";
 import { ACCEPTED_EXTENSIONS, formatFileSize, validateFile } from "../utils/fileUtils";
 import { getErrorMessage } from "../utils/errorUtils";
 import { useProjectContext } from "../context/ProjectContext";
+import EmptyState from "./common/EmptyState";
 
 // Must stay in sync with UpdateProjectRequest in dataloom-backend/app/schemas.py
 const PROJECT_NAME_MAX_LENGTH = 255;
@@ -130,39 +131,23 @@ const NewProjectCard = ({ onClick }) => (
 
 const ACCEPT_ATTR = ACCEPTED_EXTENSIONS.join(",");
 
-const EmptyState = ({ onClick }) => (
-  <div className="flex flex-col items-center justify-center py-16 px-6 rounded-xl border-2 border-dashed border-app-border bg-surface text-center">
-    <div className="mb-4 flex items-center justify-center w-16 h-16 rounded-full bg-blue-50">
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        className="h-8 w-8 text-blue-400"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
-        strokeWidth={1.5}
-        aria-hidden="true"
-      >
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          d="M3 7a2 2 0 012-2h4l2 2h8a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2V7z"
-        />
-        <path strokeLinecap="round" strokeLinejoin="round" d="M12 11v4m-2-2h4" />
-      </svg>
-    </div>
-    <h3 className="text-lg font-semibold text-foreground mb-1">No projects yet</h3>
-    <p className="text-sm text-muted-foreground mb-6 max-w-xs">
-      Upload a dataset to get started. Your recent projects will appear here.
-    </p>
-    <button
-      type="button"
-      data-testid="new-project-card"
-      onClick={onClick}
-      className="px-5 py-2.5 bg-blue-500 hover:bg-blue-600 text-white text-sm font-medium rounded-lg transition-colors duration-150 shadow-sm"
-    >
-      Create your first project
-    </button>
-  </div>
+const emptyProjectsIcon = (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    className="h-8 w-8 text-blue-400"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    aria-hidden="true"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M3 7a2 2 0 012-2h4l2 2h8a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2V7z"
+    />
+    <path strokeLinecap="round" strokeLinejoin="round" d="M12 11v4m-2-2h4" />
+  </svg>
 );
 
 const HomeScreen = () => {
@@ -530,7 +515,21 @@ const HomeScreen = () => {
         </div>
 
         {recentProjects.length === 0 && !isSearching ? (
-          <EmptyState onClick={handleNewProjectClick} />
+          <EmptyState
+            icon={emptyProjectsIcon}
+            title="No projects yet"
+            description="Upload a dataset to get started. Your recent projects will appear here."
+            action={
+              <button
+                type="button"
+                data-testid="new-project-card"
+                onClick={handleNewProjectClick}
+                className="px-5 py-2.5 bg-blue-500 hover:bg-blue-600 text-white text-sm font-medium rounded-lg transition-colors duration-150 shadow-sm"
+              >
+                Create your first project
+              </button>
+            }
+          />
         ) : (
           renderProjectGrid()
         )}

--- a/dataloom-frontend/src/Components/Table.tsx
+++ b/dataloom-frontend/src/Components/Table.tsx
@@ -25,6 +25,7 @@ import InputDialog from "./common/InputDialog";
 import Toast from "./common/Toast";
 import DtypeBadge from "./common/DtypeBadge";
 import ColumnProfileCard from "./profiling/ColumnProfileCard";
+import TableSkeleton from "./TableSkeleton";
 import useColumnProfiles from "../hooks/useColumnProfiles";
 import { useToast } from "../context/ToastContext";
 
@@ -102,6 +103,7 @@ const Table = ({ projectId, showColumnProfiles = false }: TableProps) => {
     setPaginationData,
     updatePreviewPage,
     refreshProject,
+    loading,
   } = useProjectContext();
   const { refreshLogs } = useHistoryRefresh();
   const [data, setData] = useState<Cell[][]>([]);
@@ -453,11 +455,19 @@ const Table = ({ projectId, showColumnProfiles = false }: TableProps) => {
     refreshProject(projectId, 1, newSize);
   };
 
+  // refreshProject sets loading on every fetch (pagination, mutations). Keep the
+  // existing table when columns are already available; skeleton only on first load.
+  const showTableSkeleton = loading && ctxColumns.length === 0;
+
   return (
     <div className="flex flex-col flex-1 min-h-0">
       <div className="flex-1 min-h-0 overflow-hidden border-x border-b border-app-border shadow-sm">
         <div className="h-full overflow-auto">
-          <table
+          {showTableSkeleton ? (
+            <TableSkeleton columnCount={ctxColumns.length} rowCount={pageSize} />
+          ) : (
+            /* prettier-ignore */
+            <table
             data-testid="data-table"
             className="min-w-full bg-surface border-separate border-spacing-0"
           >
@@ -620,6 +630,7 @@ const Table = ({ projectId, showColumnProfiles = false }: TableProps) => {
               ))}
             </tbody>
           </table>
+          )}
         </div>
       </div>
 

--- a/dataloom-frontend/src/Components/TableSkeleton.tsx
+++ b/dataloom-frontend/src/Components/TableSkeleton.tsx
@@ -1,0 +1,76 @@
+/** Number of data columns (excluding S.No.) when the real schema is not yet known. */
+const FALLBACK_DATA_COLUMN_COUNT = 5;
+
+interface TableSkeletonProps {
+  /** Real data-column count, not including the leading S.No. column. */
+  columnCount?: number;
+  rowCount?: number;
+}
+
+function SkeletonBar({ className }: { className?: string }) {
+  return <div className={`h-3 bg-surface-hover rounded w-3/4 ${className ?? ""}`} />;
+}
+
+/**
+ * Placeholder table that mirrors DataSet header/body cell sizes to limit layout shift.
+ */
+export default function TableSkeleton({ columnCount = 0, rowCount = 10 }: TableSkeletonProps) {
+  const dataColumnCount = columnCount > 0 ? columnCount : FALLBACK_DATA_COLUMN_COUNT;
+  const totalColumns = dataColumnCount + 1;
+
+  return (
+    <table
+      data-testid="data-table-skeleton"
+      className="min-w-full bg-surface border-separate border-spacing-0 animate-pulse"
+    >
+      <thead className="sticky top-0 z-20 bg-surface">
+        <tr>
+          {Array.from({ length: totalColumns }, (_, columnIndex) => {
+            const isSerialNumber = columnIndex === 0;
+            return (
+              <th
+                key={`name-${columnIndex}`}
+                className={`h-6 px-0.5 py-0 border-r border-app-border text-left ${
+                  isSerialNumber ? "w-16 sticky left-0 z-10 bg-surface" : "bg-surface"
+                }`}
+              >
+                <SkeletonBar />
+              </th>
+            );
+          })}
+        </tr>
+        <tr>
+          {Array.from({ length: totalColumns }, (_, columnIndex) => {
+            const isSerialNumber = columnIndex === 0;
+            return (
+              <th
+                key={`dtype-${columnIndex}`}
+                className={`h-5 px-0.5 py-0 border-b border-r border-app-border text-left ${
+                  isSerialNumber ? "w-16 sticky left-0 z-10 bg-surface" : "bg-surface"
+                }`}
+              >
+                {!isSerialNumber ? <SkeletonBar className="w-1/2" /> : null}
+              </th>
+            );
+          })}
+        </tr>
+      </thead>
+      <tbody>
+        {Array.from({ length: rowCount }, (_, rowIndex) => (
+          <tr key={rowIndex} className="hover:bg-surface-hover transition-colors duration-150">
+            {Array.from({ length: totalColumns }, (_, cellIndex) => (
+              <td
+                key={cellIndex}
+                className={`h-6 px-0.5 py-0 border-b border-r border-app-border ${
+                  cellIndex === 0 ? "w-16 sticky left-0 z-10 bg-surface" : ""
+                }`}
+              >
+                <SkeletonBar className={cellIndex === 0 ? "mx-auto w-1/2" : ""} />
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/dataloom-frontend/src/Components/__tests__/TableSkeleton.test.tsx
+++ b/dataloom-frontend/src/Components/__tests__/TableSkeleton.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import TableSkeleton from "../TableSkeleton";
+
+describe("TableSkeleton", () => {
+  it("renders successfully", () => {
+    render(<TableSkeleton columnCount={3} rowCount={4} />);
+
+    expect(screen.getByTestId("data-table-skeleton")).toBeInTheDocument();
+  });
+
+  it('exposes data-testid="data-table-skeleton"', () => {
+    render(<TableSkeleton />);
+
+    expect(screen.getByTestId("data-table-skeleton")).toBeInTheDocument();
+  });
+
+  it("renders S.No. plus the requested data columns", () => {
+    const { container } = render(<TableSkeleton columnCount={3} rowCount={2} />);
+
+    const nameHeaderCells = container.querySelectorAll("thead tr:first-child th");
+    expect(nameHeaderCells).toHaveLength(4);
+  });
+
+  it("renders the requested number of body rows", () => {
+    const { container } = render(<TableSkeleton columnCount={2} rowCount={7} />);
+
+    expect(container.querySelectorAll("tbody tr")).toHaveLength(7);
+  });
+
+  it("falls back to a visible column set when columns are empty", () => {
+    const { container } = render(<TableSkeleton columnCount={0} rowCount={3} />);
+
+    const nameHeaderCells = container.querySelectorAll("thead tr:first-child th");
+    expect(nameHeaderCells.length).toBeGreaterThan(1);
+    expect(screen.getByTestId("data-table-skeleton")).toBeInTheDocument();
+  });
+});

--- a/dataloom-frontend/src/Components/common/EmptyState.jsx
+++ b/dataloom-frontend/src/Components/common/EmptyState.jsx
@@ -1,0 +1,37 @@
+import PropTypes from "prop-types";
+
+/**
+ * Shared empty-state placeholder.
+ * Default layout matches the Homescreen empty projects card.
+ * Pass `compact` to render title-only copy for table-cell empty rows.
+ */
+const EmptyState = ({ title, description, action, icon, compact = false }) => {
+  if (compact) {
+    return title;
+  }
+
+  return (
+    <div className="flex flex-col items-center justify-center py-16 px-6 rounded-xl border-2 border-dashed border-app-border bg-surface text-center">
+      {icon ? (
+        <div className="mb-4 flex items-center justify-center w-16 h-16 rounded-full bg-blue-50">
+          {icon}
+        </div>
+      ) : null}
+      <h3 className="text-lg font-semibold text-foreground mb-1">{title}</h3>
+      {description ? (
+        <p className="text-sm text-muted-foreground mb-6 max-w-xs">{description}</p>
+      ) : null}
+      {action ?? null}
+    </div>
+  );
+};
+
+EmptyState.propTypes = {
+  title: PropTypes.string.isRequired,
+  description: PropTypes.string,
+  action: PropTypes.node,
+  icon: PropTypes.node,
+  compact: PropTypes.bool,
+};
+
+export default EmptyState;

--- a/dataloom-frontend/src/Components/common/__tests__/EmptyState.test.jsx
+++ b/dataloom-frontend/src/Components/common/__tests__/EmptyState.test.jsx
@@ -1,0 +1,59 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import EmptyState from "../EmptyState";
+
+describe("EmptyState", () => {
+  it("renders the title", () => {
+    render(<EmptyState title="No projects yet" />);
+
+    expect(screen.getByRole("heading", { name: "No projects yet" })).toBeInTheDocument();
+  });
+
+  it("renders the description when provided", () => {
+    render(
+      <EmptyState
+        title="No projects yet"
+        description="Upload a dataset to get started. Your recent projects will appear here."
+      />,
+    );
+
+    expect(
+      screen.getByText("Upload a dataset to get started. Your recent projects will appear here."),
+    ).toBeInTheDocument();
+  });
+
+  it("omits the description when it is not provided", () => {
+    const { container } = render(<EmptyState title="No projects yet" />);
+
+    expect(container.querySelector("p")).not.toBeInTheDocument();
+  });
+
+  it("renders an optional action", () => {
+    render(
+      <EmptyState
+        title="No projects yet"
+        action={
+          <button type="button" data-testid="new-project-card">
+            Create your first project
+          </button>
+        }
+      />,
+    );
+
+    expect(screen.getByTestId("new-project-card")).toHaveTextContent("Create your first project");
+  });
+
+  it("omits the action when it is not provided", () => {
+    render(<EmptyState title="No projects yet" />);
+
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("renders compact title-only content without the card layout", () => {
+    const { container } = render(<EmptyState compact title="No logs available" />);
+
+    expect(screen.getByText("No logs available")).toBeInTheDocument();
+    expect(container.querySelector("h3")).not.toBeInTheDocument();
+  });
+});

--- a/dataloom-frontend/src/Components/history/CheckpointsPanel.tsx
+++ b/dataloom-frontend/src/Components/history/CheckpointsPanel.tsx
@@ -3,6 +3,7 @@ import { deleteCheckpoint, type Checkpoint } from "../../api";
 import Modal from "../common/Modal";
 import { useToast } from "../../context/ToastContext";
 import Button from "../common/Button";
+import EmptyState from "../common/EmptyState";
 
 interface CheckpointsPanelProps {
   projectId: string;
@@ -82,7 +83,7 @@ const CheckpointsPanel = ({
             ) : (
               <tr>
                 <td colSpan={3} className="py-4 px-4 text-center text-sm text-muted-foreground">
-                  No checkpoints available
+                  <EmptyState compact title="No checkpoints available" />
                 </td>
               </tr>
             )}

--- a/dataloom-frontend/src/Components/history/LogsPanel.tsx
+++ b/dataloom-frontend/src/Components/history/LogsPanel.tsx
@@ -1,4 +1,5 @@
 import type { LogEntry } from "../../api";
+import EmptyState from "../common/EmptyState";
 
 interface LogsPanelProps {
   logs: LogEntry[];
@@ -45,7 +46,7 @@ const LogsPanel = ({ logs }: LogsPanelProps) => {
             ) : (
               <tr>
                 <td colSpan={4} className="py-4 px-4 text-center text-sm text-muted-foreground">
-                  No logs available
+                  <EmptyState compact title="No logs available" />
                 </td>
               </tr>
             )}

--- a/dataloom-frontend/src/test/Table.skeleton.test.jsx
+++ b/dataloom-frontend/src/test/Table.skeleton.test.jsx
@@ -1,0 +1,69 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import Table from "../Components/Table";
+import { ToastProvider } from "../context/ToastContext";
+
+vi.mock("../api", () => ({
+  transformProject: vi.fn(),
+}));
+
+const mockContext = {
+  columns: [],
+  rows: [],
+  dtypes: {},
+  columnOrder: [],
+  setColumnOrder: vi.fn(),
+  updateData: vi.fn(),
+  totalRows: 0,
+  totalPages: 1,
+  page: 1,
+  pageSize: 10,
+  setPaginationData: vi.fn(),
+  refreshProject: vi.fn(),
+  loading: true,
+};
+
+vi.mock("../context/ProjectContext", () => ({
+  useProjectContext: () => mockContext,
+}));
+
+vi.mock("../context/HistoryRefreshContext", () => ({
+  useHistoryRefresh: () => ({ refreshLogs: vi.fn(), refreshCheckpoints: vi.fn() }),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockContext.columns = [];
+  mockContext.rows = [];
+  mockContext.loading = true;
+  mockContext.pageSize = 10;
+});
+
+const renderTable = () =>
+  render(
+    <ToastProvider>
+      <Table projectId="test-id" />
+    </ToastProvider>,
+  );
+
+describe("Table — initial loading skeleton", () => {
+  it("shows the table skeleton when loading and no columns are available yet", () => {
+    renderTable();
+
+    expect(screen.getByTestId("data-table-skeleton")).toBeInTheDocument();
+    expect(screen.queryByTestId("data-table")).not.toBeInTheDocument();
+  });
+
+  it("keeps the existing table while loading if columns are already present", () => {
+    mockContext.loading = true;
+    mockContext.columns = ["City", "Amount"];
+    mockContext.rows = [["New York", "100"]];
+    mockContext.columnOrder = [0, 1];
+
+    renderTable();
+
+    expect(screen.queryByTestId("data-table-skeleton")).not.toBeInTheDocument();
+    expect(screen.getByTestId("data-table")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Description

Adds a table loading skeleton and a shared `EmptyState` component.

- Shows a skeleton while table data is initially loading
- Extracts the Homescreen empty state into a reusable component
- Reuses `EmptyState` for logs and checkpoints
- Adds Vitest tests for the skeleton and shared empty state

Fixes #94

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

- [x] Existing tests pass
- [x] New tests added
- [ ] Manual testing

Tests:
- `npm test -- --run` - 436 tests passed
- `npm run lint` - passed
- `git diff --check` - passed

## Screenshots (if applicable)

Not applicable.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [ ] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally