### PR TITLE
docs: correct the preview-before-persist contract in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,9 @@ app/config.py            → Pydantic BaseSettings with @lru_cache (get_settings
 app/database.py          → SQLModel engine + get_db session generator
 ```
 
-**Key pattern: original + working copy files.** Each upload creates two files: `{name}.csv` (original, never modified during transforms) and `{name}_copy.csv` (working copy). The "save" operation replays logged transformations onto the original. The "revert" operation restores from the original.
+**Key pattern: original + working copy files.** Each upload creates two files: `{name}.csv` (original, never modified during transforms) and `{name}_copy.csv` (working copy). A transform called with `preview=true` reads the working copy and writes nothing; with `preview=false` it writes the working copy and appends a change log entry. The "save" operation creates a checkpoint from the working copy as it stands and marks pending logs applied, without replaying anything. The "revert" operation rebuilds the working copy from the original, replaying logged transformations up to the chosen checkpoint, or restoring the bare original when no checkpoint is given.
+
+**Preview before persist.** A preview lives only in frontend state, so a reload (`GET /projects/get/{id}`) and a CSV export both read the working copy and an unsaved preview is discarded. Apply issues `preview=true`; Save Changes reissues the same payload with `preview=false`, and that second call is the one that persists.
 
 **Transformation service functions are pure** — they take a DataFrame and return a new DataFrame. Side effects (saving to disk, logging) are handled by the endpoint layer.
 
@@ -101,6 +103,8 @@ src/Components/          → NOTE: uppercase "C" in directory name
 **Project navigation uses URL params** (`/workspace/:projectId`), not state-based routing.
 
 **API functions return `response.data`** — callers receive the parsed body directly, not the Axios response wrapper.
+
+**Transform forms wire into preview mode** — after a successful `preview=true` request call `enterPreviewMode` from ProjectContext, and `cancelPreview` from the Cancel handler. Use the shared `usePreviewSave` hook for Save Changes; it reissues the pending transform with `preview: false` and calls `confirmPreview` on success.
 
 ### API routes
 


### PR DESCRIPTION
## Description

CLAUDE.md said the save operation "replays logged transformations onto the original". That is what revert does. `POST /projects/{id}/save` reads the working copy as it stands and checkpoints it without replaying anything, which its own docstring confirms.

Corrects that sentence, and adds the two facts that were missing alongside it:

- A pending preview lives only in frontend state, so a browser reload and a CSV export both read the working copy and an unsaved preview is discarded.
- What a transform form wires up: `enterPreviewMode` and `cancelPreview` from ProjectContext, and the shared `usePreviewSave` hook which reissues with `preview: false` and calls `confirmPreview`.

One file, documentation only, no behaviour change.

Fixes #238

### Note on #239

#239 was the behavioural half of this issue and was closed for conflicts with a suggestion to rebase. Worth flagging that a straight rebase would not be right now: that PR set `should_save = True` for the view transforms, but `should_save` has since been removed entirely and the codebase went with the preview flow instead. `grep -rn "should_save"` returns nothing in source. The behavioural work landed a different way, so only the written contract was left, which is what this PR does.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## How Has This Been Tested?

- [x] Existing tests pass
- [ ] New tests added
- [ ] Manual testing

Ran `npx vitest run`: 419 passed, 13 failed. The 13 are all localStorage-related and sit in `ProjectContext.columnOrder`, `MenuNavbar` and `SettingsPreferencesPage`. They reproduce identically on unmodified `main` at 96718ba, so they are pre-existing and unrelated to this PR, which changes no code at all.

Since it is a docs change, the more useful check was reading it against the implementation rather than against the issue text:

- `transform_project` takes `preview` and only calls `save_table_safe` + `log_transformations_or_restore` on the non-preview path
- `save_project` checkpoints the working copy and never replays; `revert_to_checkpoint` is the one that reads the original and replays logs
- `usePreviewSave` reissues the pending transform with `preview: false`
- `export_project` and the project GET both read `project.file_path`, the working copy, which is why a pending preview shows up in neither
- `e2e/transformations.spec.js` waits for Save Changes to appear after Apply on both filter and sort, matching the flow as documented

## Screenshots

N/A, documentation only.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally (see the note above on the 13 pre-existing failures)
