### PR TITLE
chore: migrate the Homescreen and DataScreen to TypeScript

### DIFF
--- a/dataloom-frontend/src/Components/DataScreen.tsx
+++ b/dataloom-frontend/src/Components/DataScreen.tsx
@@ -1,6 +1,5 @@
 import { useParams } from "react-router-dom";
 import { useEffect } from "react";
-import PropTypes from "prop-types";
 import { useProjectContext } from "../context/ProjectContext";
 import { WorkspaceTabsProvider, useWorkspaceTabs } from "../context/WorkspaceTabsContext";
 import { PanelProvider } from "../context/PanelContext";
@@ -25,7 +24,7 @@ import WorkspaceTabBar from "./workspace/WorkspaceTabBar";
 import RightPanel from "./workspace/RightPanel";
 import MenuNavbar from "./MenuNavbar";
 
-function WorkspaceContent({ projectId }) {
+function WorkspaceContent({ projectId }: { projectId: string }) {
   const { activeTab, openTab } = useWorkspaceTabs();
 
   const renderActiveTab = () => {
@@ -70,12 +69,8 @@ function WorkspaceContent({ projectId }) {
   );
 }
 
-WorkspaceContent.propTypes = {
-  projectId: PropTypes.string,
-};
-
 export default function DataScreen() {
-  const { projectId } = useParams();
+  const { projectId } = useParams() as { projectId: string };
   const { setProjectInfo, refreshProject } = useProjectContext();
 
   useEffect(() => {

--- a/dataloom-frontend/src/Components/Homescreen.tsx
+++ b/dataloom-frontend/src/Components/Homescreen.tsx
@@ -1,4 +1,13 @@
-import { useState, useEffect, useRef, useCallback } from "react";
+import {
+  useState,
+  useEffect,
+  useRef,
+  useCallback,
+  type ChangeEvent,
+  type DragEvent,
+  type FormEvent,
+  type MouseEvent,
+} from "react";
 import { useNavigate } from "react-router-dom";
 import {
   uploadProject,
@@ -6,6 +15,7 @@ import {
   deleteProject,
   searchProjects,
   updateProject,
+  type ProjectSummary,
 } from "../api";
 import { useToast } from "../context/ToastContext";
 import ConfirmDialog from "./common/ConfirmDialog";
@@ -20,8 +30,26 @@ import { useProjectContext } from "../context/ProjectContext";
 const PROJECT_NAME_MAX_LENGTH = 255;
 const PROJECT_DESCRIPTION_MAX_LENGTH = 1000;
 
-const ProjectCard = ({ project, onClick, onDelete, onEdit, isOpen, onToggleMenu, onCloseMenu }) => {
-  const menuRef = useRef(null);
+interface ProjectCardProps {
+  project: ProjectSummary;
+  onClick: () => void;
+  onDelete: (projectId: string) => void;
+  onEdit: (project: ProjectSummary) => void;
+  isOpen: boolean;
+  onToggleMenu: (projectId: string) => void;
+  onCloseMenu: () => void;
+}
+
+const ProjectCard = ({
+  project,
+  onClick,
+  onDelete,
+  onEdit,
+  isOpen,
+  onToggleMenu,
+  onCloseMenu,
+}: ProjectCardProps) => {
+  const menuRef = useRef<HTMLDivElement>(null);
 
   const modified = new Date(project.last_modified).toLocaleDateString(undefined, {
     year: "numeric",
@@ -31,12 +59,12 @@ const ProjectCard = ({ project, onClick, onDelete, onEdit, isOpen, onToggleMenu,
 
   useEffect(() => {
     if (!isOpen) return;
-    const handleClickOutside = (e) => {
-      if (menuRef.current && !menuRef.current.contains(e.target)) {
+    const handleClickOutside = (e: globalThis.MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
         onCloseMenu();
       }
     };
-    const handleKeyDown = (e) => {
+    const handleKeyDown = (e: globalThis.KeyboardEvent) => {
       if (e.key === "Escape") onCloseMenu();
     };
     document.addEventListener("click", handleClickOutside);
@@ -117,7 +145,7 @@ const ProjectCard = ({ project, onClick, onDelete, onEdit, isOpen, onToggleMenu,
   );
 };
 
-const NewProjectCard = ({ onClick }) => (
+const NewProjectCard = ({ onClick }: { onClick: () => void }) => (
   <button
     data-testid="new-project-card"
     onClick={onClick}
@@ -130,7 +158,7 @@ const NewProjectCard = ({ onClick }) => (
 
 const ACCEPT_ATTR = ACCEPTED_EXTENSIONS.join(",");
 
-const EmptyState = ({ onClick }) => (
+const EmptyState = ({ onClick }: { onClick: () => void }) => (
   <div className="flex flex-col items-center justify-center py-16 px-6 rounded-xl border-2 border-dashed border-app-border bg-surface text-center">
     <div className="mb-4 flex items-center justify-center w-16 h-16 rounded-full bg-blue-50">
       <svg
@@ -165,20 +193,36 @@ const EmptyState = ({ onClick }) => (
   </div>
 );
 
+interface DeleteConfirmState {
+  open: boolean;
+  projectId: string | null;
+}
+
+interface EditModalState {
+  open: boolean;
+  project: ProjectSummary | null;
+  name: string;
+  description: string;
+  isSubmitting: boolean;
+}
+
 const HomeScreen = () => {
-  const fileInputRef = useRef(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const [showModal, setShowModal] = useState(false);
-  const [fileUpload, setFileUpload] = useState(null);
+  const [fileUpload, setFileUpload] = useState<File | null>(null);
   const [projectName, setProjectName] = useState("");
   const [projectDescription, setProjectDescription] = useState("");
-  const [recentProjects, setRecentProjects] = useState([]);
+  const [recentProjects, setRecentProjects] = useState<ProjectSummary[]>([]);
   const [searchQuery, setSearchQuery] = useState("");
-  const [searchResults, setSearchResults] = useState([]);
+  const [searchResults, setSearchResults] = useState<ProjectSummary[]>([]);
   const [isSearchLoading, setIsSearchLoading] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [deleteConfirm, setDeleteConfirm] = useState({ open: false, projectId: null });
-  const [activeMenuProjectId, setActiveMenuProjectId] = useState(null);
-  const [editModal, setEditModal] = useState({
+  const [deleteConfirm, setDeleteConfirm] = useState<DeleteConfirmState>({
+    open: false,
+    projectId: null,
+  });
+  const [activeMenuProjectId, setActiveMenuProjectId] = useState<string | null>(null);
+  const [editModal, setEditModal] = useState<EditModalState>({
     open: false,
     project: null,
     name: "",
@@ -189,7 +233,7 @@ const HomeScreen = () => {
   const { showToast } = useToast();
   const { deleteProjectOrder } = useProjectContext();
 
-  const handleToggleMenu = useCallback((projectId) => {
+  const handleToggleMenu = useCallback((projectId: string) => {
     setActiveMenuProjectId((prev) => (prev === projectId ? null : projectId));
   }, []);
 
@@ -213,7 +257,7 @@ const HomeScreen = () => {
     }
   }, []);
 
-  const handleEditClick = (project) => {
+  const handleEditClick = (project: ProjectSummary) => {
     setEditModal({
       open: true,
       project,
@@ -233,10 +277,11 @@ const HomeScreen = () => {
     });
   }, []);
 
-  const handleSaveEdit = async (e) => {
+  const handleSaveEdit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (!editModal.project) return;
 
+    const { project } = editModal;
     const trimmedName = editModal.name.trim();
     const trimmedDesc = editModal.description.trim();
 
@@ -247,7 +292,7 @@ const HomeScreen = () => {
 
     try {
       setEditModal((prev) => ({ ...prev, isSubmitting: true }));
-      await updateProject(editModal.project.project_id, {
+      await updateProject(project.project_id, {
         name: trimmedName,
         description: trimmedDesc,
       });
@@ -255,7 +300,7 @@ const HomeScreen = () => {
       await fetchRecentProjects();
       setSearchResults((prev) =>
         prev.map((p) =>
-          p.project_id === editModal.project.project_id
+          p.project_id === project.project_id
             ? { ...p, name: trimmedName, description: trimmedDesc }
             : p,
         ),
@@ -309,7 +354,7 @@ const HomeScreen = () => {
 
   useEffect(() => {
     if (!showModal) return;
-    const handleKeyDown = (e) => {
+    const handleKeyDown = (e: globalThis.KeyboardEvent) => {
       if (e.key === "Escape" && !isSubmitting) handleCloseModal();
     };
     window.addEventListener("keydown", handleKeyDown);
@@ -318,7 +363,7 @@ const HomeScreen = () => {
 
   useEffect(() => {
     if (!editModal.open) return;
-    const handleKeyDown = (e) => {
+    const handleKeyDown = (e: globalThis.KeyboardEvent) => {
       if (e.key === "Escape" && !editModal.isSubmitting) handleCloseEditModal();
     };
     window.addEventListener("keydown", handleKeyDown);
@@ -329,12 +374,12 @@ const HomeScreen = () => {
     setShowModal(true);
   };
 
-  const handleSubmitModal = async (event) => {
+  const handleSubmitModal = async (event: MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
 
     const validation = validateFile(fileUpload);
-    if (!validation.valid) {
-      showToast(validation.error, "warning");
+    if (!validation.valid || !fileUpload) {
+      showToast(validation.error ?? "Please select a file to upload.", "warning");
       return;
     }
 
@@ -361,7 +406,9 @@ const HomeScreen = () => {
       }
     } catch (error) {
       console.error("Error uploading file:", error);
-      const message = error?.response?.data?.detail || "Error uploading file. Please try again.";
+      const message =
+        (error as { response?: { data?: { detail?: string } } })?.response?.data?.detail ||
+        "Error uploading file. Please try again.";
       showToast(message, "error");
     } finally {
       setIsSubmitting(false);
@@ -371,14 +418,14 @@ const HomeScreen = () => {
     fetchRecentProjects();
   };
 
-  const handleFileUpload = (fileOrEvent) => {
+  const handleFileUpload = (fileOrEvent: File | ChangeEvent<HTMLInputElement>) => {
     const file = fileOrEvent instanceof File ? fileOrEvent : fileOrEvent.target.files?.[0];
 
     if (!file) return;
 
     const validation = validateFile(file);
     if (!validation.valid) {
-      showToast(validation.error, "warning");
+      showToast(validation.error ?? "Please select a file to upload.", "warning");
 
       if (fileInputRef.current) {
         fileInputRef.current.value = "";
@@ -391,7 +438,7 @@ const HomeScreen = () => {
     setFileUpload(file);
   };
 
-  const handleDrop = (e) => {
+  const handleDrop = (e: DragEvent<HTMLElement>) => {
     e.preventDefault();
     e.stopPropagation();
 
@@ -401,7 +448,7 @@ const HomeScreen = () => {
     }
   };
 
-  const handleDragOver = (e) => {
+  const handleDragOver = (e: DragEvent<HTMLElement>) => {
     e.preventDefault();
     e.stopPropagation();
   };
@@ -414,17 +461,19 @@ const HomeScreen = () => {
     }
   };
 
-  const handleDeleteClick = (projectId) => {
+  const handleDeleteClick = (projectId: string) => {
     setDeleteConfirm({ open: true, projectId });
   };
 
   const handleDeleteConfirm = async () => {
+    const { projectId } = deleteConfirm;
+    if (!projectId) return;
     try {
-      await deleteProject(deleteConfirm.projectId);
-      deleteProjectOrder(deleteConfirm.projectId);
+      await deleteProject(projectId);
+      deleteProjectOrder(projectId);
       showToast("Project deleted successfully", "success");
       await fetchRecentProjects();
-      setSearchResults((prev) => prev.filter((p) => p.project_id !== deleteConfirm.projectId));
+      setSearchResults((prev) => prev.filter((p) => p.project_id !== projectId));
     } catch (error) {
       console.error("Error deleting project:", error);
       showToast("Failed to delete project", "error");
@@ -436,7 +485,7 @@ const HomeScreen = () => {
     setDeleteConfirm({ open: false, projectId: null });
   };
 
-  const handleRecentProjectClick = (projectId) => {
+  const handleRecentProjectClick = (projectId: string) => {
     if (!projectId) return;
     navigate(`/workspace/${projectId}`);
   };
@@ -659,7 +708,7 @@ const HomeScreen = () => {
 
                           <p className="text-xs text-muted-foreground mt-1">
                             {formatFileSize(fileUpload.size)} •{" "}
-                            {fileUpload.name.split(".").pop().toUpperCase()} File
+                            {fileUpload.name.split(".").pop()?.toUpperCase()} File
                           </p>
                         </div>
                       </div>

--- a/dataloom-frontend/src/test/Homescreen.test.tsx
+++ b/dataloom-frontend/src/test/Homescreen.test.tsx
@@ -65,7 +65,7 @@ describe("HomeScreen - Dataset Card Menu & Edit", () => {
     });
 
     const menuButtons = screen.getAllByTestId("project-card-menu-button");
-    fireEvent.click(menuButtons[0]);
+    fireEvent.click(menuButtons[0]!);
 
     expect(screen.getByTestId("edit-project-action")).toBeInTheDocument();
     expect(screen.getByTestId("delete-project-action")).toBeInTheDocument();
@@ -81,11 +81,11 @@ describe("HomeScreen - Dataset Card Menu & Edit", () => {
     const menuButtons = screen.getAllByTestId("project-card-menu-button");
 
     // Open first card's menu
-    fireEvent.click(menuButtons[0]);
+    fireEvent.click(menuButtons[0]!);
     expect(screen.getAllByTestId("project-card-menu").length).toBe(1);
 
     // Open second card's menu -> first card's menu should close automatically
-    fireEvent.click(menuButtons[1]);
+    fireEvent.click(menuButtons[1]!);
     expect(screen.getAllByTestId("project-card-menu").length).toBe(1);
   });
 
@@ -97,7 +97,7 @@ describe("HomeScreen - Dataset Card Menu & Edit", () => {
     });
 
     const menuButtons = screen.getAllByTestId("project-card-menu-button");
-    fireEvent.click(menuButtons[0]);
+    fireEvent.click(menuButtons[0]!);
 
     const editOption = screen.getByTestId("edit-project-action");
     fireEvent.click(editOption);
@@ -123,7 +123,7 @@ describe("HomeScreen - Dataset Card Menu & Edit", () => {
     });
 
     const menuButtons = screen.getAllByTestId("project-card-menu-button");
-    fireEvent.click(menuButtons[0]);
+    fireEvent.click(menuButtons[0]!);
     fireEvent.click(screen.getByTestId("edit-project-action"));
 
     const nameInput = screen.getByTestId("edit-project-name-input");
@@ -151,7 +151,7 @@ describe("HomeScreen - Dataset Card Menu & Edit", () => {
     });
 
     const menuButtons = screen.getAllByTestId("project-card-menu-button");
-    fireEvent.click(menuButtons[0]);
+    fireEvent.click(menuButtons[0]!);
     expect(screen.getByTestId("project-card-menu")).toBeInTheDocument();
 
     fireEvent.click(document.body);
@@ -167,7 +167,7 @@ describe("HomeScreen - Dataset Card Menu & Edit", () => {
     });
 
     const menuButtons = screen.getAllByTestId("project-card-menu-button");
-    fireEvent.click(menuButtons[0]);
+    fireEvent.click(menuButtons[0]!);
 
     const toggle = menuButtons[0];
     expect(toggle).toHaveAttribute("aria-expanded", "true");
@@ -185,7 +185,7 @@ describe("HomeScreen - Dataset Card Menu & Edit", () => {
       expect(screen.getByText("Time series test")).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getAllByTestId("project-card-menu-button")[0]);
+    fireEvent.click(screen.getAllByTestId("project-card-menu-button")[0]!);
     fireEvent.click(screen.getByTestId("edit-project-action"));
 
     expect(screen.getByTestId("edit-project-name-input")).toHaveAttribute("maxLength", "255");
@@ -216,7 +216,7 @@ describe("HomeScreen - Dataset Card Menu & Edit", () => {
       expect(screen.getByText("Time series test")).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getAllByTestId("project-card-menu-button")[0]);
+    fireEvent.click(screen.getAllByTestId("project-card-menu-button")[0]!);
     fireEvent.click(screen.getByTestId("edit-project-action"));
     fireEvent.click(screen.getByTestId("save-edit-project"));
 
@@ -234,7 +234,7 @@ describe("HomeScreen - Dataset Card Menu & Edit", () => {
       expect(screen.getByText("Time series test")).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getAllByTestId("project-card-menu-button")[0]);
+    fireEvent.click(screen.getAllByTestId("project-card-menu-button")[0]!);
     fireEvent.click(screen.getByTestId("edit-project-action"));
     fireEvent.click(screen.getByTestId("save-edit-project"));
 
@@ -249,7 +249,7 @@ describe("HomeScreen - Dataset Card Menu & Edit", () => {
     });
 
     const menuButtons = screen.getAllByTestId("project-card-menu-button");
-    fireEvent.click(menuButtons[0]);
+    fireEvent.click(menuButtons[0]!);
     fireEvent.click(screen.getByTestId("edit-project-action"));
 
     expect(screen.getByTestId("edit-project-modal")).toBeInTheDocument();

--- a/dataloom-frontend/src/test/PreviewWorkflow.test.tsx
+++ b/dataloom-frontend/src/test/PreviewWorkflow.test.tsx
@@ -46,9 +46,14 @@ beforeEach(() => {
   mockContext.pageSize = 50;
 });
 
+const mockTransformProject = vi.mocked(transformProject);
+
 describe("PreviewWorkflow — updateData propagation", () => {
   it("calls enterPreviewMode with dtypes and pagination metadata after successful transform", async () => {
-    transformProject.mockResolvedValueOnce({
+    mockTransformProject.mockResolvedValueOnce({
+      project_id: "proj-1",
+      operation_type: "filter",
+      row_count: 1,
       columns: ["City", "Amount"],
       rows: [["Paris", "300"]],
       dtypes: {
@@ -106,7 +111,7 @@ describe("PreviewWorkflow — updateData propagation", () => {
   });
 
   it("does not call enterPreviewMode when transform fails", async () => {
-    transformProject.mockRejectedValueOnce(new Error("Server error"));
+    mockTransformProject.mockRejectedValueOnce(new Error("Server error"));
 
     const { getByTestId, getByText } = render(<FilterForm projectId="proj-1" onClose={vi.fn()} />);
 
@@ -128,7 +133,10 @@ describe("PreviewWorkflow — updateData propagation", () => {
 
 describe("PreviewWorkflow — Newly migrated forms (TrimWhitespaceForm)", () => {
   it("calls enterPreviewMode with dtypes and pagination metadata on apply", async () => {
-    transformProject.mockResolvedValueOnce({
+    mockTransformProject.mockResolvedValueOnce({
+      project_id: "proj-1",
+      operation_type: "trimWhitespace",
+      row_count: 1,
       columns: ["City"],
       rows: [["Paris"]],
       dtypes: {

--- a/dataloom-frontend/src/test/Table.columnOrder.test.tsx
+++ b/dataloom-frontend/src/test/Table.columnOrder.test.tsx
@@ -112,9 +112,9 @@ describe("Table — column reorder behavior", () => {
       getData: vi.fn(),
     };
 
-    fireEvent.dragStart(cityHeader, { dataTransfer });
-    fireEvent.dragOver(dateHeader, { dataTransfer });
-    fireEvent.drop(dateHeader, { dataTransfer });
+    fireEvent.dragStart(cityHeader!, { dataTransfer });
+    fireEvent.dragOver(dateHeader!, { dataTransfer });
+    fireEvent.drop(dateHeader!, { dataTransfer });
 
     expect(mockContext.setColumnOrder).toHaveBeenCalledWith([1, 2, 0]);
   });
@@ -128,7 +128,7 @@ describe("Table — column reorder behavior", () => {
 
     const cells = screen.getAllByText("New York");
 
-    await user.click(cells[0]);
+    await user.click(cells[0]!);
 
     const input = await screen.findByDisplayValue("New York");
 


### PR DESCRIPTION
## Description

Sixth PR of the TypeScript migration, split up so each piece stays reviewable. Follows #483 (utils/constants/config), #485 (contexts and hooks), #486 (api response types), #490 (common components) and #491 (app shell). Rebased onto current `main` and stands on its own; the diff is a single commit.

This one converts the two screens themselves.

- Converts `Components/Homescreen` and `Components/DataScreen` to `.tsx`, along with the 3 tests that render them (`Homescreen`, `PreviewWorkflow`, `Table.columnOrder`)
- Types the `Homescreen` project lists as `ProjectSummary[]`, and its modal state as `DeleteConfirmState` / `EditModalState`
- Narrows `editModal.project` and `deleteConfirm.projectId` before the awaits that use them, instead of re-reading state that the await may have cleared
- Types `handleSubmitModal` as a button `MouseEvent`, because it is wired to `onClick` rather than to a form submit
- Drops the last two `prop-types` blocks in the codebase

One `.jsx` group remains after this: the form tests plus the build config. That is the last PR, and it turns `allowJs` off.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

Housekeeping, with no user-facing change.

## How Has This Been Tested?

- [x] Existing tests pass
- [ ] New tests added
- [x] Manual testing

`npm run lint` (ESLint + `tsc --noEmit`) clean and all 432 frontend tests pass locally. Test files touched by the migration were renamed, not rewritten. No `any`, `@ts-ignore` or `@ts-expect-error` was added.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally
