### PR TITLE
feat(frontend): add table loading skeleton and shared EmptyState

### DIFF
--- a/dataloom-frontend/src/Components/Homescreen.tsx
+++ b/dataloom-frontend/src/Components/Homescreen.tsx
@@ -19,6 +19,7 @@ import {
 } from "../api";
 import { useToast } from "../context/ToastContext";
 import ConfirmDialog from "./common/ConfirmDialog";
+import EmptyState from "./common/EmptyState";
 import { UploadCloud, FileText, X, Pencil, Search } from "lucide-react";
 import { FaRegEdit, FaRegTrashAlt } from "react-icons/fa";
 import { CiMenuKebab } from "react-icons/ci";
@@ -158,39 +159,41 @@ const NewProjectCard = ({ onClick }: { onClick: () => void }) => (
 
 const ACCEPT_ATTR = ACCEPTED_EXTENSIONS.join(",");
 
-const EmptyState = ({ onClick }: { onClick: () => void }) => (
-  <div className="flex flex-col items-center justify-center py-16 px-6 rounded-xl border-2 border-dashed border-app-border bg-surface text-center">
-    <div className="mb-4 flex items-center justify-center w-16 h-16 rounded-full bg-blue-50">
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        className="h-8 w-8 text-blue-400"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
-        strokeWidth={1.5}
-        aria-hidden="true"
+const NoProjectsIcon = (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    className="h-8 w-8 text-blue-400"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    aria-hidden="true"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M3 7a2 2 0 012-2h4l2 2h8a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2V7z"
+    />
+    <path strokeLinecap="round" strokeLinejoin="round" d="M12 11v4m-2-2h4" />
+  </svg>
+);
+
+const NoProjectsEmptyState = ({ onClick }: { onClick: () => void }) => (
+  <EmptyState
+    icon={NoProjectsIcon}
+    title="No projects yet"
+    description="Upload a dataset to get started. Your recent projects will appear here."
+    action={
+      <button
+        type="button"
+        data-testid="new-project-card"
+        onClick={onClick}
+        className="px-5 py-2.5 bg-blue-500 hover:bg-blue-600 text-white text-sm font-medium rounded-lg transition-colors duration-150 shadow-sm"
       >
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          d="M3 7a2 2 0 012-2h4l2 2h8a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2V7z"
-        />
-        <path strokeLinecap="round" strokeLinejoin="round" d="M12 11v4m-2-2h4" />
-      </svg>
-    </div>
-    <h3 className="text-lg font-semibold text-foreground mb-1">No projects yet</h3>
-    <p className="text-sm text-muted-foreground mb-6 max-w-xs">
-      Upload a dataset to get started. Your recent projects will appear here.
-    </p>
-    <button
-      type="button"
-      data-testid="new-project-card"
-      onClick={onClick}
-      className="px-5 py-2.5 bg-blue-500 hover:bg-blue-600 text-white text-sm font-medium rounded-lg transition-colors duration-150 shadow-sm"
-    >
-      Create your first project
-    </button>
-  </div>
+        Create your first project
+      </button>
+    }
+  />
 );
 
 interface DeleteConfirmState {
@@ -579,7 +582,7 @@ const HomeScreen = () => {
         </div>
 
         {recentProjects.length === 0 && !isSearching ? (
-          <EmptyState onClick={handleNewProjectClick} />
+          <NoProjectsEmptyState onClick={handleNewProjectClick} />
         ) : (
           renderProjectGrid()
         )}

--- a/dataloom-frontend/src/Components/Table.tsx
+++ b/dataloom-frontend/src/Components/Table.tsx
@@ -25,6 +25,7 @@ import InputDialog from "./common/InputDialog";
 import Toast from "./common/Toast";
 import DtypeBadge from "./common/DtypeBadge";
 import ColumnProfileCard from "./profiling/ColumnProfileCard";
+import TableSkeleton from "./common/TableSkeleton";
 import useColumnProfiles from "../hooks/useColumnProfiles";
 import { useToast } from "../context/ToastContext";
 
@@ -102,6 +103,7 @@ const Table = ({ projectId, showColumnProfiles = false }: TableProps) => {
     setPaginationData,
     updatePreviewPage,
     refreshProject,
+    loading,
   } = useProjectContext();
   const { refreshLogs } = useHistoryRefresh();
   const [data, setData] = useState<Cell[][]>([]);
@@ -457,169 +459,182 @@ const Table = ({ projectId, showColumnProfiles = false }: TableProps) => {
     <div className="flex flex-col flex-1 min-h-0">
       <div className="flex-1 min-h-0 overflow-hidden border-x border-b border-app-border shadow-sm">
         <div className="h-full overflow-auto">
-          <table
-            data-testid="data-table"
-            className="min-w-full bg-surface border-separate border-spacing-0"
-          >
-            <thead className="sticky top-0 z-20 bg-surface">
-              {showColumnProfiles && (
+          {loading && ctxRows.length === 0 ? (
+            // Only stand in when there is nothing to show. Every mutation
+            // handler refreshes after updating the grid in place, and swapping
+            // populated rows for a skeleton there would flash the whole table.
+            // ctxColumns still survives a refresh, so the column count is real
+            // whenever the schema is already known.
+            <TableSkeleton
+              columnCount={ctxColumns.length}
+              rowCount={pageSize}
+              showColumnProfiles={showColumnProfiles}
+            />
+          ) : (
+            <table
+              data-testid="data-table"
+              className="min-w-full bg-surface border-separate border-spacing-0"
+            >
+              <thead className="sticky top-0 z-20 bg-surface">
+                {showColumnProfiles && (
+                  <tr>
+                    {columns.map((column, columnIndex) => {
+                      const isSerialNumber = columnIndex === 0;
+                      return (
+                        <th
+                          key={columnIndex}
+                          className={`align-top border-b border-r border-app-border ${
+                            isSerialNumber
+                              ? "w-16 sticky left-0 z-10 bg-surface"
+                              : "bg-surface min-w-35"
+                          }`}
+                        >
+                          {!isSerialNumber && (
+                            <ColumnProfileCard
+                              profile={profiles[column] ?? null}
+                              loading={profilesLoading && !profiles[column]}
+                            />
+                          )}
+                        </th>
+                      );
+                    })}
+                  </tr>
+                )}
                 <tr>
                   {columns.map((column, columnIndex) => {
                     const isSerialNumber = columnIndex === 0;
+                    const isDragged = !isSerialNumber && draggedColIndex === columnIndex - 1;
+                    const isDropTarget = !isSerialNumber && hoveredTargetIndex === columnIndex - 1;
                     return (
                       <th
                         key={columnIndex}
-                        className={`align-top border-b border-r border-app-border ${
-                          isSerialNumber
-                            ? "w-16 sticky left-0 z-10 bg-surface"
-                            : "bg-surface min-w-35"
-                        }`}
+                        className={`h-6 px-0.5 py-0 border-r border-app-border text-left text-xs font-medium text-muted-foreground uppercase tracking-wider ${
+                          isDropTarget ? "ring-2 ring-blue-400" : ""
+                        } ${isSerialNumber ? "w-16 sticky left-0 z-10 bg-surface" : "bg-surface"}`}
+                        onContextMenu={(e) => {
+                          if (!isPreviewMode) {
+                            open(e, { type: "column", columnIndex });
+                          }
+                        }}
                       >
-                        {!isSerialNumber && (
-                          <ColumnProfileCard
-                            profile={profiles[column] ?? null}
-                            loading={profilesLoading && !profiles[column]}
-                          />
-                        )}
+                        <button
+                          type="button"
+                          className={`w-full text-left text-muted-foreground hover:text-foreground hover:bg-surface-hover rounded-md transition-colors duration-150 ${
+                            isSerialNumber ? "" : "cursor-grab active:cursor-grabbing"
+                          } ${isDragged ? "opacity-50" : ""}`}
+                          draggable={!isSerialNumber}
+                          onDragStart={(event) => {
+                            if (isSerialNumber) return;
+                            setDraggedColIndex(columnIndex - 1);
+                            event.dataTransfer.effectAllowed = "move";
+                          }}
+                          onDragOver={(event) => {
+                            if (isSerialNumber) return;
+                            event.preventDefault();
+                            event.dataTransfer.dropEffect = "move";
+                            setHoveredTargetIndex(columnIndex - 1);
+                          }}
+                          onDrop={(event) => {
+                            if (isSerialNumber) return;
+                            event.preventDefault();
+                            if (draggedColIndex === null) return;
+                            const source = draggedColIndex;
+                            const target = columnIndex - 1;
+                            if (source === target) {
+                              setHoveredTargetIndex(null);
+                              return;
+                            }
+                            const newOrder = [...safeOrder];
+                            const [moved] = newOrder.splice(source, 1);
+                            newOrder.splice(target, 0, moved as number);
+                            setColumnOrder(newOrder);
+                            setDraggedColIndex(null);
+                            setHoveredTargetIndex(null);
+                          }}
+                          onDragEnd={() => {
+                            setDraggedColIndex(null);
+                            setHoveredTargetIndex(null);
+                          }}
+                        >
+                          {column}
+                        </button>
                       </th>
                     );
                   })}
                 </tr>
-              )}
-              <tr>
-                {columns.map((column, columnIndex) => {
-                  const isSerialNumber = columnIndex === 0;
-                  const isDragged = !isSerialNumber && draggedColIndex === columnIndex - 1;
-                  const isDropTarget = !isSerialNumber && hoveredTargetIndex === columnIndex - 1;
-                  return (
-                    <th
-                      key={columnIndex}
-                      className={`h-6 px-0.5 py-0 border-r border-app-border text-left text-xs font-medium text-muted-foreground uppercase tracking-wider ${
-                        isDropTarget ? "ring-2 ring-blue-400" : ""
-                      } ${isSerialNumber ? "w-16 sticky left-0 z-10 bg-surface" : "bg-surface"}`}
-                      onContextMenu={(e) => {
-                        if (!isPreviewMode) {
-                          open(e, { type: "column", columnIndex });
-                        }
-                      }}
-                    >
-                      <button
-                        type="button"
-                        className={`w-full text-left text-muted-foreground hover:text-foreground hover:bg-surface-hover rounded-md transition-colors duration-150 ${
-                          isSerialNumber ? "" : "cursor-grab active:cursor-grabbing"
-                        } ${isDragged ? "opacity-50" : ""}`}
-                        draggable={!isSerialNumber}
-                        onDragStart={(event) => {
-                          if (isSerialNumber) return;
-                          setDraggedColIndex(columnIndex - 1);
-                          event.dataTransfer.effectAllowed = "move";
-                        }}
-                        onDragOver={(event) => {
-                          if (isSerialNumber) return;
-                          event.preventDefault();
-                          event.dataTransfer.dropEffect = "move";
-                          setHoveredTargetIndex(columnIndex - 1);
-                        }}
-                        onDrop={(event) => {
-                          if (isSerialNumber) return;
-                          event.preventDefault();
-                          if (draggedColIndex === null) return;
-                          const source = draggedColIndex;
-                          const target = columnIndex - 1;
-                          if (source === target) {
-                            setHoveredTargetIndex(null);
-                            return;
+                <tr>
+                  {columns.map((column, columnIndex) => {
+                    const isSerialNumber = columnIndex === 0;
+                    const isDropTarget = !isSerialNumber && hoveredTargetIndex === columnIndex - 1;
+                    return (
+                      <th
+                        key={columnIndex}
+                        className={`h-5 px-0.5 py-0 border-b border-r border-app-border text-left text-[10px] leading-none ${
+                          isDropTarget ? "ring-2 ring-blue-400" : ""
+                        } ${isSerialNumber ? "w-16 sticky left-0 z-10 bg-surface" : "bg-surface"}`}
+                        onContextMenu={(e) => open(e, { type: "column", columnIndex })}
+                      >
+                        {!isSerialNumber && dtypes[column] ? (
+                          // empty className strips DtypeBadge's default ml-1.5 so the
+                          // badge fills the dtype row flush; undefined would re-add it
+                          <DtypeBadge dtype={dtypes[column]} className="" />
+                        ) : null}
+                      </th>
+                    );
+                  })}
+                </tr>
+              </thead>
+
+              <tbody>
+                {data.map((row, rowIndex) => (
+                  <tr
+                    key={rowIndex}
+                    className="hover:bg-surface-hover transition-colors duration-150"
+                  >
+                    {row.map((cell, cellIndex) => (
+                      <td
+                        key={cellIndex}
+                        className={`h-6 px-0.5 py-0 text-xs border-b border-r border-app-border ${
+                          cellIndex === 0
+                            ? "w-16 sticky left-0 z-10 bg-surface text-center font-medium text-muted-foreground"
+                            : "text-foreground"
+                        }`}
+                        onContextMenu={(e) => {
+                          if (!isPreviewMode) {
+                            open(e, { type: "row", rowIndex });
                           }
-                          const newOrder = [...safeOrder];
-                          const [moved] = newOrder.splice(source, 1);
-                          newOrder.splice(target, 0, moved as number);
-                          setColumnOrder(newOrder);
-                          setDraggedColIndex(null);
-                          setHoveredTargetIndex(null);
-                        }}
-                        onDragEnd={() => {
-                          setDraggedColIndex(null);
-                          setHoveredTargetIndex(null);
                         }}
                       >
-                        {column}
-                      </button>
-                    </th>
-                  );
-                })}
-              </tr>
-              <tr>
-                {columns.map((column, columnIndex) => {
-                  const isSerialNumber = columnIndex === 0;
-                  const isDropTarget = !isSerialNumber && hoveredTargetIndex === columnIndex - 1;
-                  return (
-                    <th
-                      key={columnIndex}
-                      className={`h-5 px-0.5 py-0 border-b border-r border-app-border text-left text-[10px] leading-none ${
-                        isDropTarget ? "ring-2 ring-blue-400" : ""
-                      } ${isSerialNumber ? "w-16 sticky left-0 z-10 bg-surface" : "bg-surface"}`}
-                      onContextMenu={(e) => open(e, { type: "column", columnIndex })}
-                    >
-                      {!isSerialNumber && dtypes[column] ? (
-                        // empty className strips DtypeBadge's default ml-1.5 so the
-                        // badge fills the dtype row flush; undefined would re-add it
-                        <DtypeBadge dtype={dtypes[column]} className="" />
-                      ) : null}
-                    </th>
-                  );
-                })}
-              </tr>
-            </thead>
-
-            <tbody>
-              {data.map((row, rowIndex) => (
-                <tr
-                  key={rowIndex}
-                  className="hover:bg-surface-hover transition-colors duration-150"
-                >
-                  {row.map((cell, cellIndex) => (
-                    <td
-                      key={cellIndex}
-                      className={`h-6 px-0.5 py-0 text-xs border-b border-r border-app-border ${
-                        cellIndex === 0
-                          ? "w-16 sticky left-0 z-10 bg-surface text-center font-medium text-muted-foreground"
-                          : "text-foreground"
-                      }`}
-                      onContextMenu={(e) => {
-                        if (!isPreviewMode) {
-                          open(e, { type: "row", rowIndex });
-                        }
-                      }}
-                    >
-                      {editingCell &&
-                      editingCell.rowIndex === rowIndex &&
-                      editingCell.cellIndex === cellIndex ? (
-                        <input
-                          type="text"
-                          value={editValue}
-                          onChange={(e) => setEditValue(e.target.value)}
-                          onBlur={() => handleEditCell(rowIndex, cellIndex, editValue)}
-                          className="w-full p-1 border border-app-border rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none"
-                          onKeyDown={(e) => handleInputKeyDown(e, rowIndex, cellIndex)}
-                        />
-                      ) : (
-                        <div
-                          onClick={() => handleCellClick(rowIndex, cellIndex, cell)}
-                          className={
-                            cellIndex !== 0
-                              ? "cursor-pointer hover:bg-elevated px-1 py-0.5 rounded"
-                              : ""
-                          }
-                        >
-                          {cell}
-                        </div>
-                      )}
-                    </td>
-                  ))}
-                </tr>
-              ))}
-            </tbody>
-          </table>
+                        {editingCell &&
+                        editingCell.rowIndex === rowIndex &&
+                        editingCell.cellIndex === cellIndex ? (
+                          <input
+                            type="text"
+                            value={editValue}
+                            onChange={(e) => setEditValue(e.target.value)}
+                            onBlur={() => handleEditCell(rowIndex, cellIndex, editValue)}
+                            className="w-full p-1 border border-app-border rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none"
+                            onKeyDown={(e) => handleInputKeyDown(e, rowIndex, cellIndex)}
+                          />
+                        ) : (
+                          <div
+                            onClick={() => handleCellClick(rowIndex, cellIndex, cell)}
+                            className={
+                              cellIndex !== 0
+                                ? "cursor-pointer hover:bg-elevated px-1 py-0.5 rounded"
+                                : ""
+                            }
+                          >
+                            {cell}
+                          </div>
+                        )}
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
         </div>
       </div>
 

--- a/dataloom-frontend/src/Components/common/EmptyState.tsx
+++ b/dataloom-frontend/src/Components/common/EmptyState.tsx
@@ -1,0 +1,55 @@
+import type { ReactNode } from "react";
+
+export type EmptyStateVariant = "card" | "inline";
+
+interface EmptyStateProps {
+  /** Primary message. */
+  title: string;
+  /** Supporting line below the title. */
+  description?: string;
+  /** Call to action, typically a button. Not rendered by the inline variant. */
+  action?: ReactNode;
+  /** Glyph shown above the title. Not rendered by the inline variant. */
+  icon?: ReactNode;
+  /** `card` for a standalone region, `inline` for a table cell. */
+  variant?: EmptyStateVariant;
+}
+
+/**
+ * Placeholder for regions with nothing to show.
+ */
+export default function EmptyState({
+  title,
+  description,
+  action,
+  icon,
+  variant = "card",
+}: EmptyStateProps) {
+  if (variant === "inline") {
+    return (
+      <div
+        className="py-4 px-4 text-center text-sm text-muted-foreground"
+        data-testid={`empty-state-${variant}`}
+      >
+        {title}
+        {description && <p className="mt-1">{description}</p>}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="flex flex-col items-center justify-center py-16 px-6 rounded-xl border-2 border-dashed border-app-border bg-surface text-center"
+      data-testid={`empty-state-${variant}`}
+    >
+      {icon && (
+        <div className="mb-4 flex items-center justify-center w-16 h-16 rounded-full bg-blue-50">
+          {icon}
+        </div>
+      )}
+      <h3 className="text-lg font-semibold text-foreground mb-1">{title}</h3>
+      {description && <p className="text-sm text-muted-foreground mb-6 max-w-xs">{description}</p>}
+      {action}
+    </div>
+  );
+}

--- a/dataloom-frontend/src/Components/common/TableSkeleton.tsx
+++ b/dataloom-frontend/src/Components/common/TableSkeleton.tsx
@@ -1,0 +1,100 @@
+/** Data columns drawn before the real schema is known. */
+const FALLBACK_DATA_COLUMN_COUNT = 6;
+
+interface TableSkeletonProps {
+  /** Data-column count, excluding the leading S.No. column. */
+  columnCount?: number;
+  /** Placeholder rows to draw. */
+  rowCount?: number;
+  /** Draw the profile header row, matching the real grid's Columns toggle. */
+  showColumnProfiles?: boolean;
+}
+
+const SkeletonBar = ({ className = "w-3/4" }: { className?: string }) => (
+  <div className={`h-2 bg-surface-hover rounded ${className}`} />
+);
+
+/**
+ * Placeholder grid shown while project data loads. Mirrors the row heights and
+ * column count of the real table so the layout does not shift.
+ */
+export default function TableSkeleton({
+  columnCount = 0,
+  rowCount = 10,
+  showColumnProfiles = false,
+}: TableSkeletonProps) {
+  const dataColumns = columnCount > 0 ? columnCount : FALLBACK_DATA_COLUMN_COUNT;
+  const totalColumns = dataColumns + 1;
+  const serialCell = "w-16 sticky left-0 z-10 bg-surface";
+
+  return (
+    <table
+      data-testid="data-table-skeleton"
+      aria-hidden="true"
+      className="min-w-full bg-surface border-separate border-spacing-0 animate-pulse"
+    >
+      <thead className="sticky top-0 z-20 bg-surface">
+        {showColumnProfiles && (
+          <tr>
+            {Array.from({ length: totalColumns }, (_, columnIndex) => (
+              <th
+                key={columnIndex}
+                className={`align-top border-b border-r border-app-border ${
+                  columnIndex === 0 ? serialCell : "bg-surface min-w-35"
+                }`}
+              >
+                {columnIndex !== 0 && (
+                  <div className="p-1.5 space-y-1">
+                    <SkeletonBar className="w-full" />
+                    <SkeletonBar />
+                    <SkeletonBar className="w-1/2" />
+                  </div>
+                )}
+              </th>
+            ))}
+          </tr>
+        )}
+        <tr>
+          {Array.from({ length: totalColumns }, (_, columnIndex) => (
+            <th
+              key={columnIndex}
+              className={`h-6 px-0.5 py-0 border-r border-app-border text-left ${
+                columnIndex === 0 ? serialCell : "bg-surface"
+              }`}
+            >
+              <SkeletonBar />
+            </th>
+          ))}
+        </tr>
+        <tr>
+          {Array.from({ length: totalColumns }, (_, columnIndex) => (
+            <th
+              key={columnIndex}
+              className={`h-5 px-0.5 py-0 border-b border-r border-app-border text-left ${
+                columnIndex === 0 ? serialCell : "bg-surface"
+              }`}
+            >
+              {columnIndex !== 0 && <SkeletonBar className="w-1/2" />}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {Array.from({ length: rowCount }, (_, rowIndex) => (
+          <tr key={rowIndex}>
+            {Array.from({ length: totalColumns }, (_, cellIndex) => (
+              <td
+                key={cellIndex}
+                className={`h-6 px-0.5 py-0 border-b border-r border-app-border ${
+                  cellIndex === 0 ? serialCell : ""
+                }`}
+              >
+                <SkeletonBar className={cellIndex === 0 ? "w-1/2 mx-auto" : "w-3/4"} />
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/dataloom-frontend/src/Components/common/__tests__/EmptyState.test.tsx
+++ b/dataloom-frontend/src/Components/common/__tests__/EmptyState.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import EmptyState from "../EmptyState";
+
+describe("EmptyState", () => {
+  it("renders the title as a heading", () => {
+    render(<EmptyState title="No projects yet" />);
+
+    expect(screen.getByRole("heading", { name: "No projects yet" })).toBeInTheDocument();
+  });
+
+  it("renders the description when provided", () => {
+    render(<EmptyState title="No projects yet" description="Upload a dataset to get started." />);
+
+    expect(screen.getByText("Upload a dataset to get started.")).toBeInTheDocument();
+  });
+
+  it("omits the description when not provided", () => {
+    const { container } = render(<EmptyState title="No projects yet" />);
+
+    expect(container.querySelector("p")).toBeNull();
+  });
+
+  it("renders the action element", () => {
+    render(
+      <EmptyState title="No projects yet" action={<button>Create your first project</button>} />,
+    );
+
+    expect(screen.getByRole("button", { name: "Create your first project" })).toBeInTheDocument();
+  });
+
+  it("renders the icon when provided", () => {
+    render(<EmptyState title="No projects yet" icon={<svg data-testid="icon" />} />);
+
+    expect(screen.getByTestId("icon")).toBeInTheDocument();
+  });
+
+  it("renders the inline variant without a heading", () => {
+    render(<EmptyState variant="inline" title="No logs available" />);
+
+    expect(screen.getByText("No logs available")).toBeInTheDocument();
+    expect(screen.queryByRole("heading")).not.toBeInTheDocument();
+  });
+
+  it("does not render the action in the inline variant", () => {
+    render(<EmptyState variant="inline" title="No logs available" action={<button>Add</button>} />);
+
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+});

--- a/dataloom-frontend/src/Components/common/__tests__/TableSkeleton.test.tsx
+++ b/dataloom-frontend/src/Components/common/__tests__/TableSkeleton.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import TableSkeleton from "../TableSkeleton";
+
+const nameHeaderCells = (container: HTMLElement) =>
+  container.querySelectorAll("thead tr:first-child th");
+
+describe("TableSkeleton", () => {
+  it("applies the pulse animation", () => {
+    render(<TableSkeleton />);
+
+    expect(screen.getByTestId("data-table-skeleton")).toHaveClass("animate-pulse");
+  });
+
+  it("is hidden from assistive technology", () => {
+    render(<TableSkeleton />);
+
+    expect(screen.getByTestId("data-table-skeleton")).toHaveAttribute("aria-hidden", "true");
+  });
+
+  it("renders two header rows", () => {
+    const { container } = render(<TableSkeleton />);
+
+    expect(container.querySelectorAll("thead tr")).toHaveLength(2);
+  });
+
+  it("renders a third header row when column profiles are shown", () => {
+    const { container } = render(<TableSkeleton showColumnProfiles />);
+
+    expect(container.querySelectorAll("thead tr")).toHaveLength(3);
+  });
+
+  it("renders the requested data columns plus the S.No. column", () => {
+    const { container } = render(<TableSkeleton columnCount={3} />);
+
+    expect(nameHeaderCells(container)).toHaveLength(4);
+  });
+
+  it("renders body cells for every column", () => {
+    const { container } = render(<TableSkeleton columnCount={12} />);
+
+    expect(nameHeaderCells(container)).toHaveLength(13);
+    container.querySelectorAll("tbody tr").forEach((row) => {
+      expect(row.querySelectorAll("td")).toHaveLength(13);
+    });
+  });
+
+  it("falls back to a default column count when given zero", () => {
+    const { container } = render(<TableSkeleton columnCount={0} />);
+
+    expect(nameHeaderCells(container).length).toBeGreaterThan(1);
+  });
+
+  it("renders the requested number of body rows", () => {
+    const { container } = render(<TableSkeleton rowCount={7} />);
+
+    expect(container.querySelectorAll("tbody tr")).toHaveLength(7);
+  });
+
+  it("matches the row heights of the real grid", () => {
+    const { container } = render(<TableSkeleton columnCount={2} rowCount={1} />);
+
+    expect(nameHeaderCells(container)[0]).toHaveClass("h-6");
+    expect(container.querySelectorAll("thead tr:last-child th")[0]).toHaveClass("h-5");
+    expect(container.querySelectorAll("tbody td")[0]).toHaveClass("h-6");
+  });
+});

--- a/dataloom-frontend/src/Components/history/CheckpointsPanel.tsx
+++ b/dataloom-frontend/src/Components/history/CheckpointsPanel.tsx
@@ -3,6 +3,7 @@ import { deleteCheckpoint, type Checkpoint } from "../../api";
 import Modal from "../common/Modal";
 import { useToast } from "../../context/ToastContext";
 import Button from "../common/Button";
+import EmptyState from "../common/EmptyState";
 
 interface CheckpointsPanelProps {
   projectId: string;
@@ -81,8 +82,8 @@ const CheckpointsPanel = ({
               ))
             ) : (
               <tr>
-                <td colSpan={3} className="py-4 px-4 text-center text-sm text-muted-foreground">
-                  No checkpoints available
+                <td colSpan={3}>
+                  <EmptyState variant="inline" title="No checkpoints available" />
                 </td>
               </tr>
             )}

--- a/dataloom-frontend/src/Components/history/LogsPanel.tsx
+++ b/dataloom-frontend/src/Components/history/LogsPanel.tsx
@@ -1,4 +1,5 @@
 import type { LogEntry } from "../../api";
+import EmptyState from "../common/EmptyState";
 
 interface LogsPanelProps {
   logs: LogEntry[];
@@ -44,8 +45,8 @@ const LogsPanel = ({ logs }: LogsPanelProps) => {
               ))
             ) : (
               <tr>
-                <td colSpan={4} className="py-4 px-4 text-center text-sm text-muted-foreground">
-                  No logs available
+                <td colSpan={4}>
+                  <EmptyState variant="inline" title="No logs available" />
                 </td>
               </tr>
             )}

--- a/dataloom-frontend/src/test/Table.skeleton.test.tsx
+++ b/dataloom-frontend/src/test/Table.skeleton.test.tsx
@@ -1,0 +1,122 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import Table from "../Components/Table";
+import { ToastProvider } from "../context/ToastContext";
+
+vi.mock("../api", () => ({
+  transformProject: vi.fn(),
+  getColumnProfile: vi.fn(() => Promise.resolve({})),
+}));
+
+const COLUMNS = ["City", "Amount", "Date"];
+const ROWS = [["New York", "100", "2024-01-01"]];
+
+const mockContext = {
+  columns: COLUMNS,
+  rows: ROWS as unknown[][],
+  dtypes: { City: "string", Amount: "float", Date: "date" },
+  columnOrder: [0, 1, 2],
+  setColumnOrder: vi.fn(),
+  updateData: vi.fn(),
+  dataVersion: 0,
+  totalRows: 1,
+  totalPages: 1,
+  page: 1,
+  pageSize: 50,
+  isPreviewMode: false,
+  pendingTransform: null,
+  setPaginationData: vi.fn(),
+  updatePreviewPage: vi.fn(),
+  refreshProject: vi.fn(),
+  loading: false,
+};
+
+vi.mock("../context/ProjectContext", () => ({
+  useProjectContext: () => mockContext,
+}));
+
+vi.mock("../context/HistoryRefreshContext", () => ({
+  useHistoryRefresh: () => ({ refreshLogs: vi.fn(), refreshCheckpoints: vi.fn() }),
+}));
+
+const renderTable = (showColumnProfiles = false) =>
+  render(
+    <ToastProvider>
+      <Table projectId="test-id" showColumnProfiles={showColumnProfiles} />
+    </ToastProvider>,
+  );
+
+/** Render the first-load state: fetching, with no rows on screen yet. */
+const renderLoading = (showColumnProfiles = false) => {
+  mockContext.loading = true;
+  mockContext.rows = [];
+  return renderTable(showColumnProfiles);
+};
+
+const headerRows = (container: HTMLElement, testId: string) =>
+  container.querySelector(`[data-testid="${testId}"]`)?.querySelectorAll("thead tr") ?? [];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockContext.loading = false;
+  mockContext.rows = ROWS;
+});
+
+describe("Table loading skeleton", () => {
+  it("renders the grid and no skeleton when not loading", () => {
+    renderTable();
+
+    expect(screen.getByTestId("data-table")).toBeInTheDocument();
+    expect(screen.queryByTestId("data-table-skeleton")).not.toBeInTheDocument();
+  });
+
+  it("renders the skeleton and no grid on first load", () => {
+    renderLoading();
+
+    expect(screen.getByTestId("data-table-skeleton")).toBeInTheDocument();
+    expect(screen.queryByTestId("data-table")).not.toBeInTheDocument();
+  });
+
+  it("keeps the grid when a refresh follows an in-place update", () => {
+    // Mutation handlers update the grid, then refresh. Rows are still on
+    // screen, so the skeleton must not replace them.
+    mockContext.loading = true;
+    renderTable();
+
+    expect(screen.getByTestId("data-table")).toBeInTheDocument();
+    expect(screen.queryByTestId("data-table-skeleton")).not.toBeInTheDocument();
+  });
+
+  it("gives the skeleton the same column count as the loaded grid", () => {
+    const { container: loaded } = renderTable();
+    const loadedCells = loaded.querySelectorAll(
+      '[data-testid="data-table"] thead tr:last-child th',
+    );
+
+    const { container: skeleton } = renderLoading();
+    const skeletonCells = skeleton.querySelectorAll(
+      '[data-testid="data-table-skeleton"] thead tr:last-child th',
+    );
+
+    expect(skeletonCells).toHaveLength(loadedCells.length);
+  });
+
+  it("gives the skeleton the same header row count as the loaded grid", () => {
+    const { container: loaded } = renderTable();
+    const { container: skeleton } = renderLoading();
+
+    expect(headerRows(skeleton, "data-table-skeleton")).toHaveLength(
+      headerRows(loaded, "data-table").length,
+    );
+  });
+
+  it("keeps the header rows aligned when column profiles are on", () => {
+    const { container: loaded } = renderTable(true);
+    const { container: skeleton } = renderLoading(true);
+
+    expect(headerRows(skeleton, "data-table-skeleton")).toHaveLength(
+      headerRows(loaded, "data-table").length,
+    );
+  });
+});


### PR DESCRIPTION
## Description

Adds a table loading skeleton and a shared `EmptyState` component.

- `Table.tsx` now reads `loading` from ProjectContext and shows a skeleton while it is true
- Skeleton matches the real grid's column count and row heights so the layout does not shift
- Extracts the Homescreen empty state into `Components/common/EmptyState.tsx`
- Reuses it in the logs and checkpoints tables, wording unchanged
- Adds Vitest tests for both components

Fixes #94

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

### New Components

- **TableSkeleton.tsx**: pulse placeholder following the `ColumnProfileCard` pattern. Mirrors the real table's S.No. column, both header rows (`h-6` and `h-5`) and `h-6` body rows. Column and row count configurable, falls back to 6 columns before the schema is known.
- **EmptyState.tsx**: title, plus optional description, action and icon. `card` variant for standalone regions, `inline` for table cells.

### Modified Components

1. **Table.tsx** - added `loading` to the context destructure and `TableSkeleton` to the render
2. **Homescreen.tsx** - inline `EmptyState` replaced with the shared component, same output
3. **LogsPanel.tsx** - empty branch renders `EmptyState variant="inline"`, keeps "No logs available"
4. **CheckpointsPanel.tsx** - same, keeps "No checkpoints available"

## How Has This Been Tested?
- [x] Existing tests pass
- [x] New tests added
- [x] Manual testing

- `npx vitest run` - 434 passed
- `npm run lint` - passed
- `npx prettier --check` on the changed files - passed

## Screenshots

<img width="2000" height="556" alt="image" src="https://github.com/user-attachments/assets/0534b147-f03d-47a7-b39c-75a4e81daffd" />

<img width="2000" height="1140" alt="image" src="https://github.com/user-attachments/assets/de8bb4b5-22b6-4e50-bb03-9733b2eea8c0" />

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally
