### PR TITLE
feat(frontend): sort a column by clicking its header

### DIFF
--- a/dataloom-frontend/src/Components/Table.tsx
+++ b/dataloom-frontend/src/Components/Table.tsx
@@ -9,7 +9,14 @@ import {
   type KeyboardEvent,
   useCallback,
 } from "react";
-import { ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight } from "lucide-react";
+import {
+  ArrowDown,
+  ArrowUp,
+  ChevronLeft,
+  ChevronRight,
+  ChevronsLeft,
+  ChevronsRight,
+} from "lucide-react";
 import { transformProject, type CellValue, type TransformationInput } from "../api";
 import { useProjectContext } from "../context/ProjectContext";
 import { useHistoryRefresh } from "../context/HistoryRefreshContext";
@@ -20,7 +27,9 @@ import {
   DELETE_COLUMN,
   DELETE_ROW,
   RENAME_COLUMN,
+  SORT,
 } from "../constants/operationTypes";
+import { sortCriteriaOf } from "./forms/transformFormProps";
 import InputDialog from "./common/InputDialog";
 import Toast from "./common/Toast";
 import DtypeBadge from "./common/DtypeBadge";
@@ -28,6 +37,7 @@ import ColumnProfileCard from "./profiling/ColumnProfileCard";
 import TableSkeleton from "./common/TableSkeleton";
 import useColumnProfiles from "../hooks/useColumnProfiles";
 import { useToast } from "../context/ToastContext";
+import { usePanel } from "../context/PanelContext";
 
 /** A single table cell value, as the API layer defines it. */
 type Cell = CellValue;
@@ -100,12 +110,15 @@ const Table = ({ projectId, showColumnProfiles = false }: TableProps) => {
     pageSize,
     isPreviewMode,
     pendingTransform,
+    enterPreviewMode,
+    cancelPreview,
     setPaginationData,
     updatePreviewPage,
     refreshProject,
     loading,
   } = useProjectContext();
   const { refreshLogs } = useHistoryRefresh();
+  const { openPanel } = usePanel();
   const [data, setData] = useState<Cell[][]>([]);
   const [columns, setColumns] = useState<string[]>([]);
   const [editingCell, setEditingCell] = useState<EditingCell | null>(null);
@@ -119,6 +132,9 @@ const Table = ({ projectId, showColumnProfiles = false }: TableProps) => {
   const [hoveredTargetIndex, setHoveredTargetIndex] = useState<number | null>(null);
 
   const [previewLoading, setPreviewLoading] = useState(false);
+  // Derived from the pending preview, so a sort applied from the panel shows it too.
+  const sortCriteria = sortCriteriaOf(pendingTransform?.payload);
+  const headerSort = sortCriteria?.length === 1 ? sortCriteria[0] : undefined;
   const previewRequestIdRef = useRef(0);
 
   // Per-column profiles for the "Columns" toggle. dataVersion is the change
@@ -365,6 +381,28 @@ const Table = ({ projectId, showColumnProfiles = false }: TableProps) => {
     }
   };
 
+  const handleHeaderSort = async (column: string) => {
+    // Inert while something else owns the grid: an open menu, a cell edit, a refresh or preview
+    // request in flight, or another form's preview. A header sort is the one this grid owns.
+    if (isOpen || editingCell || loading || previewLoading || (isPreviewMode && !headerSort))
+      return;
+    if (headerSort?.column === column && !headerSort.ascending) return cancelPreview();
+
+    const ascending = headerSort?.column !== column;
+    const payload = { operation_type: SORT, sort_params: { criteria: [{ column, ascending }] } };
+    setPreviewLoading(true);
+    try {
+      const res = await transformProject(projectId, payload, { preview: true, page: 1, pageSize });
+      enterPreviewMode(res.columns, res.rows, res.dtypes, { projectId, payload }, res);
+      // The Sort panel carries Save Changes and Cancel for the pending preview.
+      openPanel("SortForm");
+    } catch {
+      setToast({ message: "Failed to sort column. Please try again.", type: "error" });
+    } finally {
+      setPreviewLoading(false);
+    }
+  };
+
   const handleCellClick = (rowIndex: number, cellIndex: number, cellValue: Cell) => {
     if (isPreviewMode) return;
 
@@ -505,12 +543,20 @@ const Table = ({ projectId, showColumnProfiles = false }: TableProps) => {
                     const isSerialNumber = columnIndex === 0;
                     const isDragged = !isSerialNumber && draggedColIndex === columnIndex - 1;
                     const isDropTarget = !isSerialNumber && hoveredTargetIndex === columnIndex - 1;
+                    const sortDir =
+                      !isSerialNumber && headerSort?.column === column
+                        ? headerSort.ascending
+                          ? "ascending"
+                          : "descending"
+                        : undefined;
+                    const SortIcon = sortDir === "ascending" ? ArrowUp : ArrowDown;
                     return (
                       <th
                         key={columnIndex}
                         className={`h-6 px-0.5 py-0 border-r border-app-border text-left text-xs font-medium text-muted-foreground uppercase tracking-wider ${
                           isDropTarget ? "ring-2 ring-blue-400" : ""
                         } ${isSerialNumber ? "w-16 sticky left-0 z-10 bg-surface" : "bg-surface"}`}
+                        aria-sort={sortDir}
                         onContextMenu={(e) => {
                           if (!isPreviewMode) {
                             open(e, { type: "column", columnIndex });
@@ -523,6 +569,9 @@ const Table = ({ projectId, showColumnProfiles = false }: TableProps) => {
                             isSerialNumber ? "" : "cursor-grab active:cursor-grabbing"
                           } ${isDragged ? "opacity-50" : ""}`}
                           draggable={!isSerialNumber}
+                          onClick={() => {
+                            if (!isSerialNumber) handleHeaderSort(column);
+                          }}
                           onDragStart={(event) => {
                             if (isSerialNumber) return;
                             setDraggedColIndex(columnIndex - 1);
@@ -557,6 +606,9 @@ const Table = ({ projectId, showColumnProfiles = false }: TableProps) => {
                           }}
                         >
                           {column}
+                          {sortDir && (
+                            <SortIcon className="inline w-3 h-3 ml-1" aria-hidden="true" />
+                          )}
                         </button>
                       </th>
                     );

--- a/dataloom-frontend/src/Components/forms/SortForm.tsx
+++ b/dataloom-frontend/src/Components/forms/SortForm.tsx
@@ -1,5 +1,5 @@
-import { captureStep, type TransformFormProps } from "./transformFormProps";
-import { useState, useCallback, FormEvent } from "react";
+import { captureStep, sortCriteriaOf, type TransformFormProps } from "./transformFormProps";
+import { useState, useCallback, useEffect, FormEvent } from "react";
 import { transformProject } from "../../api";
 import { SORT } from "../../constants/operationTypes";
 import useError from "../../hooks/useError";
@@ -21,16 +21,25 @@ interface SortCriterion {
   ascending: boolean;
 }
 
+const withId = (c: Omit<SortCriterion, "id">, i: number): SortCriterion => ({ id: i + 1, ...c });
+
 /**
  * SortForm component for multi-column sorting.
  * Allows users to add, remove, and reorder multiple sort criteria.
  */
 const SortForm = ({ projectId, onClose, onCapture }: TransformFormProps) => {
-  const { pageSize, isPreviewMode, enterPreviewMode, cancelPreview } = useProjectContext();
-  const [criteria, setCriteria] = useState<SortCriterion[]>([
-    { id: 1, column: "", ascending: true },
-  ]);
-  const [nextId, setNextId] = useState(2);
+  const { pageSize, isPreviewMode, enterPreviewMode, cancelPreview, pendingTransform } =
+    useProjectContext();
+  // A sort started from a column header is already pending when the panel opens; show it
+  // (not when capturing a pipeline step, which is unrelated to the grid's preview).
+  const pending = onCapture ? undefined : sortCriteriaOf(pendingTransform?.payload);
+  const [criteria, setCriteria] = useState<SortCriterion[]>(
+    () => pending?.map(withId) ?? [{ id: 1, column: "", ascending: true }],
+  );
+  const [nextId, setNextId] = useState(criteria.length + 1);
+  useEffect(() => {
+    if (pending) setCriteria(pending.map(withId));
+  }, [pending]);
   const [loading, setLoading] = useState(false);
   const { error, setError, clearError, handleError } = useError();
   const { saving, handleSave } = usePreviewSave({ clearError, handleError, onClose });

--- a/dataloom-frontend/src/Components/forms/transformFormProps.ts
+++ b/dataloom-frontend/src/Components/forms/transformFormProps.ts
@@ -8,6 +8,7 @@
  * of previewing it against the current project.
  */
 import type { PanelProps } from "../workspace/featureRegistry";
+import { SORT } from "../../constants/operationTypes";
 
 export interface CaptureStep {
   action_type: string;
@@ -21,6 +22,13 @@ export interface TransformFormProps extends PanelProps {
 
 /** A transform payload: the operation plus its op-specific params bag. */
 export type CapturablePayload = Record<string, unknown> & { operation_type: string };
+
+/** The sort criteria a pending transform carries, or undefined when it is not a sort. */
+export const sortCriteriaOf = (payload: CapturablePayload | undefined) =>
+  payload?.operation_type === SORT
+    ? (payload.sort_params as { criteria?: { column: string; ascending: boolean }[] } | undefined)
+        ?.criteria
+    : undefined;
 
 /**
  * Hand a validated payload to the pipeline builder instead of applying it.

--- a/dataloom-frontend/src/test/SortForm.test.tsx
+++ b/dataloom-frontend/src/test/SortForm.test.tsx
@@ -76,12 +76,18 @@ const mockEnterPreviewMode = vi.fn();
 const mockCancelPreview = vi.fn();
 const mockHandleSave = vi.fn();
 
-const renderForm = ({ isPreviewMode = false, onClose = vi.fn(), saving = false } = {}) => {
+const renderForm = ({
+  isPreviewMode = false,
+  onClose = vi.fn(),
+  saving = false,
+  pendingTransform = null as unknown,
+} = {}) => {
   mockUseProjectContext.mockReturnValue({
     isPreviewMode,
     pageSize: 50,
     enterPreviewMode: mockEnterPreviewMode,
     cancelPreview: mockCancelPreview,
+    pendingTransform,
   });
 
   mockUsePreviewSave.mockReturnValue({
@@ -113,6 +119,22 @@ describe("SortForm", () => {
     expect(screen.getByLabelText("Order")).toHaveValue("true");
     expect(screen.getByRole("button", { name: "Apply Sort" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+  });
+
+  it("shows the sort already pending from a column header", () => {
+    renderForm({
+      isPreviewMode: true,
+      pendingTransform: {
+        projectId: "project-123",
+        payload: {
+          operation_type: SORT,
+          sort_params: { criteria: [{ column: "amount", ascending: false }] },
+        },
+      },
+    });
+
+    expect(screen.getByTestId("sort-column")).toHaveValue("amount");
+    expect(screen.getByLabelText("Order")).toHaveValue("false");
   });
 
   it("adds a new sort criterion row", async () => {

--- a/dataloom-frontend/src/test/Table.columnOrder.test.tsx
+++ b/dataloom-frontend/src/test/Table.columnOrder.test.tsx
@@ -5,6 +5,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import Table from "../Components/Table";
 import { transformProject } from "../api";
 import { ToastProvider } from "../context/ToastContext";
+import { PanelProvider } from "../context/PanelContext";
 
 vi.mock("../api", () => ({
   transformProject: vi.fn(() =>
@@ -52,9 +53,11 @@ beforeEach(() => {
 
 const renderTable = () =>
   render(
-    <ToastProvider>
-      <Table projectId="test-id" />
-    </ToastProvider>,
+    <PanelProvider>
+      <ToastProvider>
+        <Table projectId="test-id" />
+      </ToastProvider>
+    </PanelProvider>,
   );
 
 describe("Table — column reorder behavior", () => {

--- a/dataloom-frontend/src/test/Table.contextMenu.test.tsx
+++ b/dataloom-frontend/src/test/Table.contextMenu.test.tsx
@@ -5,6 +5,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import Table from "../Components/Table";
 import { transformProject } from "../api";
 import { ToastProvider } from "../context/ToastContext";
+import { PanelProvider } from "../context/PanelContext";
 
 vi.mock("../api", () => ({
   transformProject: vi.fn(() =>
@@ -55,9 +56,11 @@ beforeEach(() => {
 
 const renderTable = () =>
   render(
-    <ToastProvider>
-      <Table projectId="test-id" />
-    </ToastProvider>,
+    <PanelProvider>
+      <ToastProvider>
+        <Table projectId="test-id" />
+      </ToastProvider>
+    </PanelProvider>,
   );
 
 describe("Table Context Menu Actions", () => {

--- a/dataloom-frontend/src/test/Table.headerSort.test.tsx
+++ b/dataloom-frontend/src/test/Table.headerSort.test.tsx
@@ -1,0 +1,118 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+
+import Table from "../Components/Table";
+import { ToastProvider } from "../context/ToastContext";
+import { SORT } from "../constants/operationTypes";
+import { transformProject } from "../api";
+
+vi.mock("../api", () => ({
+  transformProject: vi.fn(),
+  getColumnProfile: vi.fn(() => Promise.resolve({})),
+}));
+
+type Pending = { projectId: string; payload: unknown } | null;
+
+// enterPreviewMode and cancelPreview update pendingTransform like the real
+// context does, since the header derives its indicator from it.
+const mockContext = {
+  columns: ["City", "Amount"],
+  rows: [["Delhi", "420"]] as unknown[][],
+  dtypes: { City: "string", Amount: "int64" },
+  columnOrder: [0, 1],
+  setColumnOrder: vi.fn(),
+  updateData: vi.fn(),
+  dataVersion: 0,
+  totalRows: 1,
+  totalPages: 1,
+  page: 1,
+  pageSize: 50,
+  isPreviewMode: false,
+  pendingTransform: null as Pending,
+  setPaginationData: vi.fn(),
+  updatePreviewPage: vi.fn(),
+  refreshProject: vi.fn(),
+  enterPreviewMode: vi.fn((_c: unknown, _r: unknown, _d: unknown, info: Pending) => {
+    mockContext.pendingTransform = info;
+    mockContext.isPreviewMode = true;
+  }),
+  cancelPreview: vi.fn(() => {
+    mockContext.pendingTransform = null;
+    mockContext.isPreviewMode = false;
+  }),
+  loading: false,
+};
+
+vi.mock("../context/ProjectContext", () => ({ useProjectContext: () => mockContext }));
+vi.mock("../context/HistoryRefreshContext", () => ({
+  useHistoryRefresh: () => ({ refreshLogs: vi.fn(), refreshCheckpoints: vi.fn() }),
+}));
+const openPanel = vi.fn();
+vi.mock("../context/PanelContext", () => ({ usePanel: () => ({ openPanel }) }));
+
+const tree = () => (
+  <ToastProvider>
+    <Table projectId="p1" />
+  </ToastProvider>
+);
+const amount = () => screen.getByRole("button", { name: "Amount" });
+const ariaSort = () => amount().closest("th")?.getAttribute("aria-sort");
+const payload = (ascending: boolean) => ({
+  operation_type: SORT,
+  sort_params: { criteria: [{ column: "Amount", ascending }] },
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockContext.isPreviewMode = false;
+  mockContext.pendingTransform = null;
+  (transformProject as Mock).mockResolvedValue({ columns: [], rows: [], dtypes: {} });
+});
+
+describe("Table header sort", () => {
+  it("cycles ascending, descending, then clears, issuing the Sort form's payload", async () => {
+    const view = render(tree());
+
+    fireEvent.click(amount());
+    await waitFor(() => expect(openPanel).toHaveBeenCalledWith("SortForm"));
+    expect(transformProject).toHaveBeenCalledWith("p1", payload(true), {
+      preview: true,
+      page: 1,
+      pageSize: 50,
+    });
+    view.rerender(tree());
+    expect(ariaSort()).toBe("ascending");
+
+    fireEvent.click(amount());
+    await waitFor(() => expect(transformProject).toHaveBeenCalledTimes(2));
+    expect(transformProject).toHaveBeenLastCalledWith("p1", payload(false), expect.anything());
+    view.rerender(tree());
+    expect(ariaSort()).toBe("descending");
+
+    fireEvent.click(amount());
+    expect(mockContext.cancelPreview).toHaveBeenCalledOnce();
+    expect(transformProject).toHaveBeenCalledTimes(2);
+    view.rerender(tree());
+    expect(ariaSort()).toBeNull();
+  });
+
+  it("shows a toast and leaves the panel closed when the sort request fails", async () => {
+    (transformProject as Mock).mockRejectedValueOnce(new Error("boom"));
+    render(tree());
+
+    fireEvent.click(amount());
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Failed to sort column");
+    expect(openPanel).not.toHaveBeenCalled();
+  });
+
+  it("stays inert while another form's preview is pending", () => {
+    mockContext.isPreviewMode = true;
+    mockContext.pendingTransform = { projectId: "p1", payload: { operation_type: "filter" } };
+    render(tree());
+
+    fireEvent.click(amount());
+
+    expect(transformProject).not.toHaveBeenCalled();
+  });
+});

--- a/dataloom-frontend/src/test/Table.skeleton.test.tsx
+++ b/dataloom-frontend/src/test/Table.skeleton.test.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import Table from "../Components/Table";
 import { ToastProvider } from "../context/ToastContext";
+import { PanelProvider } from "../context/PanelContext";
 
 vi.mock("../api", () => ({
   transformProject: vi.fn(),
@@ -42,9 +43,11 @@ vi.mock("../context/HistoryRefreshContext", () => ({
 
 const renderTable = (showColumnProfiles = false) =>
   render(
-    <ToastProvider>
-      <Table projectId="test-id" showColumnProfiles={showColumnProfiles} />
-    </ToastProvider>,
+    <PanelProvider>
+      <ToastProvider>
+        <Table projectId="test-id" showColumnProfiles={showColumnProfiles} />
+      </ToastProvider>
+    </PanelProvider>,
   );
 
 /** Render the first-load state: fetching, with no rows on screen yet. */


### PR DESCRIPTION
## Description

Clicking a column header now sorts the grid. It sends the same `sort` transform the Sort form sends, as a preview, and opens the Sort panel so its Save Changes and Cancel apply. Clicks cycle ascending, descending, then clear.

The indicator comes from `pendingTransform`, so a sort applied from the panel shows it too. `aria-sort` is set on the header. The Sort panel reads the same pending sort, so after a header click it shows that column and order instead of an empty row, and follows the next click.

Fixes #200

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

- `Table.tsx`: header click handler, `aria-sort` and an arrow on the sorted column
- `SortForm.tsx`: seeds its rows from the pending sort and re-seeds when a header click changes it
- `transformFormProps.ts`: `sortCriteriaOf`, shared by Table and SortForm
- `Table.headerSort.test.tsx`: the click cycle and its payload, inert while another preview is pending, and the toast on a failed request
- `SortForm.test.tsx`: the panel shows the pending header sort
- `Table.skeleton`, `Table.contextMenu`, `Table.columnOrder` tests: render inside `PanelProvider`, since Table now uses `usePanel`

## How Has This Been Tested?

- [x] Existing tests pass
- [x] New tests added
- [x] Manual testing

- `npm run lint` - passed
- `npm test` - 454 passed, 19 failed (same 19 as main)
- `npm run build` - passed

## Screenshots

Unsorted, after one click, after two.

![header sort](https://raw.githubusercontent.com/iamtanishqjain/dataloom/assets/pr-508/header-sort.png)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally

